### PR TITLE
Rename ProcessControlBlock to Process

### DIFF
--- a/examples/spawn-chain/src/apply_3.rs
+++ b/examples/spawn-chain/src/apply_3.rs
@@ -4,12 +4,12 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::runtime;
 use liblumen_alloc::erts::process::code::stack::frame::Placement;
 use liblumen_alloc::erts::process::code::Result;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term, TypedTerm};
 
 use crate::elixir;
 
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> Result {
+pub fn code(arc_process: &Arc<Process>) -> Result {
     let module_term = arc_process.stack_pop().unwrap();
     let function_term = arc_process.stack_pop().unwrap();
 
@@ -52,7 +52,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> Result {
 
                     // don't count finding the function as a reduction if it is found, only on
                     // exception in `undef`, so that each path is at least one reduction.
-                    ProcessControlBlock::call_code(arc_process)
+                    Process::call_code(arc_process)
                 }
                 _ => undef(arc_process, module_term, function_term, argument_list),
             },
@@ -67,7 +67,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> Result {
 
                     // don't count finding the function as a reduction if it is found, only on
                     // exception in `undef`, so that each path is at least one reduction.
-                    ProcessControlBlock::call_code(arc_process)
+                    Process::call_code(arc_process)
                 }
                 _ => undef(arc_process, module_term, function_term, argument_list),
             },
@@ -82,7 +82,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> Result {
 
                     // don't count finding the function as a reduction if it is found, only on
                     // exception in `undef`, so that each path is at least one reduction.
-                    ProcessControlBlock::call_code(arc_process)
+                    Process::call_code(arc_process)
                 }
                 _ => undef(arc_process, module_term, function_term, argument_list),
             },
@@ -96,7 +96,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> Result {
 
                     // don't count finding the function as a reduction if it is found, only on
                     // exception in `undef`, so that each path is at least one reduction.
-                    ProcessControlBlock::call_code(arc_process)
+                    Process::call_code(arc_process)
                 }
                 _ => undef(arc_process, module_term, function_term, argument_list),
             },
@@ -108,7 +108,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> Result {
                         argument_vec[0],
                     )?;
 
-                    ProcessControlBlock::call_code(arc_process)
+                    Process::call_code(arc_process)
                 }
                 _ => undef(arc_process, module_term, function_term, argument_list),
             },
@@ -118,12 +118,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> Result {
     }
 }
 
-fn undef(
-    arc_process: &Arc<ProcessControlBlock>,
-    module: Term,
-    function: Term,
-    arguments: Term,
-) -> Result {
+fn undef(arc_process: &Arc<Process>, module: Term, function: Term, arguments: Term) -> Result {
     arc_process.reduce();
     let exception = liblumen_alloc::undef!(arc_process, module, function, arguments);
     let runtime_exception: runtime::Exception = exception.try_into().unwrap();

--- a/examples/spawn-chain/src/elixir/chain/console_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/console_1.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -18,7 +18,7 @@ use crate::elixir::chain::{console_output_1, run_2};
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     n: Term,
 ) -> Result<(), Alloc> {
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let n = arc_process.stack_pop().unwrap();
@@ -40,7 +40,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     let console_output_closure = console_output_1::closure(arc_process)?;
     run_2::place_frame_with_arguments(arc_process, Placement::Replace, n, console_output_closure)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/examples/spawn-chain/src/elixir/chain/console_output_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/console_output_1.rs
@@ -4,20 +4,20 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::Placement;
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
 use lumen_runtime::otp::erlang;
 
-pub fn closure(process: &ProcessControlBlock) -> Result<Term, Alloc> {
+pub fn closure(process: &Process) -> Result<Term, Alloc> {
     process.closure(process.pid_term(), module_function_arity(), code, vec![])
 }
 
 /// defp console_output(text) do
 ///   IO.puts("#{self()} #{text}")
 /// end
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let text = arc_process.stack_pop().unwrap();
@@ -25,7 +25,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     label_1::place_frame_with_arguments(arc_process, Placement::Replace, text)?;
     erlang::self_0::place_frame(arc_process, Placement::Push);
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn function() -> Atom {

--- a/examples/spawn-chain/src/elixir/chain/console_output_1/label_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/console_output_1/label_1.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 use crate::elixir;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     text: Term,
 ) -> Result<(), Alloc> {
@@ -28,7 +28,7 @@ pub fn place_frame_with_arguments(
 /// # returns: :ok
 /// IO.puts("#{self()} #{text}")
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let self_term = arc_process.stack_pop().unwrap();
@@ -39,10 +39,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     let full_text = arc_process.binary_from_str(&format!("pid={} {}", self_term, text))?;
     elixir::io::puts_1::place_frame_with_arguments(arc_process, Placement::Replace, full_text)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/counter_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/counter_2.rs
@@ -8,12 +8,12 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Boxed, Closure, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     next_pid: Term,
     output: Term,
@@ -41,7 +41,7 @@ pub fn place_frame_with_arguments(
 ///   end
 /// end
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let next_pid = arc_process.stack_pop().unwrap();
@@ -72,7 +72,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     let output_data = arc_process.binary_from_str("spawned")?;
     output_closure.place_frame_with_arguments(arc_process, Placement::Push, vec![output_data])?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/examples/spawn-chain/src/elixir/chain/counter_2/label_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/counter_2/label_1.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::Term;
 
 use lumen_runtime::otp::erlang;
@@ -11,7 +11,7 @@ use lumen_runtime::otp::erlang;
 use crate::elixir::chain::counter_2::label_2;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     next_pid: Term,
     output: Term,
@@ -38,7 +38,7 @@ pub fn place_frame_with_arguments(
 ///     output.("sent #{sent} to #{next_pid}")
 /// end
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     // Because there is a guardless match in the receive block, the first message will always be
@@ -77,14 +77,14 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
             let one = arc_process.integer(1)?;
             erlang::add_2::place_frame_with_arguments(arc_process, Placement::Push, n, one)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         None => Ok(Arc::clone(arc_process).wait()),
         Some(Err(alloc_err)) => Err(alloc_err.into()),
     }
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/counter_2/label_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/counter_2/label_2.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 use lumen_runtime::otp::erlang;
@@ -10,7 +10,7 @@ use lumen_runtime::otp::erlang;
 use crate::elixir::chain::counter_2::label_3;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     next_pid: Term,
     output: Term,
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 /// sent = send(next_pid, sum)
 /// output.("sent #{sent} to #{next_pid}")
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let sum = arc_process.stack_pop().unwrap();
@@ -62,10 +62,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     // send(next_pid, sum)
     erlang::send_2::place_frame_with_arguments(arc_process, Placement::Push, next_pid, sum)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/counter_2/label_3.rs
+++ b/examples/spawn-chain/src/elixir/chain/counter_2/label_3.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Boxed, Closure, Term};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     output: Term,
     next_pid: Term,
@@ -28,7 +28,7 @@ pub fn place_frame_with_arguments(
 /// sent = ...
 /// output.("sent #{sent} to #{next_pid}")
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let sent = arc_process.stack_pop().unwrap();
@@ -45,10 +45,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     let data = arc_process.binary_from_str(&format!("sent {} to {}", sent, next_pid))?;
     output_closure.place_frame_with_arguments(arc_process, Placement::Replace, vec![data])?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/create_processes_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/create_processes_2.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -43,7 +43,7 @@ use crate::elixir;
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     n: Term,
     output: Term,
@@ -59,7 +59,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     let n = arc_process.stack_pop().unwrap();
     let output = arc_process.stack_pop().unwrap();
 
@@ -101,7 +101,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
                 reducer,
             )?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/examples/spawn-chain/src/elixir/chain/create_processes_2/label_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/create_processes_2/label_1.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Boxed, Closure, Term};
 
 use lumen_runtime::otp::erlang;
@@ -16,7 +16,7 @@ use crate::elixir::chain::create_processes_2::label_2;
 ///  # full stack: (last, output)
 ///  # returns: sent
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     output: Term,
 ) -> Result<(), Alloc> {
@@ -45,7 +45,7 @@ pub fn place_frame_with_arguments(
 ///     final_answer
 /// end
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     // placed on top of stack by return from `elixir::r#enum::reduce_0_code`
     let last = arc_process.stack_pop().unwrap();
     assert!(last.is_local_pid(), "last ({:?}) is not a local pid", last);
@@ -76,10 +76,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     let message = arc_process.integer(0)?;
     erlang::send_2::place_frame_with_arguments(arc_process, Placement::Push, last, message)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/create_processes_2/label_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/create_processes_2/label_2.rs
@@ -5,13 +5,13 @@ use liblumen_alloc::borrow::clone_to_process::CloneToProcess;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::message::{self, Message};
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Boxed, Closure, Term};
 
 use crate::elixir::chain::create_processes_2::label_3;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     output: Term,
 ) -> Result<(), Alloc> {
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 ///     final_answer
 /// end
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     // locked mailbox scope
     let received = {
         let mailbox_guard = arc_process.mailbox.lock();
@@ -117,7 +117,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     arc_process.reduce();
 
     if received {
-        ProcessControlBlock::call_code(arc_process)
+        Process::call_code(arc_process)
     } else {
         arc_process.wait();
 
@@ -125,7 +125,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     }
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/create_processes_2/label_3.rs
+++ b/examples/spawn-chain/src/elixir/chain/create_processes_2/label_3.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
 /// ```elixir
@@ -13,7 +13,7 @@ use liblumen_alloc::erts::term::{atom_unchecked, Term};
 /// final_answer
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     final_answer: Term,
 ) -> Result<(), Alloc> {
@@ -23,7 +23,7 @@ pub fn place_frame_with_arguments(
     Ok(())
 }
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -33,10 +33,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
 
     arc_process.return_from_call(final_answer)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/create_processes_reducer_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/create_processes_reducer_2.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::Placement;
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
 use lumen_runtime::otp::erlang;
 
-pub fn closure(process: &ProcessControlBlock, output: Term) -> std::result::Result<Term, Alloc> {
+pub fn closure(process: &Process, output: Term) -> std::result::Result<Term, Alloc> {
     process.closure(
         process.pid_term(),
         module_function_arity(),
@@ -29,7 +29,7 @@ pub fn closure(process: &ProcessControlBlock, output: Term) -> std::result::Resu
 ///   spawn(Chain, :counter, [send_to, output])
 /// end
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     // from environment
@@ -56,7 +56,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         arguments,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn function() -> Atom {

--- a/examples/spawn-chain/src/elixir/chain/dom_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_1.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -18,7 +18,7 @@ use crate::elixir::chain::{dom_output_1, run_2};
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     n: Term,
 ) -> Result<(), Alloc> {
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let n = arc_process.stack_pop().unwrap();
@@ -40,7 +40,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     let dom_output_closure = dom_output_1::closure(arc_process)?;
     run_2::place_frame_with_arguments(arc_process, Placement::Replace, n, dom_output_closure)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1.rs
@@ -15,11 +15,11 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::Placement;
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
-pub fn closure(process: &ProcessControlBlock) -> Result<Term, Alloc> {
+pub fn closure(process: &Process) -> Result<Term, Alloc> {
     process.closure(process.pid_term(), module_function_arity(), code, vec![])
 }
 
@@ -48,7 +48,7 @@ pub fn closure(process: &ProcessControlBlock) -> Result<Term, Alloc> {
 ///   Lumen::Web::Node.append_child(tbody, tr)
 /// end
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let text = arc_process.stack_pop().unwrap();
@@ -56,7 +56,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     label_1::place_frame_with_arguments(arc_process, Placement::Replace, text)?;
     lumen_web::window::window_0::place_frame(arc_process, Placement::Push);
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn function() -> Atom {

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_1.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 use crate::elixir::chain::dom_output_1::label_2;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     text: Term,
 ) -> Result<(), Alloc> {
@@ -42,7 +42,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_window = arc_process.stack_pop().unwrap();
@@ -67,10 +67,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         window,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_10.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_10.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
 use crate::elixir::chain::dom_output_1::label_11;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tr: Term,
@@ -35,7 +35,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -55,10 +55,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         text_td,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_11.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_11.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
 use crate::elixir::chain::dom_output_1::label_12;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tr: Term,
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -51,10 +51,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         id,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_12.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_12.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     tr: Term,
 ) -> Result<(), Alloc> {
@@ -27,7 +27,7 @@ pub fn place_frame_with_arguments(
 /// # returns: :ok
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_tbody = arc_process.stack_pop().unwrap();
@@ -48,10 +48,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         tr,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_2.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 use crate::elixir::chain::dom_output_1::label_3;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     text: Term,
 ) -> Result<(), Alloc> {
@@ -41,7 +41,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_document = arc_process.stack_pop().unwrap();
@@ -68,10 +68,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_3.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_3.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 use crate::elixir::chain::dom_output_1::label_4;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     text: Term,
@@ -42,7 +42,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_tr = arc_process.stack_pop().unwrap();
@@ -68,10 +68,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         pid_text_binary,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_4.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_4.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 use crate::elixir::chain::dom_output_1::label_5;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tr: Term,
@@ -43,7 +43,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let pid_text = arc_process.stack_pop().unwrap();
@@ -71,10 +71,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_5.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_5.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 use crate::elixir::chain::dom_output_1::label_6;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tr: Term,
@@ -44,7 +44,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_pid_td = arc_process.stack_pop().unwrap();
@@ -78,10 +78,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         pid_text,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_6.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_6.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
 use crate::elixir::chain::dom_output_1::label_7;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tr: Term,
@@ -42,7 +42,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -63,10 +63,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         pid_td,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_7.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_7.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
 use crate::elixir::chain::dom_output_1::label_8;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tr: Term,
@@ -38,7 +38,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -57,10 +57,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         text,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_8.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_8.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 use crate::elixir::chain::dom_output_1::label_9;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tr: Term,
@@ -35,7 +35,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let text_text = arc_process.stack_pop().unwrap();
@@ -55,10 +55,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1/label_9.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1/label_9.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 use crate::elixir::chain::dom_output_1::label_10;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tr: Term,
@@ -37,7 +37,7 @@ pub fn place_frame_with_arguments(
 /// {:ok, tbody} = Lumen::Web::Document.get_element_by_id(document, "output")
 /// Lumen::Web::Node.append_child(tbody, tr)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_text_td = arc_process.stack_pop().unwrap();
@@ -63,10 +63,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         text_text,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/none_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/none_1.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -21,7 +21,7 @@ use crate::elixir::chain::{none_output_1, run_2};
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     n: Term,
 ) -> Result<(), Alloc> {
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let n = arc_process.stack_pop().unwrap();
@@ -43,7 +43,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     let none_output_closure = none_output_1::closure(arc_process)?;
     run_2::place_frame_with_arguments(arc_process, Placement::Replace, n, none_output_closure)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/examples/spawn-chain/src/elixir/chain/none_1/test.rs
+++ b/examples/spawn-chain/src/elixir/chain/none_1/test.rs
@@ -93,13 +93,13 @@ fn with_65536() {
     run_through(65536)
 }
 
-fn inspect_code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn inspect_code(arc_process: &Arc<Process>) -> code::Result {
     let time_value = arc_process.stack_pop().unwrap();
 
     lumen_runtime::system::io::puts(&format!("{}", time_value));
     arc_process.remove_last_frame();
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn run_through(n: usize) {

--- a/examples/spawn-chain/src/elixir/chain/none_output_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/none_output_1.rs
@@ -1,25 +1,25 @@
 use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
-pub fn closure(process: &ProcessControlBlock) -> Result<Term, Alloc> {
+pub fn closure(process: &Process) -> Result<Term, Alloc> {
     process.closure(process.pid_term(), module_function_arity(), code, vec![])
 }
 
 /// defp none_output(_text) do
 ///   :ok
 /// end
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let _text = arc_process.stack_pop().unwrap();
 
-    ProcessControlBlock::return_from_call(arc_process, atom_unchecked("ok"))?;
+    Process::return_from_call(arc_process, atom_unchecked("ok"))?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn function() -> Atom {

--- a/examples/spawn-chain/src/elixir/chain/on_submit_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/on_submit_1.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -25,7 +25,7 @@ use liblumen_alloc::erts::ModuleFunctionArity;
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     event: Term,
 ) -> Result<(), Alloc> {
@@ -38,7 +38,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let event = arc_process.stack_pop().unwrap();
@@ -59,7 +59,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
 
     lumen_web::event::target_1::place_frame_with_arguments(arc_process, Placement::Push, event)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/examples/spawn-chain/src/elixir/chain/on_submit_1/label_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/on_submit_1/label_1.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 
 use super::label_2;
@@ -18,13 +18,13 @@ use super::label_2;
 /// n = :erlang.binary_to_integer(value_string)
 /// dom(n)
 /// ```
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(process), placement);
 }
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_event_target = arc_process.stack_pop().unwrap();
@@ -59,10 +59,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         name,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/on_submit_1/label_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/on_submit_1/label_2.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 
 use super::label_3;
@@ -17,13 +17,13 @@ use super::label_3;
 /// n = :erlang.binary_to_integer(value_string)
 /// dom(n)
 /// ```
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(process), placement);
 }
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_n_input = arc_process.stack_pop().unwrap();
@@ -55,10 +55,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         n_input,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/on_submit_1/label_3.rs
+++ b/examples/spawn-chain/src/elixir/chain/on_submit_1/label_3.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 
 use lumen_runtime::otp::erlang;
 
@@ -16,13 +16,13 @@ use super::label_4;
 /// n = :erlang.binary_to_integer(value_string)
 /// dom(n)
 /// ```
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(process), placement);
 }
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let value_string = arc_process.stack_pop().unwrap();
@@ -44,10 +44,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         value_string,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/on_submit_1/label_4.rs
+++ b/examples/spawn-chain/src/elixir/chain/on_submit_1/label_4.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::atom_unchecked;
 
 use lumen_runtime::otp::erlang;
@@ -15,13 +15,13 @@ use lumen_runtime::otp::erlang;
 /// # returns: {time, value}
 /// :erlang.spawn_opt(Chain, dom, [n], [min_heap_size: 79 + n *5])
 /// ```
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(process), placement);
 }
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let n = arc_process.stack_pop().unwrap();
@@ -40,10 +40,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         ])?])?,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/run_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/run_2.rs
@@ -5,14 +5,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
 use lumen_runtime::otp::timer;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     n: Term,
     output: Term,
@@ -35,7 +35,7 @@ pub fn place_frame_with_arguments(
 ///   output.("Chain.run(#{n}) in #{time} microseconds")
 ///   {time, value}
 /// end
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let n = arc_process.stack_pop().unwrap();
@@ -54,7 +54,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         arguments,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/examples/spawn-chain/src/elixir/chain/run_2/label_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/run_2/label_1.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Boxed, Closure, Term, Tuple};
 
 use crate::elixir::chain::run_2::label_2;
@@ -18,7 +18,7 @@ use crate::elixir::chain::run_2::label_2;
 /// output.("Chain.run(#{n}) in #{time} microseconds")
 /// value
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     output: Term,
     n: Term,
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let time_value = arc_process.stack_pop().unwrap();
@@ -65,10 +65,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         arc_process.binary_from_str(&format!("Chain.run({}) in {} microsecond(s)", n, time))?;
     output_closure.place_frame_with_arguments(arc_process, Placement::Push, vec![output_data])?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/chain/run_2/label_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/run_2/label_2.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
 /// ```elixir
@@ -14,7 +14,7 @@ use liblumen_alloc::erts::term::{atom_unchecked, Term};
 /// # returns: {time, value}
 /// {time, value}
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     time_value: Term,
 ) -> Result<(), Alloc> {
@@ -27,7 +27,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -36,10 +36,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
 
     arc_process.return_from_call(time_value)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/enum/reduce_3.rs
+++ b/examples/spawn-chain/src/elixir/enum/reduce_3.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term, TypedTerm};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -10,7 +10,7 @@ use crate::elixir::r#enum::reduce_range_dec_4;
 use crate::elixir::r#enum::reduce_range_inc_4;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     enumerable: Term,
     acc: Term,
@@ -26,7 +26,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     let enumerable = arc_process.stack_pop().unwrap();
     let initial = arc_process.stack_pop().unwrap();
     let reducer = arc_process.stack_pop().unwrap();
@@ -67,7 +67,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
                                 )?;
                             }
 
-                            ProcessControlBlock::call_code(arc_process)
+                            Process::call_code(arc_process)
                         } else {
                             arc_process.reduce();
                             arc_process.exception(liblumen_alloc::badarg!());

--- a/examples/spawn-chain/src/elixir/enum/reduce_range_dec_4.rs
+++ b/examples/spawn-chain/src/elixir/enum/reduce_range_dec_4.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -16,7 +16,7 @@ use liblumen_alloc::erts::ModuleFunctionArity;
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     first: Term,
     last: Term,
@@ -32,7 +32,7 @@ pub fn place_frame_with_arguments(
     Ok(())
 }
 
-fn code(_arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(_arc_process: &Arc<Process>) -> code::Result {
     unimplemented!()
 }
 

--- a/examples/spawn-chain/src/elixir/enum/reduce_range_inc_4.rs
+++ b/examples/spawn-chain/src/elixir/enum/reduce_range_inc_4.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term, TypedTerm};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -22,7 +22,7 @@ use lumen_runtime::otp::erlang::add_2;
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     first: Term,
     last: Term,
@@ -38,7 +38,7 @@ pub fn place_frame_with_arguments(
     Ok(())
 }
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     let first = arc_process.stack_pop().unwrap();
     let last = arc_process.stack_pop().unwrap();
     let acc = arc_process.stack_pop().unwrap();
@@ -60,7 +60,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
                             vec![first, acc],
                         )?;
 
-                        ProcessControlBlock::call_code(arc_process)
+                        Process::call_code(arc_process)
                     } else {
                         let argument_list = arc_process.list_from_slice(&[first, acc])?;
 
@@ -109,7 +109,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         let inc = arc_process.integer(1)?;
         add_2::place_frame_with_arguments(arc_process, Placement::Push, first, inc)?;
 
-        ProcessControlBlock::call_code(arc_process)
+        Process::call_code(arc_process)
     }
 }
 

--- a/examples/spawn-chain/src/elixir/enum/reduce_range_inc_4/label_1.rs
+++ b/examples/spawn-chain/src/elixir/enum/reduce_range_inc_4/label_1.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Term, TypedTerm};
 
 use crate::elixir::r#enum::reduce_range_inc_4::label_2;
@@ -17,7 +17,7 @@ use crate::elixir::r#enum::reduce_range_inc_4::label_2;
 /// reduce_range_inc(new_first, last, new_acc, reducer)
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     first: Term,
     last: Term,
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
     Ok(())
 }
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let new_first = arc_process.stack_pop().unwrap();
@@ -63,7 +63,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
                         vec![first, acc],
                     )?;
 
-                    ProcessControlBlock::call_code(arc_process)
+                    Process::call_code(arc_process)
                 } else {
                     let argument_list = arc_process.list_from_slice(&[first, acc])?;
 
@@ -79,7 +79,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     }
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/enum/reduce_range_inc_4/label_2.rs
+++ b/examples/spawn-chain/src/elixir/enum/reduce_range_inc_4/label_2.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 use crate::elixir::r#enum::reduce_range_inc_4;
@@ -15,7 +15,7 @@ use crate::elixir::r#enum::reduce_range_inc_4;
 /// reduce_range_inc(new_first, last, new_acc, reducer)
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     new_first: Term,
     last: Term,
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
     Ok(())
 }
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     // new_acc is on top of stack because it is the return from `reducer` call
@@ -51,10 +51,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         reducer,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/examples/spawn-chain/src/elixir/io/puts_1.rs
+++ b/examples/spawn-chain/src/elixir/io/puts_1.rs
@@ -5,7 +5,7 @@ use liblumen_alloc::erts::exception::runtime;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::Term;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom};
 use liblumen_alloc::erts::ModuleFunctionArity;
@@ -13,7 +13,7 @@ use liblumen_alloc::erts::ModuleFunctionArity;
 use lumen_runtime::system;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     binary: Term,
 ) -> Result<(), Alloc> {
@@ -27,7 +27,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     let elixir_string = arc_process.stack_pop().unwrap();
 
     match elixir_string.try_into(): Result<String, runtime::Exception> {
@@ -39,7 +39,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
             let ok = atom_unchecked("ok");
             arc_process.return_from_call(ok)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => {
             arc_process.reduce();

--- a/examples/spawn-chain/src/elixir/range.rs
+++ b/examples/spawn-chain/src/elixir/range.rs
@@ -1,8 +1,8 @@
 use liblumen_alloc::erts::exception::Result;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
-pub fn new(first: Term, last: Term, process: &ProcessControlBlock) -> Result {
+pub fn new(first: Term, last: Term, process: &Process) -> Result {
     if first.is_integer() & last.is_integer() {
         process
             .map_from_slice(&[

--- a/liblumen_alloc/src/borrow/clone_to_process.rs
+++ b/liblumen_alloc/src/borrow/clone_to_process.rs
@@ -2,7 +2,7 @@ use core::mem;
 use core::ptr::NonNull;
 
 use crate::erts::exception::system::Alloc;
-use crate::erts::{self, HeapAlloc, HeapFragment, ProcessControlBlock, Term};
+use crate::erts::{self, HeapAlloc, HeapFragment, Process, Term};
 
 /// This trait represents cloning, like `Clone`, but specifically
 /// in the context of terms which need to be cloned into the heap
@@ -21,7 +21,7 @@ pub trait CloneToProcess {
     /// Returns boxed copy of this value, performing any heap allocations
     /// using the process heap of `process`, possibly using heap fragments if
     /// there is not enough space for the cloned value
-    fn clone_to_process(&self, process: &ProcessControlBlock) -> Term {
+    fn clone_to_process(&self, process: &Process) -> Term {
         let mut heap = process.acquire_heap();
         match self.clone_to_heap(&mut heap) {
             Ok(term) => term,

--- a/liblumen_alloc/src/borrow/cow.rs
+++ b/liblumen_alloc/src/borrow/cow.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use crate::erts::{ProcessControlBlock, Term};
+use crate::erts::{Process, Term};
 
 use super::CloneToProcess;
 
@@ -22,14 +22,14 @@ pub enum Cow {
     Owned(Term),
 }
 impl Cow {
-    pub fn clone_to_process(&self, process: &mut ProcessControlBlock) -> Self {
+    pub fn clone_to_process(&self, process: &mut Process) -> Self {
         match *self {
             Self::Borrowed(b) => Self::Borrowed(b),
             Self::Owned(o) => Self::Owned(o.clone_to_process(process)),
         }
     }
 
-    pub fn clone_from(&mut self, source: &Self, process: &mut ProcessControlBlock) {
+    pub fn clone_from(&mut self, source: &Self, process: &mut Process) {
         if let Self::Owned(ref mut dest) = *self {
             if let Self::Owned(ref o) = *source {
                 *dest = o.clone_to_process(process);

--- a/liblumen_alloc/src/erts/exception.rs
+++ b/liblumen_alloc/src/erts/exception.rs
@@ -6,7 +6,7 @@ use core::convert::Into;
 use core::num::TryFromIntError;
 
 use crate::erts::process::alloc::heap_alloc::MakePidError;
-use crate::erts::process::ProcessControlBlock;
+use crate::erts::process::Process;
 use crate::erts::term::atom::AtomError;
 use crate::erts::term::atom::EncodingError;
 use crate::erts::term::list::ImproperList;
@@ -23,7 +23,7 @@ pub enum Exception {
 
 impl Exception {
     pub fn badarity(
-        process: &ProcessControlBlock,
+        process: &Process,
         function: Term,
         arguments: Term,
         file: &'static str,
@@ -37,7 +37,7 @@ impl Exception {
     }
 
     pub fn badfun(
-        process: &ProcessControlBlock,
+        process: &Process,
         function: Term,
         file: &'static str,
         line: u32,
@@ -50,7 +50,7 @@ impl Exception {
     }
 
     pub fn badkey(
-        process: &ProcessControlBlock,
+        process: &Process,
         key: Term,
         file: &'static str,
         line: u32,
@@ -63,7 +63,7 @@ impl Exception {
     }
 
     pub fn badmap(
-        process: &ProcessControlBlock,
+        process: &Process,
         map: Term,
         file: &'static str,
         line: u32,
@@ -76,7 +76,7 @@ impl Exception {
     }
 
     pub fn undef(
-        process: &ProcessControlBlock,
+        process: &Process,
         module: Term,
         function: Term,
         arguments: Term,

--- a/liblumen_alloc/src/erts/exception/runtime.rs
+++ b/liblumen_alloc/src/erts/exception/runtime.rs
@@ -3,7 +3,7 @@ use core::num::TryFromIntError;
 use core::result::Result;
 
 use crate::erts::exception::system::Alloc;
-use crate::erts::process::ProcessControlBlock;
+use crate::erts::process::Process;
 use crate::erts::term::atom::{AtomError, EncodingError};
 use crate::erts::term::list::ImproperList;
 use crate::erts::term::{
@@ -56,7 +56,7 @@ impl Exception {
     }
 
     pub fn badarity(
-        process: &ProcessControlBlock,
+        process: &Process,
         function: Term,
         arguments: Term,
         file: &'static str,
@@ -70,7 +70,7 @@ impl Exception {
     }
 
     pub fn badfun(
-        process: &ProcessControlBlock,
+        process: &Process,
         function: Term,
         file: &'static str,
         line: u32,
@@ -85,7 +85,7 @@ impl Exception {
     }
 
     pub fn badkey(
-        process: &ProcessControlBlock,
+        process: &Process,
         key: Term,
         file: &'static str,
         line: u32,
@@ -99,7 +99,7 @@ impl Exception {
     }
 
     pub fn badmap(
-        process: &ProcessControlBlock,
+        process: &Process,
         map: Term,
         file: &'static str,
         line: u32,
@@ -124,7 +124,7 @@ impl Exception {
     }
 
     pub fn undef(
-        process: &ProcessControlBlock,
+        process: &Process,
         module: Term,
         function: Term,
         arguments: Term,
@@ -151,11 +151,7 @@ impl Exception {
         atom_unchecked("badarith")
     }
 
-    fn badarity_reason(
-        process: &ProcessControlBlock,
-        function: Term,
-        arguments: Term,
-    ) -> Result<Term, Alloc> {
+    fn badarity_reason(process: &Process, function: Term, arguments: Term) -> Result<Term, Alloc> {
         let function_arguments = process.tuple_from_slice(&[function, arguments])?;
 
         process.tuple_from_slice(&[Self::badarity_tag(), function_arguments])
@@ -200,7 +196,7 @@ impl Exception {
     }
 
     fn undef_stacktrace(
-        process: &ProcessControlBlock,
+        process: &Process,
         module: Term,
         function: Term,
         arguments: Term,

--- a/liblumen_alloc/src/erts/process.rs
+++ b/liblumen_alloc/src/erts/process.rs
@@ -68,7 +68,7 @@ cfg_if::cfg_if! {
 /// to a writer lock and modify/access the heap, process dictionary, off-heap
 /// fragments and message list without requiring multiple locks
 #[repr(C)]
-pub struct ProcessControlBlock {
+pub struct Process {
     /// ID of the scheduler that is running the process
     scheduler_id: Mutex<Option<scheduler::ID>>,
     /// The priority of the process in `scheduler`.
@@ -113,7 +113,7 @@ pub struct ProcessControlBlock {
     // process heap, cache line aligned to avoid false sharing with rest of struct
     heap: Mutex<ProcessHeap>,
 }
-impl ProcessControlBlock {
+impl Process {
     /// Creates a new PCB with a heap defined by the given pointer, and
     /// `heap_size`, which is the size of the heap in words.
     pub fn new(
@@ -328,7 +328,7 @@ impl ProcessControlBlock {
 
     // Links
 
-    pub fn link(&self, other: &ProcessControlBlock) {
+    pub fn link(&self, other: &Process) {
         // link in order so that locks are always taken in the same order to prevent deadlocks
         if self.pid < other.pid {
             let mut self_pid_set = self.linked_pid_set.lock();
@@ -341,7 +341,7 @@ impl ProcessControlBlock {
         }
     }
 
-    pub fn unlink(&self, other: &ProcessControlBlock) {
+    pub fn unlink(&self, other: &Process) {
         // unlink in order so that locks are always taken in the same order to prevent deadlocks
         if self.pid < other.pid {
             let mut self_pid_set = self.linked_pid_set.lock();
@@ -749,7 +749,7 @@ impl ProcessControlBlock {
     }
 
     /// Run process until `reductions` exceeds `MAX_REDUCTIONS` or process exits
-    pub fn run(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+    pub fn run(arc_process: &Arc<Process>) -> code::Result {
         arc_process.start_running();
 
         // `code` is expected to set `code` before it returns to be the next spot to continue
@@ -822,7 +822,7 @@ impl ProcessControlBlock {
     }
 
     /// Calls top `Frame`'s `Code` if it exists and the process is not reduced.
-    pub fn call_code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+    pub fn call_code(arc_process: &Arc<Process>) -> code::Result {
         if !arc_process.is_reduced() {
             let option_code = arc_process
                 .code_stack
@@ -902,7 +902,7 @@ impl ProcessControlBlock {
 }
 
 #[cfg(test)]
-impl ProcessControlBlock {
+impl Process {
     #[inline]
     fn young_heap_used(&self) -> usize {
         let heap = self.heap.lock();
@@ -922,7 +922,7 @@ impl ProcessControlBlock {
     }
 }
 
-impl fmt::Debug for ProcessControlBlock {
+impl fmt::Debug for Process {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.pid)?;
 
@@ -933,7 +933,7 @@ impl fmt::Debug for ProcessControlBlock {
     }
 }
 
-impl fmt::Display for ProcessControlBlock {
+impl fmt::Display for Process {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let pid = self.pid;
         let (number, serial) = (pid.number(), pid.serial());
@@ -947,22 +947,22 @@ impl fmt::Display for ProcessControlBlock {
     }
 }
 
-impl Eq for ProcessControlBlock {}
+impl Eq for Process {}
 
-impl Hash for ProcessControlBlock {
+impl Hash for Process {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.pid.hash(state);
     }
 }
 
-impl PartialEq for ProcessControlBlock {
+impl PartialEq for Process {
     fn eq(&self, other: &Self) -> bool {
         self.pid == other.pid
     }
 }
 
-unsafe impl Send for ProcessControlBlock {}
-unsafe impl Sync for ProcessControlBlock {}
+unsafe impl Send for Process {}
+unsafe impl Sync for Process {}
 
 type Reductions = u16;
 

--- a/liblumen_alloc/src/erts/process/code.rs
+++ b/liblumen_alloc/src/erts/process/code.rs
@@ -3,12 +3,12 @@ pub mod stack;
 use alloc::sync::Arc;
 
 use crate::erts::exception::{system, Exception};
-use crate::erts::process::ProcessControlBlock;
+use crate::erts::process::Process;
 
 pub type Result = core::result::Result<(), system::Exception>;
-pub type Code = fn(&Arc<ProcessControlBlock>) -> Result;
+pub type Code = fn(&Arc<Process>) -> Result;
 
-pub fn result_from_exception(process: &ProcessControlBlock, exception: Exception) -> Result {
+pub fn result_from_exception(process: &Process, exception: Exception) -> Result {
     match exception {
         Exception::Runtime(runtime_exception) => {
             process.exception(runtime_exception);

--- a/liblumen_alloc/src/erts/process/gc/collector.rs
+++ b/liblumen_alloc/src/erts/process/gc/collector.rs
@@ -57,17 +57,13 @@ enum CollectionType {
 /// missing features here correspondingly
 pub struct GarbageCollector<'p, 'h> {
     mode: CollectionType,
-    process: &'p ProcessControlBlock,
+    process: &'p Process,
     heap: &'h mut ProcessHeap,
     roots: RootSet,
 }
 impl<'p, 'h> GarbageCollector<'p, 'h> {
     /// Initializes the collector with the given process and root set
-    pub fn new(
-        heap: &'h mut ProcessHeap,
-        process: &'p ProcessControlBlock,
-        roots: RootSet,
-    ) -> Self {
+    pub fn new(heap: &'h mut ProcessHeap, process: &'p Process, roots: RootSet) -> Self {
         let mode = if Self::need_fullsweep(heap, process) {
             CollectionType::Full
         } else {
@@ -550,7 +546,7 @@ impl<'p, 'h> GarbageCollector<'p, 'h> {
 
     /// Determines if the current collection requires a full sweep or not
     #[inline]
-    fn need_fullsweep(heap: &ProcessHeap, process: &ProcessControlBlock) -> bool {
+    fn need_fullsweep(heap: &ProcessHeap, process: &Process) -> bool {
         if process.needs_fullsweep() {
             return true;
         }

--- a/liblumen_alloc/src/erts/process/heap.rs
+++ b/liblumen_alloc/src/erts/process/heap.rs
@@ -5,7 +5,7 @@ use crate::erts::term::{ProcBin, Term};
 
 use super::alloc::{HeapAlloc, StackAlloc, StackPrimitives, VirtualAlloc};
 use super::gc::*;
-use super::ProcessControlBlock;
+use super::Process;
 
 #[derive(Debug)]
 #[repr(C)]
@@ -52,7 +52,7 @@ impl ProcessHeap {
     #[inline]
     pub fn garbage_collect(
         &mut self,
-        process: &ProcessControlBlock,
+        process: &Process,
         need: usize,
         mut rootset: RootSet,
     ) -> Result<usize, GcError> {

--- a/liblumen_alloc/src/erts/process/test.rs
+++ b/liblumen_alloc/src/erts/process/test.rs
@@ -178,7 +178,7 @@ mod tuple_from_slice {
         }
     }
 
-    fn closure(process: &ProcessControlBlock) -> Term {
+    fn closure(process: &Process) -> Term {
         let creator = process.pid_term();
 
         let module = Atom::try_from_str("module").unwrap();
@@ -189,7 +189,7 @@ mod tuple_from_slice {
             function,
             arity,
         });
-        let code = |arc_process: &Arc<ProcessControlBlock>| {
+        let code = |arc_process: &Arc<Process>| {
             arc_process.wait();
 
             Ok(())
@@ -201,7 +201,7 @@ mod tuple_from_slice {
     }
 }
 
-fn simple_gc_test(process: ProcessControlBlock) {
+fn simple_gc_test(process: Process) {
     // Allocate an `{:ok, "hello world"}` tuple
     // First, the `ok` atom, an immediate, is super easy
     let ok = unsafe { Atom::try_from_str("ok").unwrap().as_term() };
@@ -313,7 +313,7 @@ fn simple_gc_test(process: ProcessControlBlock) {
     assert_eq!("test", test_string.as_str());
 }
 
-fn tenuring_gc_test(process: ProcessControlBlock, _perform_fullsweep: bool) {
+fn tenuring_gc_test(process: Process, _perform_fullsweep: bool) {
     // Allocate an `{:ok, "hello world"}` tuple
     // First, the `ok` atom, an immediate, is super easy
     let ok = unsafe { Atom::try_from_str("ok").unwrap().as_term() };
@@ -556,7 +556,7 @@ fn tenuring_gc_test(process: ProcessControlBlock, _perform_fullsweep: bool) {
     */
 }
 
-fn process() -> ProcessControlBlock {
+fn process() -> Process {
     let init = Atom::try_from_str("init").unwrap();
     let initial_module_function_arity = Arc::new(ModuleFunctionArity {
         module: init,
@@ -565,7 +565,7 @@ fn process() -> ProcessControlBlock {
     });
     let (heap, heap_size) = alloc::default_heap().unwrap();
 
-    let process = ProcessControlBlock::new(
+    let process = Process::new(
         Priority::Normal,
         None,
         initial_module_function_arity,

--- a/liblumen_alloc/src/erts/term/binary/process.rs
+++ b/liblumen_alloc/src/erts/term/binary/process.rs
@@ -16,7 +16,7 @@ use intrusive_collections::LinkedListLink;
 use crate::borrow::CloneToProcess;
 use crate::erts::exception::runtime;
 use crate::erts::exception::system::Alloc;
-use crate::erts::process::ProcessControlBlock;
+use crate::erts::process::Process;
 use crate::erts::term::binary::heap::HeapBin;
 use crate::erts::term::binary::sub::{Original, SubBinary};
 use crate::erts::term::{arity_of, AsTerm, Boxed, MatchContext, Term};
@@ -292,7 +292,7 @@ impl Clone for ProcBin {
 }
 
 impl CloneToProcess for ProcBin {
-    fn clone_to_process(&self, process: &ProcessControlBlock) -> Term {
+    fn clone_to_process(&self, process: &Process) -> Term {
         let mut heap = process.acquire_heap();
         let boxed = self.clone_to_heap(&mut heap).unwrap();
         let ptr = boxed.boxed_val() as *mut Self;

--- a/liblumen_alloc/src/erts/term/boxed.rs
+++ b/liblumen_alloc/src/erts/term/boxed.rs
@@ -8,7 +8,7 @@ use core::ptr::NonNull;
 use crate::borrow::CloneToProcess;
 use crate::erts::exception::system::Alloc;
 use crate::erts::term::binary::Bitstring;
-use crate::erts::ProcessControlBlock;
+use crate::erts::Process;
 use crate::erts::{HeapAlloc, HeapFragment};
 
 use super::{AsTerm, Term};
@@ -137,7 +137,7 @@ impl<T: PartialOrd> PartialOrd<T> for Boxed<T> {
 }
 
 impl<T: CloneToProcess> CloneToProcess for Boxed<T> {
-    fn clone_to_process(&self, process: &ProcessControlBlock) -> Term {
+    fn clone_to_process(&self, process: &Process) -> Term {
         let term = unsafe { &*self.term };
         term.clone_to_process(process)
     }

--- a/liblumen_alloc/src/erts/term/closure.rs
+++ b/liblumen_alloc/src/erts/term/closure.rs
@@ -14,7 +14,7 @@ use crate::borrow::CloneToProcess;
 use crate::erts::exception::system::Alloc;
 use crate::erts::process::code::stack::frame::{Frame, Placement};
 use crate::erts::process::code::Code;
-use crate::erts::process::ProcessControlBlock;
+use crate::erts::process::Process;
 use crate::erts::term::{arity_of, Boxed, TypeError, TypedTerm};
 use crate::erts::{HeapAlloc, ModuleFunctionArity};
 
@@ -56,7 +56,7 @@ impl Closure {
 
     pub fn place_frame_with_arguments(
         &self,
-        process: &ProcessControlBlock,
+        process: &Process,
         placement: Placement,
         arguments: Vec<Term>,
     ) -> Result<(), Alloc> {
@@ -72,7 +72,7 @@ impl Closure {
         Ok(())
     }
 
-    fn push_env_to_stack(&self, process: &ProcessControlBlock) -> Result<(), Alloc> {
+    fn push_env_to_stack(&self, process: &Process) -> Result<(), Alloc> {
         for term in self.env.iter().rev() {
             process.stack_push(*term)?;
         }

--- a/liblumen_alloc/src/erts/term/list.rs
+++ b/liblumen_alloc/src/erts/term/list.rs
@@ -656,7 +656,7 @@ mod tests {
 
         use ::alloc::sync::Arc;
 
-        use crate::erts::process::{alloc, Priority, ProcessControlBlock};
+        use crate::erts::process::{alloc, Priority, Process};
         use crate::erts::scheduler;
         use crate::erts::term::{atom_unchecked, Atom};
         use crate::erts::ModuleFunctionArity;
@@ -747,7 +747,7 @@ mod tests {
             assert_eq!(heap_fragment_cons_term, cons_term);
         }
 
-        fn process() -> ProcessControlBlock {
+        fn process() -> Process {
             let init = Atom::try_from_str("init").unwrap();
             let initial_module_function_arity = Arc::new(ModuleFunctionArity {
                 module: init,
@@ -756,7 +756,7 @@ mod tests {
             });
             let (heap, heap_size) = alloc::default_heap().unwrap();
 
-            let process = ProcessControlBlock::new(
+            let process = Process::new(
                 Priority::Normal,
                 None,
                 initial_module_function_arity,

--- a/liblumen_alloc/src/erts/term/term.rs
+++ b/liblumen_alloc/src/erts/term/term.rs
@@ -14,7 +14,7 @@ use crate::erts::exception::system::Alloc;
 use crate::erts::term::binary::aligned_binary::AlignedBinary;
 use crate::erts::term::resource;
 use crate::erts::term::InvalidTermError;
-use crate::erts::ProcessControlBlock;
+use crate::erts::Process;
 
 use num_bigint::BigInt;
 
@@ -1587,7 +1587,7 @@ impl Ord for Term {
 }
 
 impl CloneToProcess for Term {
-    fn clone_to_process(&self, process: &ProcessControlBlock) -> Term {
+    fn clone_to_process(&self, process: &Process) -> Term {
         if self.is_immediate() {
             *self
         } else if self.is_boxed() || self.is_non_empty_list() {

--- a/liblumen_alloc/src/erts/term/tuple.rs
+++ b/liblumen_alloc/src/erts/term/tuple.rs
@@ -348,7 +348,7 @@ mod tests {
 
     use alloc::sync::Arc;
 
-    use crate::erts::process::{default_heap, Priority, ProcessControlBlock};
+    use crate::erts::process::{default_heap, Priority, Process};
     use crate::erts::scheduler;
     use crate::erts::term::{Boxed, Tuple};
     use crate::erts::ModuleFunctionArity;
@@ -475,7 +475,7 @@ mod tests {
         }
     }
 
-    fn closure(process: &ProcessControlBlock) -> Term {
+    fn closure(process: &Process) -> Term {
         let creator = process.pid_term();
 
         let module = Atom::try_from_str("module").unwrap();
@@ -486,7 +486,7 @@ mod tests {
             function,
             arity,
         });
-        let code = |arc_process: &Arc<ProcessControlBlock>| {
+        let code = |arc_process: &Arc<Process>| {
             arc_process.wait();
 
             Ok(())
@@ -497,7 +497,7 @@ mod tests {
             .unwrap()
     }
 
-    fn process() -> ProcessControlBlock {
+    fn process() -> Process {
         let init = Atom::try_from_str("init").unwrap();
         let initial_module_function_arity = Arc::new(ModuleFunctionArity {
             module: init,
@@ -506,7 +506,7 @@ mod tests {
         });
         let (heap, heap_size) = default_heap().unwrap();
 
-        let process = ProcessControlBlock::new(
+        let process = Process::new(
             Priority::Normal,
             None,
             initial_module_function_arity,

--- a/liblumen_alloc/src/erts/term/typed_term.rs
+++ b/liblumen_alloc/src/erts/term/typed_term.rs
@@ -11,7 +11,7 @@ use crate::borrow::CloneToProcess;
 use crate::erts::exception::runtime;
 use crate::erts::exception::system::Alloc;
 use crate::erts::term::resource;
-use crate::erts::ProcessControlBlock;
+use crate::erts::Process;
 
 use super::*;
 
@@ -804,7 +804,7 @@ unsafe impl AsTerm for TypedTerm {
 }
 
 impl CloneToProcess for TypedTerm {
-    fn clone_to_process(&self, process: &ProcessControlBlock) -> Term {
+    fn clone_to_process(&self, process: &Process) -> Term {
         // Immediates are just copied and returned, all other terms
         // are expected to require allocation, so we delegate to those types
         match self {

--- a/liblumen_alloc/src/macros/erts/exception.rs
+++ b/liblumen_alloc/src/macros/erts/exception.rs
@@ -5,49 +5,43 @@ mod system;
 
 #[macro_export]
 macro_rules! badkey {
-    ($process_control_block:expr, $key:expr) => {{
+    ($process:expr, $key:expr) => {{
         use $crate::erts::exception::Exception;
 
-        Exception::badkey($process_control_block, $key, file!(), line!(), column!())
+        Exception::badkey($process, $key, file!(), line!(), column!())
     }};
-    ($process_control_block:expr, $key:expr,) => {{
-        badkey!($process_control_block, $key)
+    ($process:expr, $key:expr,) => {{
+        badkey!($process, $key)
     }};
 }
 
 #[macro_export]
 macro_rules! badmap {
-    ($process_control_block:expr, $map:expr) => {{
+    ($process:expr, $map:expr) => {{
         use $crate::erts::exception::Exception;
 
-        Exception::badmap($process_control_block, $map, file!(), line!(), column!())
+        Exception::badmap($process, $map, file!(), line!(), column!())
     }};
-    ($process_control_block:expr, $map:expr,) => {{
-        badmap!($process_control_block, $map)
+    ($process:expr, $map:expr,) => {{
+        badmap!($process, $map)
     }};
 }
 
 #[macro_export]
 macro_rules! undef {
-    ($process_control_block:expr, $module:expr, $function:expr, $arguments:expr) => {{
+    ($process:expr, $module:expr, $function:expr, $arguments:expr) => {{
         use $crate::erts::Term;
 
-        $crate::undef!(
-            $process_control_block,
-            $module,
-            $function,
-            $arguments,
-            Term::NIL
-        )
+        $crate::undef!($process, $module, $function, $arguments, Term::NIL)
     }};
-    ($process_control_block:expr, $module:expr, $function:expr, $arguments:expr,) => {
-        $crate::undef!($process_control_block, $module, $function, $arguments)
+    ($process:expr, $module:expr, $function:expr, $arguments:expr,) => {
+        $crate::undef!($process, $module, $function, $arguments)
     };
-    ($process_control_block:expr, $module:expr, $function:expr, $arguments:expr, $stacktrace_tail:expr) => {{
+    ($process:expr, $module:expr, $function:expr, $arguments:expr, $stacktrace_tail:expr) => {{
         use $crate::erts::exception::{runtime, Exception};
 
         Exception::undef(
-            $process_control_block,
+            $process,
             $module,
             $function,
             $arguments,
@@ -57,13 +51,7 @@ macro_rules! undef {
             column!(),
         )
     }};
-    ($process_control_block:expr, $module:expr, $function:expr, $arguments:expr, $stacktrace_tail:expr,) => {
-        $crate::undef!(
-            $process_control_block,
-            $module,
-            $function,
-            $arguments,
-            $stacktrace_tail
-        )
+    ($process:expr, $module:expr, $function:expr, $arguments:expr, $stacktrace_tail:expr,) => {
+        $crate::undef!($process, $module, $function, $arguments, $stacktrace_tail)
     };
 }

--- a/liblumen_eir_interpreter/src/code.rs
+++ b/liblumen_eir_interpreter/src/code.rs
@@ -6,13 +6,13 @@ use libeir_ir::Block;
 
 use liblumen_alloc::erts::process::code::stack::frame::Frame;
 use liblumen_alloc::erts::process::code::Result;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term, TypedTerm};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
 use crate::exec::CallExecutor;
 
-pub fn return_throw(arc_process: &Arc<ProcessControlBlock>) -> Result {
+pub fn return_throw(arc_process: &Arc<Process>) -> Result {
     let argument_list = arc_process.stack_pop().unwrap();
 
     panic!("{:?}", argument_list);
@@ -34,25 +34,25 @@ pub fn return_throw(arc_process: &Arc<ProcessControlBlock>) -> Result {
     //result_from_exception(arc_process, exc.into())
 }
 
-pub fn return_ok(arc_process: &Arc<ProcessControlBlock>) -> Result {
+pub fn return_ok(arc_process: &Arc<Process>) -> Result {
     let argument_list = arc_process.stack_pop().unwrap();
 
     println!("PROCESS EXIT NORMAL WITH: {:?}", argument_list);
 
     arc_process.return_from_call(argument_list)?;
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-pub fn return_clean(arc_process: &Arc<ProcessControlBlock>) -> Result {
+pub fn return_clean(arc_process: &Arc<Process>) -> Result {
     let argument_list = arc_process.stack_pop().unwrap();
     arc_process.return_from_call(argument_list)?;
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 /// Expects the following on stack:
 /// * arity integer
 /// * argument list
-pub fn interpreter_mfa_code(arc_process: &Arc<ProcessControlBlock>) -> Result {
+pub fn interpreter_mfa_code(arc_process: &Arc<Process>) -> Result {
     let argument_list = arc_process.stack_pop().unwrap();
 
     let mfa = arc_process.current_module_function_arity().unwrap();
@@ -88,7 +88,7 @@ pub fn interpreter_mfa_code(arc_process: &Arc<ProcessControlBlock>) -> Result {
 /// * argument list
 /// * block id integer
 /// * environment list
-pub fn interpreter_closure_code(arc_process: &Arc<ProcessControlBlock>) -> Result {
+pub fn interpreter_closure_code(arc_process: &Arc<Process>) -> Result {
     let arity_term = arc_process.stack_pop().unwrap();
     let argument_list = arc_process.stack_pop().unwrap();
     let block_id_term = arc_process.stack_pop().unwrap();
@@ -140,7 +140,7 @@ pub fn interpreter_closure_code(arc_process: &Arc<ProcessControlBlock>) -> Resul
     )
 }
 
-pub fn apply(arc_process: &Arc<ProcessControlBlock>) -> Result {
+pub fn apply(arc_process: &Arc<Process>) -> Result {
     let module_term = arc_process.stack_pop().unwrap();
     let function_term = arc_process.stack_pop().unwrap();
     let argument_list = arc_process.stack_pop().unwrap();
@@ -166,5 +166,5 @@ pub fn apply(arc_process: &Arc<ProcessControlBlock>) -> Result {
     arc_process.stack_push(argument_list)?;
     arc_process.replace_frame(frame);
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }

--- a/liblumen_eir_interpreter/src/exec/match.rs
+++ b/liblumen_eir_interpreter/src/exec/match.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use libeir_ir::{BasicType, Block, MatchKind, PrimOpKind};
 
 use liblumen_alloc::erts::exception::system;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::TypedTerm;
 
 use super::{CallExecutor, OpResult};
@@ -11,7 +11,7 @@ use crate::module::ErlangFunction;
 
 pub fn match_op(
     exec: &mut CallExecutor,
-    proc: &Arc<ProcessControlBlock>,
+    proc: &Arc<Process>,
     fun: &ErlangFunction,
     branches: &[MatchKind],
     block: Block,

--- a/liblumen_eir_interpreter/src/lib.rs
+++ b/liblumen_eir_interpreter/src/lib.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use liblumen_alloc::erts::exception;
-use liblumen_alloc::erts::process::{ProcessControlBlock, Status};
+use liblumen_alloc::erts::process::{Process, Status};
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -25,7 +25,7 @@ lazy_static! {
 }
 
 pub fn call_erlang(
-    proc: Arc<ProcessControlBlock>,
+    proc: Arc<Process>,
     module: Atom,
     function: Atom,
     args: &[Term],
@@ -87,7 +87,7 @@ pub fn call_erlang(
                 } => {
                     if *reason != atom_unchecked("normal") {
                         return Err(());
-                    //panic!("ProcessControlBlock exited: {:?}", reason);
+                    //panic!("Process exited: {:?}", reason);
                     } else {
                         return Ok(());
                     }
@@ -95,7 +95,7 @@ pub fn call_erlang(
                 _ => {
                     return Err(());
                     //panic!(
-                    //    "ProcessControlBlock exception: {:?}\n{:?}",
+                    //    "Process exception: {:?}\n{:?}",
                     //    exception,
                     //    run_arc_process.stacktrace()
                     //);

--- a/liblumen_eir_interpreter/src/module.rs
+++ b/liblumen_eir_interpreter/src/module.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use libeir_ir::{Function, LiveValues, Module};
 
 use liblumen_alloc::erts::process::code::Result;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 
 pub enum ResolvedFunction<'a> {
@@ -79,8 +79,8 @@ impl ModuleRegistry {
 
 #[derive(Copy, Clone)]
 pub enum NativeFunctionKind {
-    Simple(fn(&Arc<ProcessControlBlock>, &[Term]) -> std::result::Result<Term, ()>),
-    Yielding(fn(&Arc<ProcessControlBlock>, &[Term]) -> Result),
+    Simple(fn(&Arc<Process>, &[Term]) -> std::result::Result<Term, ()>),
+    Yielding(fn(&Arc<Process>, &[Term]) -> Result),
 }
 
 pub struct NativeModule {
@@ -99,7 +99,7 @@ impl NativeModule {
         &mut self,
         name: Atom,
         arity: usize,
-        fun: fn(&Arc<ProcessControlBlock>, &[Term]) -> std::result::Result<Term, ()>,
+        fun: fn(&Arc<Process>, &[Term]) -> std::result::Result<Term, ()>,
     ) {
         self.functions
             .insert((name, arity), NativeFunctionKind::Simple(fun));
@@ -109,7 +109,7 @@ impl NativeModule {
         &mut self,
         name: Atom,
         arity: usize,
-        fun: fn(&Arc<ProcessControlBlock>, &[Term]) -> Result,
+        fun: fn(&Arc<Process>, &[Term]) -> Result,
     ) {
         self.functions
             .insert((name, arity), NativeFunctionKind::Yielding(fun));

--- a/liblumen_eir_interpreter/src/vm.rs
+++ b/liblumen_eir_interpreter/src/vm.rs
@@ -70,14 +70,14 @@ impl VMState {
                         ..
                     } => {
                         if *reason != atom_unchecked("normal") {
-                            panic!("ProcessControlBlock exited: {:?}", reason);
+                            panic!("Process exited: {:?}", reason);
                         } else {
                             panic!("yay!");
                         }
                     }
                     _ => {
                         panic!(
-                            "ProcessControlBlock exception: {:?}\n{:?}",
+                            "Process exception: {:?}\n{:?}",
                             exception,
                             run_arc_process.stacktrace()
                         );

--- a/lumen_runtime/src/binary.rs
+++ b/lumen_runtime/src/binary.rs
@@ -4,7 +4,7 @@ use core::ops::Range;
 use liblumen_alloc::badarg;
 use liblumen_alloc::erts::exception::{self, Exception};
 use liblumen_alloc::erts::term::{Atom, Term, TypedTerm};
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 pub(crate) struct PartRange {
     pub byte_offset: usize,
@@ -52,7 +52,7 @@ pub(crate) fn start_length_to_part_range(
 }
 
 pub trait ToTerm {
-    fn to_term(&self, options: ToTermOptions, process: &ProcessControlBlock) -> exception::Result;
+    fn to_term(&self, options: ToTermOptions, process: &Process) -> exception::Result;
 }
 
 pub struct ToTermOptions {

--- a/lumen_runtime/src/code.rs
+++ b/lumen_runtime/src/code.rs
@@ -1,10 +1,10 @@
 use alloc::sync::Arc;
 
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 
 /// A stub that just puts the init process into `Status::Waiting`, so it remains alive without
 /// wasting CPU cycles
-pub fn init(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn init(arc_process: &Arc<Process>) -> code::Result {
     Arc::clone(arc_process).wait();
 
     Ok(())

--- a/lumen_runtime/src/otp/binary.rs
+++ b/lumen_runtime/src/otp/binary.rs
@@ -6,7 +6,7 @@ use liblumen_alloc::erts::term::binary::aligned_binary::AlignedBinary;
 use liblumen_alloc::erts::term::binary::maybe_aligned_maybe_binary::MaybeAlignedMaybeBinary;
 use liblumen_alloc::erts::term::binary::IterableBitstring;
 use liblumen_alloc::erts::term::{Bitstring, Term, TypedTerm};
-use liblumen_alloc::{badarg, ProcessControlBlock};
+use liblumen_alloc::{badarg, Process};
 
 use crate::binary::start_length_to_part_range;
 
@@ -24,12 +24,7 @@ use crate::binary::start_length_to_part_range;
 ///
 /// * `Ok(Term)` - the list of bytes
 /// * `Err(BadArgument)` - binary is not a binary; position is invalid; length is invalid.
-pub fn bin_to_list(
-    binary: Term,
-    position: Term,
-    length: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn bin_to_list(binary: Term, position: Term, length: Term, process: &Process) -> Result {
     let position_usize: usize = position.try_into()?;
     let length_isize: isize = length.try_into()?;
 
@@ -44,7 +39,7 @@ pub fn bin_to_list(
                 let byte_iter = byte_slice.iter();
                 let byte_term_iter = byte_iter.map(|byte| (*byte).into());
 
-                let list = process_control_block.list_from_iter(byte_term_iter)?;
+                let list = process.list_from_iter(byte_term_iter)?;
 
                 Ok(list)
             }
@@ -57,7 +52,7 @@ pub fn bin_to_list(
                 let byte_iter = byte_slice.iter();
                 let byte_term_iter = byte_iter.map(|byte| (*byte).into());
 
-                let list = process_control_block.list_from_iter(byte_term_iter)?;
+                let list = process.list_from_iter(byte_term_iter)?;
 
                 Ok(list)
             }
@@ -72,7 +67,7 @@ pub fn bin_to_list(
                     let byte_iter = byte_slice.iter();
                     let byte_term_iter = byte_iter.map(|byte| (*byte).into());
 
-                    process_control_block.list_from_iter(byte_term_iter)
+                    process.list_from_iter(byte_term_iter)
                 } else {
                     let mut byte_iter = subbinary.full_byte_iter();
 
@@ -87,7 +82,7 @@ pub fn bin_to_list(
 
                     let byte_term_iter = byte_iter.map(|byte| byte.into());
 
-                    process_control_block.list_from_iter(byte_term_iter)
+                    process.list_from_iter(byte_term_iter)
                 };
 
                 match result {

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -44,6 +44,7 @@ use liblumen_core::locks::MutexGuard;
 
 use liblumen_alloc::erts::exception::runtime::Class;
 use liblumen_alloc::erts::exception::{Exception, Result};
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::binary::aligned_binary::AlignedBinary;
 use liblumen_alloc::erts::term::binary::maybe_aligned_maybe_binary::MaybeAlignedMaybeBinary;
 use liblumen_alloc::erts::term::binary::{Bitstring, IterableBitstring, MaybePartialByte};
@@ -51,7 +52,6 @@ use liblumen_alloc::erts::term::{
     atom_unchecked, AsTerm, Atom, Boxed, Cons, Encoding, Float, ImproperList, Map, SmallInteger,
     Term, Tuple, TypedTerm,
 };
-use liblumen_alloc::erts::ProcessControlBlock;
 use liblumen_alloc::{badarg, badarith, badkey, badmap, error, raise, throw};
 
 use crate::binary::{start_length_to_part_range, PartRange, ToTermOptions};
@@ -67,14 +67,14 @@ use crate::timer::{self, Timeout};
 use crate::tuple::ZeroBasedIndex;
 use liblumen_alloc::erts::process::alloc::heap_alloc::HeapAlloc;
 
-pub fn abs_1(number: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn abs_1(number: Term, process: &Process) -> Result {
     let option_abs = match number.to_typed_term().unwrap() {
         TypedTerm::SmallInteger(small_integer) => {
             let i: isize = small_integer.into();
 
             if i < 0 {
                 let positive = -i;
-                let abs_number = process_control_block.integer(positive)?;
+                let abs_number = process.integer(positive)?;
 
                 Some(abs_number)
             } else {
@@ -89,7 +89,7 @@ pub fn abs_1(number: Term, process_control_block: &ProcessControlBlock) -> Resul
                 let abs_number: Term = if big_int < zero_big_int {
                     let positive_big_int: BigInt = -1 * big_int;
 
-                    process_control_block.integer(positive_big_int)?
+                    process.integer(positive_big_int)?
                 } else {
                     number
                 };
@@ -103,7 +103,7 @@ pub fn abs_1(number: Term, process_control_block: &ProcessControlBlock) -> Resul
                     Ordering::Less => {
                         let positive_f = f.abs();
 
-                        process_control_block.float(positive_f).unwrap()
+                        process.float(positive_f).unwrap()
                     }
                     _ => number,
                 };
@@ -144,13 +144,9 @@ pub fn andalso_2(boolean: Term, term: Term) -> Result {
     }
 }
 
-pub fn append_element_2(
-    tuple: Term,
-    element: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn append_element_2(tuple: Term, element: Term, process: &Process) -> Result {
     let internal: Boxed<Tuple> = tuple.try_into()?;
-    let new_tuple = process_control_block.tuple_from_slices(&[&internal[..], &[element]])?;
+    let new_tuple = process.tuple_from_slices(&[&internal[..], &[element]])?;
 
     Ok(new_tuple)
 }
@@ -175,15 +171,11 @@ pub fn are_not_equal_after_conversion_2(left: Term, right: Term) -> Term {
     left.ne(&right).into()
 }
 
-pub fn atom_to_binary_2(
-    atom: Term,
-    encoding: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn atom_to_binary_2(atom: Term, encoding: Term, process: &Process) -> Result {
     match atom.to_typed_term().unwrap() {
         TypedTerm::Atom(atom) => {
             let _: Encoding = encoding.try_into()?;
-            let binary = process_control_block.binary_from_str(atom.name())?;
+            let binary = process.binary_from_str(atom.name())?;
 
             Ok(binary)
         }
@@ -191,44 +183,29 @@ pub fn atom_to_binary_2(
     }
 }
 
-pub fn atom_to_list_1(atom: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn atom_to_list_1(atom: Term, process: &Process) -> Result {
     match atom.to_typed_term().unwrap() {
         TypedTerm::Atom(atom) => {
             let chars = atom.name().chars();
 
-            process_control_block
-                .list_from_chars(chars)
-                .map_err(|error| error.into())
+            process.list_from_chars(chars).map_err(|error| error.into())
         }
         _ => Err(badarg!().into()),
     }
 }
 
 // `band/2` infix operator.
-pub fn band_2(
-    left_integer: Term,
-    right_integer: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
-    bitwise_infix_operator!(left_integer, right_integer, process_control_block, &)
+pub fn band_2(left_integer: Term, right_integer: Term, process: &Process) -> Result {
+    bitwise_infix_operator!(left_integer, right_integer, process, &)
 }
 
-pub fn binary_part_2(
-    binary: Term,
-    start_length: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn binary_part_2(binary: Term, start_length: Term, process: &Process) -> Result {
     let option_result = match start_length.to_typed_term().unwrap() {
         TypedTerm::Boxed(unboxed_start_length) => {
             match unboxed_start_length.to_typed_term().unwrap() {
                 TypedTerm::Tuple(tuple) => {
                     if tuple.len() == 2 {
-                        Some(binary_part_3(
-                            binary,
-                            tuple[0],
-                            tuple[1],
-                            process_control_block,
-                        ))
+                        Some(binary_part_3(binary, tuple[0], tuple[1], process))
                     } else {
                         None
                     }
@@ -245,12 +222,7 @@ pub fn binary_part_2(
     }
 }
 
-pub fn binary_part_3(
-    binary: Term,
-    start: Term,
-    length: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn binary_part_3(binary: Term, start: Term, length: Term, process: &Process) -> Result {
     let start_usize: usize = start.try_into()?;
     let length_isize: isize = length.try_into()?;
 
@@ -266,7 +238,7 @@ pub fn binary_part_3(
                 if (byte_offset == 0) && (byte_len == available_byte_count) {
                     Ok(binary)
                 } else {
-                    process_control_block
+                    process
                         .subbinary_from_original(binary, byte_offset, 0, byte_len, 0)
                         .map_err(|error| error.into())
                 }
@@ -281,7 +253,7 @@ pub fn binary_part_3(
                 if (byte_offset == 0) && (byte_len == available_byte_count) {
                     Ok(binary)
                 } else {
-                    process_control_block
+                    process
                         .subbinary_from_original(binary, byte_offset, 0, byte_len, 0)
                         .map_err(|error| error.into())
                 }
@@ -303,7 +275,7 @@ pub fn binary_part_3(
                 {
                     Ok(binary)
                 } else {
-                    process_control_block
+                    process
                         .subbinary_from_original(
                             subbinary.original(),
                             subbinary.byte_offset() + byte_offset,
@@ -390,11 +362,8 @@ pub fn binary_to_existing_atom_2(binary: Term, encoding: Term) -> Result {
     .map(|atom| unsafe { atom.as_term() })
 }
 
-pub fn binary_to_float_1<'process>(
-    binary: Term,
-    process_control_block: &'process ProcessControlBlock,
-) -> Result {
-    let mut heap: MutexGuard<'process, _> = process_control_block.acquire_heap();
+pub fn binary_to_float_1<'process>(binary: Term, process: &'process Process) -> Result {
+    let mut heap: MutexGuard<'process, _> = process.acquire_heap();
     let s: &str = heap.str_from_binary(binary)?;
 
     match s.parse::<f64>() {
@@ -423,11 +392,8 @@ pub fn binary_to_float_1<'process>(
     }
 }
 
-pub fn binary_to_integer_1<'process>(
-    binary: Term,
-    process_control_block: &'process ProcessControlBlock,
-) -> Result {
-    let mut heap = process_control_block.acquire_heap();
+pub fn binary_to_integer_1<'process>(binary: Term, process: &'process Process) -> Result {
+    let mut heap = process.acquire_heap();
     let s: &str = heap.str_from_binary(binary)?;
     let bytes = s.as_bytes();
 
@@ -444,9 +410,9 @@ pub fn binary_to_integer_1<'process>(
 pub fn binary_to_integer_2<'process>(
     binary: Term,
     base: Term,
-    process_control_block: &'process ProcessControlBlock,
+    process: &'process Process,
 ) -> Result {
-    let mut heap = process_control_block.acquire_heap();
+    let mut heap = process.acquire_heap();
     let s: &str = heap.str_from_binary(binary)?;
     let radix: usize = base.try_into()?;
 
@@ -467,11 +433,11 @@ pub fn binary_to_integer_2<'process>(
     .map_err(|error| error.into())
 }
 
-pub fn binary_to_list_1(binary: Term, process_control_block: &ProcessControlBlock) -> Result {
-    let bytes = process_control_block.bytes_from_binary(binary)?;
+pub fn binary_to_list_1(binary: Term, process: &Process) -> Result {
+    let bytes = process.bytes_from_binary(binary)?;
     let byte_terms = bytes.iter().map(|byte| (*byte).into());
 
-    process_control_block
+    process
         .list_from_iter(byte_terms)
         .map_err(|error| error.into())
 }
@@ -479,12 +445,7 @@ pub fn binary_to_list_1(binary: Term, process_control_block: &ProcessControlBloc
 /// The one-based indexing for binaries used by this function is deprecated. New code is to use
 /// [crate::otp::binary::bin_to_list] instead. All functions in module [crate::otp::binary]
 /// consistently use zero-based indexing.
-pub fn binary_to_list_3(
-    binary: Term,
-    start: Term,
-    stop: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn binary_to_list_3(binary: Term, start: Term, stop: Term, process: &Process) -> Result {
     let one_based_start_usize: usize = start.try_into()?;
 
     if 1 <= one_based_start_usize {
@@ -498,9 +459,9 @@ pub fn binary_to_list_3(
 
             otp::binary::bin_to_list(
                 binary,
-                process_control_block.integer(zero_based_start_usize)?,
-                process_control_block.integer(length_usize)?,
-                process_control_block,
+                process.integer(zero_based_start_usize)?,
+                process.integer(length_usize)?,
+                process,
             )
         } else {
             Err(badarg!().into())
@@ -510,15 +471,11 @@ pub fn binary_to_list_3(
     }
 }
 
-pub fn binary_to_term_1(binary: Term, process_control_block: &ProcessControlBlock) -> Result {
-    binary_to_term_2(binary, Term::NIL, process_control_block)
+pub fn binary_to_term_1(binary: Term, process: &Process) -> Result {
+    binary_to_term_2(binary, Term::NIL, process)
 }
 
-pub fn binary_to_term_2(
-    binary: Term,
-    options: Term,
-    _process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn binary_to_term_2(binary: Term, options: Term, _process: &Process) -> Result {
     let _to_term_options: ToTermOptions = options.try_into()?;
 
     match binary.to_typed_term().unwrap() {
@@ -532,7 +489,7 @@ pub fn binary_to_term_2(
     }
 }
 
-pub fn bit_size_1(bitstring: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn bit_size_1(bitstring: Term, process: &Process) -> Result {
     let option_total_bit_len = match bitstring.to_typed_term().unwrap() {
         TypedTerm::Boxed(boxed) => match boxed.to_typed_term().unwrap() {
             TypedTerm::HeapBinary(heap_binary) => Some(heap_binary.total_bit_len()),
@@ -544,7 +501,7 @@ pub fn bit_size_1(bitstring: Term, process_control_block: &ProcessControlBlock) 
     };
 
     match option_total_bit_len {
-        Some(total_bit_len) => Ok(process_control_block.integer(total_bit_len)?),
+        Some(total_bit_len) => Ok(process.integer(total_bit_len)?),
         None => Err(badarg!().into()),
     }
 }
@@ -552,17 +509,14 @@ pub fn bit_size_1(bitstring: Term, process_control_block: &ProcessControlBlock) 
 /// Returns a list of integers corresponding to the bytes of `bitstring`. If the number of bits in
 /// `bitstring` is not divisible by `8`, the last element of the list is a `bitstring` containing
 /// the remaining `1`-`7` bits.
-pub fn bitstring_to_list_1<'process>(
-    bitstring: Term,
-    process_control_block: &'process ProcessControlBlock,
-) -> Result {
+pub fn bitstring_to_list_1<'process>(bitstring: Term, process: &'process Process) -> Result {
     match bitstring.to_typed_term().unwrap() {
         TypedTerm::Boxed(boxed) => match boxed.to_typed_term().unwrap() {
             TypedTerm::HeapBinary(heap_binary) => {
                 let byte_term_iter = heap_binary.as_bytes().iter().map(|byte| (*byte).into());
                 let last = Term::NIL;
 
-                process_control_block
+                process
                     .improper_list_from_iter(byte_term_iter, last)
                     .map_err(|error| error.into())
             }
@@ -570,7 +524,7 @@ pub fn bitstring_to_list_1<'process>(
                 let byte_term_iter = process_binary.as_bytes().iter().map(|byte| (*byte).into());
                 let last = Term::NIL;
 
-                process_control_block
+                process
                     .improper_list_from_iter(byte_term_iter, last)
                     .map_err(|error| error.into())
             }
@@ -578,7 +532,7 @@ pub fn bitstring_to_list_1<'process>(
                 let last = if subbinary.is_binary() {
                     Term::NIL
                 } else {
-                    let partial_byte_subbinary = process_control_block.subbinary_from_original(
+                    let partial_byte_subbinary = process.subbinary_from_original(
                         subbinary.original(),
                         subbinary.byte_offset() + subbinary.full_byte_len(),
                         subbinary.bit_offset(),
@@ -586,12 +540,12 @@ pub fn bitstring_to_list_1<'process>(
                         subbinary.partial_byte_bit_len(),
                     )?;
 
-                    process_control_block.cons(partial_byte_subbinary, Term::NIL)?
+                    process.cons(partial_byte_subbinary, Term::NIL)?
                 };
 
                 let byte_term_iter = subbinary.full_byte_iter().map(|byte| byte.into());
 
-                process_control_block
+                process
                     .improper_list_from_iter(byte_term_iter, last)
                     .map_err(|error| error.into())
             }
@@ -602,12 +556,12 @@ pub fn bitstring_to_list_1<'process>(
 }
 
 // `bnot/1` prefix operator.
-pub fn bnot_1(integer: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn bnot_1(integer: Term, process: &Process) -> Result {
     match integer.to_typed_term().unwrap() {
         TypedTerm::SmallInteger(small_integer) => {
             let integer_isize: isize = small_integer.into();
             let output = !integer_isize;
-            let output_term = process_control_block.integer(output)?;
+            let output_term = process.integer(output)?;
 
             Ok(output_term)
         }
@@ -615,7 +569,7 @@ pub fn bnot_1(integer: Term, process_control_block: &ProcessControlBlock) -> Res
             TypedTerm::BigInteger(big_integer) => {
                 let big_int: &BigInt = big_integer.as_ref().into();
                 let output_big_int = !big_int;
-                let output_term = process_control_block.integer(output_big_int)?;
+                let output_term = process.integer(output_big_int)?;
 
                 Ok(output_term)
             }
@@ -626,36 +580,28 @@ pub fn bnot_1(integer: Term, process_control_block: &ProcessControlBlock) -> Res
 }
 
 /// `bor/2` infix operator.
-pub fn bor_2(
-    left_integer: Term,
-    right_integer: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
-    bitwise_infix_operator!(left_integer, right_integer, process_control_block, |)
+pub fn bor_2(left_integer: Term, right_integer: Term, process: &Process) -> Result {
+    bitwise_infix_operator!(left_integer, right_integer, process, |)
 }
 
 pub const MAX_SHIFT: usize = std::mem::size_of::<isize>() * 8 - 1;
 
 /// `bsl/2` infix operator.
-pub fn bsl_2(integer: Term, shift: Term, process_control_block: &ProcessControlBlock) -> Result {
-    bitshift_infix_operator!(integer, shift, process_control_block, <<, >>)
+pub fn bsl_2(integer: Term, shift: Term, process: &Process) -> Result {
+    bitshift_infix_operator!(integer, shift, process, <<, >>)
 }
 
 /// `bsr/2` infix operator.
-pub fn bsr_2(integer: Term, shift: Term, process_control_block: &ProcessControlBlock) -> Result {
-    bitshift_infix_operator!(integer, shift, process_control_block, >>, <<)
+pub fn bsr_2(integer: Term, shift: Term, process: &Process) -> Result {
+    bitshift_infix_operator!(integer, shift, process, >>, <<)
 }
 
 /// `bxor/2` infix operator.
-pub fn bxor_2(
-    left_integer: Term,
-    right_integer: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
-    bitwise_infix_operator!(left_integer, right_integer, process_control_block, ^)
+pub fn bxor_2(left_integer: Term, right_integer: Term, process: &Process) -> Result {
+    bitwise_infix_operator!(left_integer, right_integer, process, ^)
 }
 
-pub fn byte_size_1(bitstring: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn byte_size_1(bitstring: Term, process: &Process) -> Result {
     let option_total_byte_len = match bitstring.to_typed_term().unwrap() {
         TypedTerm::Boxed(boxed) => match boxed.to_typed_term().unwrap() {
             TypedTerm::HeapBinary(heap_binary) => Some(heap_binary.total_byte_len()),
@@ -667,29 +613,22 @@ pub fn byte_size_1(bitstring: Term, process_control_block: &ProcessControlBlock)
     };
 
     match option_total_byte_len {
-        Some(total_byte_len) => Ok(process_control_block.integer(total_byte_len)?),
+        Some(total_byte_len) => Ok(process.integer(total_byte_len)?),
         None => Err(badarg!().into()),
     }
 }
 
-pub fn cancel_timer_1(
-    timer_reference: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
-    cancel_timer(timer_reference, Default::default(), process_control_block)
+pub fn cancel_timer_1(timer_reference: Term, process: &Process) -> Result {
+    cancel_timer(timer_reference, Default::default(), process)
 }
 
-pub fn cancel_timer_2(
-    timer_reference: Term,
-    options: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn cancel_timer_2(timer_reference: Term, options: Term, process: &Process) -> Result {
     let cancel_timer_options: timer::cancel::Options = options.try_into()?;
 
-    cancel_timer(timer_reference, cancel_timer_options, process_control_block)
+    cancel_timer(timer_reference, cancel_timer_options, process)
 }
 
-pub fn ceil_1(number: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn ceil_1(number: Term, process: &Process) -> Result {
     let option_ceil = match number.to_typed_term().unwrap() {
         TypedTerm::SmallInteger(_) => Some(number),
         TypedTerm::Boxed(boxed) => {
@@ -704,13 +643,13 @@ pub fn ceil_1(number: Term, process_control_block: &ProcessControlBlock) -> Resu
                         <= ceil_inner
                         && ceil_inner <= (SmallInteger::MAX_VALUE as f64).min(Float::INTEGRAL_MAX)
                     {
-                        process_control_block.integer(ceil_inner as isize)?
+                        process.integer(ceil_inner as isize)?
                     } else {
                         let ceil_string = ceil_inner.to_string();
                         let ceil_bytes = ceil_string.as_bytes();
                         let big_int = BigInt::parse_bytes(ceil_bytes, 10).unwrap();
 
-                        process_control_block.integer(big_int)?
+                        process.integer(big_int)?
                     };
 
                     Some(ceil_term)
@@ -728,18 +667,14 @@ pub fn ceil_1(number: Term, process_control_block: &ProcessControlBlock) -> Resu
 }
 
 /// `++/2`
-pub fn concatenate_2(
-    list: Term,
-    term: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn concatenate_2(list: Term, term: Term, process: &Process) -> Result {
     match list.to_typed_term().unwrap() {
         TypedTerm::Nil => Ok(term),
         TypedTerm::List(cons) => match cons
             .into_iter()
             .collect::<std::result::Result<Vec<Term>, _>>()
         {
-            Ok(vec) => process_control_block
+            Ok(vec) => process
                 .improper_list_from_slice(&vec, term)
                 .map_err(|error| error.into()),
             Err(ImproperList { .. }) => Err(badarg!().into()),
@@ -748,11 +683,7 @@ pub fn concatenate_2(
     }
 }
 
-pub fn delete_element_2(
-    index: Term,
-    tuple: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn delete_element_2(index: Term, tuple: Term, process: &Process) -> Result {
     let initial_inner_tuple: Boxed<Tuple> = tuple.try_into()?;
     let ZeroBasedIndex(index_zero_based): ZeroBasedIndex = index.try_into()?;
     let initial_len = initial_inner_tuple.len();
@@ -770,8 +701,7 @@ pub fn delete_element_2(
                         Some(old_term)
                     }
                 });
-        let smaller_tuple =
-            process_control_block.tuple_from_iter(smaller_element_iterator, smaller_len)?;
+        let smaller_tuple = process.tuple_from_iter(smaller_element_iterator, smaller_len)?;
 
         Ok(smaller_tuple)
     } else {
@@ -780,17 +710,13 @@ pub fn delete_element_2(
 }
 
 /// `div/2` infix operator.  Integer division.
-pub fn div_2(dividend: Term, divisor: Term, process_control_block: &ProcessControlBlock) -> Result {
-    integer_infix_operator!(dividend, divisor, process_control_block, /)
+pub fn div_2(dividend: Term, divisor: Term, process: &Process) -> Result {
+    integer_infix_operator!(dividend, divisor, process, /)
 }
 
 /// `//2` infix operator.  Unlike `+/2`, `-/2` and `*/2` always promotes to `float` returns the
 /// `float`.
-pub fn divide_2(
-    dividend: Term,
-    divisor: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn divide_2(dividend: Term, divisor: Term, process: &Process) -> Result {
     let dividend_f64: f64 = dividend.try_into().map_err(|_| badarith!())?;
     let divisor_f64: f64 = divisor.try_into().map_err(|_| badarith!())?;
 
@@ -798,7 +724,7 @@ pub fn divide_2(
         Err(badarith!().into())
     } else {
         let quotient_f64 = dividend_f64 / divisor_f64;
-        let quotient_term = process_control_block.float(quotient_f64)?;
+        let quotient_term = process.float(quotient_f64)?;
 
         Ok(quotient_term)
     }
@@ -841,12 +767,7 @@ pub fn hd_1(list: Term) -> Result {
     Ok(cons.head)
 }
 
-pub fn insert_element_3(
-    index: Term,
-    tuple: Term,
-    element: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn insert_element_3(index: Term, tuple: Term, element: Term, process: &Process) -> Result {
     let initial_inner_tuple: Boxed<Tuple> = tuple.try_into()?;
     let ZeroBasedIndex(index_zero_based): ZeroBasedIndex = index.try_into()?;
 
@@ -855,15 +776,15 @@ pub fn insert_element_3(
     // can be equal to arity when insertion is at the end
     if index_zero_based <= length {
         if index_zero_based == 0 {
-            process_control_block.tuple_from_slices(&[&[element], &initial_inner_tuple[..]])
+            process.tuple_from_slices(&[&[element], &initial_inner_tuple[..]])
         } else if index_zero_based < length {
-            process_control_block.tuple_from_slices(&[
+            process.tuple_from_slices(&[
                 &initial_inner_tuple[..index_zero_based],
                 &[element],
                 &initial_inner_tuple[index_zero_based..],
             ])
         } else {
-            process_control_block.tuple_from_slices(&[&initial_inner_tuple[..], &[element]])
+            process.tuple_from_slices(&[&initial_inner_tuple[..], &[element]])
         }
         .map_err(|error| error.into())
     } else {
@@ -959,11 +880,11 @@ pub fn is_tuple_1(term: Term) -> Term {
     term.is_tuple().into()
 }
 
-pub fn length_1(list: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn length_1(list: Term, process: &Process) -> Result {
     match list.to_typed_term().unwrap() {
         TypedTerm::Nil => Ok(0.into()),
         TypedTerm::List(cons) => match cons.count() {
-            Some(count) => Ok(process_control_block.integer(count)?),
+            Some(count) => Ok(process.integer(count)?),
             None => Err(badarg!().into()),
         },
         _ => Err(badarg!().into()),
@@ -984,7 +905,7 @@ pub fn list_to_existing_atom_1(string: Term) -> Result {
     })
 }
 
-pub fn list_to_binary_1(iolist: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn list_to_binary_1(iolist: Term, process: &Process) -> Result {
     match iolist.to_typed_term().unwrap() {
         TypedTerm::Nil | TypedTerm::List(_) => {
             let mut byte_vec: Vec<u8> = Vec::new();
@@ -1034,15 +955,13 @@ pub fn list_to_binary_1(iolist: Term, process_control_block: &ProcessControlBloc
                 }
             }
 
-            Ok(process_control_block
-                .binary_from_bytes(byte_vec.as_slice())
-                .unwrap())
+            Ok(process.binary_from_bytes(byte_vec.as_slice()).unwrap())
         }
         _ => Err(badarg!().into()),
     }
 }
 
-pub fn list_to_bitstring_1(iolist: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn list_to_bitstring_1(iolist: Term, process: &Process) -> Result {
     match iolist.to_typed_term().unwrap() {
         TypedTerm::Nil | TypedTerm::List(_) => {
             let mut byte_vec: Vec<u8> = Vec::new();
@@ -1131,17 +1050,13 @@ pub fn list_to_bitstring_1(iolist: Term, process_control_block: &ProcessControlB
             }
 
             if partial_byte_bit_count == 0 {
-                Ok(process_control_block
-                    .binary_from_bytes(byte_vec.as_slice())
-                    .unwrap())
+                Ok(process.binary_from_bytes(byte_vec.as_slice()).unwrap())
             } else {
                 let full_byte_len = byte_vec.len();
                 byte_vec.push(partial_byte);
-                let original = process_control_block
-                    .binary_from_bytes(byte_vec.as_slice())
-                    .unwrap();
+                let original = process.binary_from_bytes(byte_vec.as_slice()).unwrap();
 
-                Ok(process_control_block
+                Ok(process
                     .subbinary_from_original(original, 0, 0, full_byte_len, partial_byte_bit_count)
                     .unwrap())
             }
@@ -1150,7 +1065,7 @@ pub fn list_to_bitstring_1(iolist: Term, process_control_block: &ProcessControlB
     }
 }
 
-pub fn list_to_pid_1(string: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn list_to_pid_1(string: Term, process: &Process) -> Result {
     let cons: Boxed<Cons> = string.try_into()?;
 
     let prefix_tail = skip_char(cons, '<')?;
@@ -1174,7 +1089,7 @@ pub fn list_to_pid_1(string: Term, process_control_block: &ProcessControlBlock) 
     let suffix_tail = skip_char(serial_tail_cons, '>')?;
 
     if suffix_tail.is_nil() {
-        process_control_block
+        process
             .pid_with_node_id(node_id, number, serial)
             .map_err(|error| error.into())
     } else {
@@ -1182,51 +1097,45 @@ pub fn list_to_pid_1(string: Term, process_control_block: &ProcessControlBlock) 
     }
 }
 
-pub fn list_to_tuple_1(list: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn list_to_tuple_1(list: Term, process: &Process) -> Result {
     match list.to_typed_term().unwrap() {
-        TypedTerm::Nil => process_control_block
-            .tuple_from_slices(&[])
-            .map_err(|error| error.into()),
+        TypedTerm::Nil => process.tuple_from_slices(&[]).map_err(|error| error.into()),
         TypedTerm::List(cons) => {
             let vec: Vec<Term> = cons.into_iter().collect::<std::result::Result<_, _>>()?;
 
-            process_control_block
-                .tuple_from_slice(&vec)
-                .map_err(|error| error.into())
+            process.tuple_from_slice(&vec).map_err(|error| error.into())
         }
         _ => Err(badarg!().into()),
     }
 }
 
-pub fn make_ref_0(process_control_block: &ProcessControlBlock) -> Result {
-    process_control_block
-        .next_reference()
-        .map_err(|error| error.into())
+pub fn make_ref_0(process: &Process) -> Result {
+    process.next_reference().map_err(|error| error.into())
 }
 
-pub fn map_get_2(key: Term, map: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn map_get_2(key: Term, map: Term, process: &Process) -> Result {
     let result: core::result::Result<Boxed<Map>, _> = map.try_into();
 
     match result {
         Ok(map_header) => match map_header.get(key) {
             Some(value) => Ok(value),
-            None => Err(badkey!(process_control_block, key)),
+            None => Err(badkey!(process, key)),
         },
-        Err(_) => Err(badmap!(process_control_block, map)),
+        Err(_) => Err(badmap!(process, map)),
     }
 }
 
-pub fn map_size_1(map: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn map_size_1(map: Term, process: &Process) -> Result {
     let result: core::result::Result<Boxed<Map>, _> = map.try_into();
 
     match result {
         Ok(map_header) => {
             let len = map_header.len();
-            let len_term = process_control_block.integer(len)?;
+            let len_term = process.integer(len)?;
 
             Ok(len_term)
         }
-        Err(_) => Err(badmap!(process_control_block, map)),
+        Err(_) => Err(badmap!(process, map)),
     }
 }
 
@@ -1250,30 +1159,26 @@ pub fn module() -> Atom {
     Atom::try_from_str("erlang").unwrap()
 }
 
-pub fn monotonic_time_1(unit: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn monotonic_time_1(unit: Term, process: &Process) -> Result {
     let unit_unit: crate::time::Unit = unit.try_into()?;
     let big_int = monotonic::time(unit_unit);
-    let term = process_control_block.integer(big_int)?;
+    let term = process.integer(big_int)?;
 
     Ok(term)
 }
 
 /// `*/2` infix operator
-pub fn multiply_2(
-    multiplier: Term,
-    multiplicand: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
-    number_infix_operator!(multiplier, multiplicand, process_control_block, checked_mul, *)
+pub fn multiply_2(multiplier: Term, multiplicand: Term, process: &Process) -> Result {
+    number_infix_operator!(multiplier, multiplicand, process, checked_mul, *)
 }
 
 /// `-/1` prefix operator.
-pub fn negate_1(number: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn negate_1(number: Term, process: &Process) -> Result {
     let option_negated = match number.to_typed_term().unwrap() {
         TypedTerm::SmallInteger(small_integer) => {
             let number_isize: isize = small_integer.into();
             let negated_isize = -number_isize;
-            let negated_number: Term = process_control_block.integer(negated_isize)?;
+            let negated_number: Term = process.integer(negated_isize)?;
 
             Some(negated_number)
         }
@@ -1281,14 +1186,14 @@ pub fn negate_1(number: Term, process_control_block: &ProcessControlBlock) -> Re
             TypedTerm::BigInteger(big_integer) => {
                 let big_int: &BigInt = big_integer.as_ref().into();
                 let negated_big_int = -big_int;
-                let negated_number = process_control_block.integer(negated_big_int)?;
+                let negated_number = process.integer(negated_big_int)?;
 
                 Some(negated_number)
             }
             TypedTerm::Float(float) => {
                 let number_f64: f64 = float.into();
                 let negated_f64: f64 = -number_f64;
-                let negated_number = process_control_block.float(negated_f64)?;
+                let negated_number = process.float(negated_f64)?;
 
                 Some(negated_number)
             }
@@ -1334,38 +1239,31 @@ pub fn raise_3(class: Term, reason: Term, stacktrace: Term) -> Result {
     Err(runtime_exception.into())
 }
 
-pub fn read_timer_1(timer_reference: Term, process_control_block: &ProcessControlBlock) -> Result {
-    read_timer(timer_reference, Default::default(), process_control_block)
+pub fn read_timer_1(timer_reference: Term, process: &Process) -> Result {
+    read_timer(timer_reference, Default::default(), process)
 }
 
-pub fn read_timer_2(
-    timer_reference: Term,
-    options: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn read_timer_2(timer_reference: Term, options: Term, process: &Process) -> Result {
     let read_timer_options: timer::read::Options = options.try_into()?;
 
-    read_timer(timer_reference, read_timer_options, process_control_block)
+    read_timer(timer_reference, read_timer_options, process)
 }
 
-pub fn register_2(
-    name: Term,
-    pid_or_port: Term,
-    arc_process_control_block: Arc<ProcessControlBlock>,
-) -> Result {
+pub fn register_2(name: Term, pid_or_port: Term, arc_process: Arc<Process>) -> Result {
     let atom: Atom = name.try_into()?;
 
     let option_registered: Option<Term> = match atom.name() {
         "undefined" => None,
         _ => match pid_or_port.to_typed_term().unwrap() {
-            TypedTerm::Pid(pid) => pid_to_self_or_process(pid, &arc_process_control_block)
-                .and_then(|pid_arc_process_control_block| {
-                    if registry::put_atom_to_process(atom, pid_arc_process_control_block) {
+            TypedTerm::Pid(pid) => {
+                pid_to_self_or_process(pid, &arc_process).and_then(|pid_arc_process| {
+                    if registry::put_atom_to_process(atom, pid_arc_process) {
                         Some(true.into())
                     } else {
                         None
                     }
-                }),
+                })
+            }
             _ => None,
         },
     };
@@ -1376,27 +1274,17 @@ pub fn register_2(
     }
 }
 
-pub fn registered_0(process_control_block: &ProcessControlBlock) -> Result {
-    registry::names(process_control_block)
+pub fn registered_0(process: &Process) -> Result {
+    registry::names(process)
 }
 
 /// `rem/2` infix operator.  Integer remainder.
-pub fn rem_2(dividend: Term, divisor: Term, process_control_block: &ProcessControlBlock) -> Result {
-    integer_infix_operator!(dividend, divisor, process_control_block, %)
+pub fn rem_2(dividend: Term, divisor: Term, process: &Process) -> Result {
+    integer_infix_operator!(dividend, divisor, process, %)
 }
 
-pub fn send_2(
-    destination: Term,
-    message: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
-    send(
-        destination,
-        message,
-        Default::default(),
-        process_control_block,
-    )
-    .map(|sent| match sent {
+pub fn send_2(destination: Term, message: Term, process: &Process) -> Result {
+    send(destination, message, Default::default(), process).map(|sent| match sent {
         Sent::Sent => message,
         _ => unreachable!(),
     })
@@ -1404,15 +1292,10 @@ pub fn send_2(
 
 // `send(destination, message, [nosuspend])` is used in `gen.erl`, which is used by `gen_server.erl`
 // See https://github.com/erlang/otp/blob/8f6d45ddc8b2b12376c252a30b267a822cad171a/lib/stdlib/src/gen.erl#L167
-pub fn send_3(
-    destination: Term,
-    message: Term,
-    options: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn send_3(destination: Term, message: Term, options: Term, process: &Process) -> Result {
     let send_options: send::Options = options.try_into()?;
 
-    send(destination, message, send_options, process_control_block)
+    send(destination, message, send_options, process)
         .map(|sent| match sent {
             Sent::Sent => "ok",
             Sent::ConnectRequired => "noconnect",
@@ -1425,7 +1308,7 @@ pub fn send_after_3(
     time: Term,
     destination: Term,
     message: Term,
-    arc_process_control_block: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> Result {
     start_timer(
         time,
@@ -1433,7 +1316,7 @@ pub fn send_after_3(
         Timeout::Message,
         message,
         Default::default(),
-        arc_process_control_block,
+        arc_process,
     )
 }
 
@@ -1442,7 +1325,7 @@ pub fn send_after_4(
     destination: Term,
     message: Term,
     options: Term,
-    arc_process_control_block: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> Result {
     let timer_start_options: timer::start::Options = options.try_into()?;
 
@@ -1452,16 +1335,11 @@ pub fn send_after_4(
         Timeout::Message,
         message,
         timer_start_options,
-        arc_process_control_block,
+        arc_process,
     )
 }
 
-pub fn setelement_3(
-    index: Term,
-    tuple: Term,
-    value: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn setelement_3(index: Term, tuple: Term, value: Term, process: &Process) -> Result {
     let initial_inner_tuple: Boxed<Tuple> = tuple.try_into()?;
     let ZeroBasedIndex(index_zero_based): ZeroBasedIndex = index.try_into()?;
 
@@ -1470,19 +1348,18 @@ pub fn setelement_3(
     if index_zero_based < length {
         if index_zero_based == 0 {
             if 1 < length {
-                process_control_block.tuple_from_slices(&[&[value], &initial_inner_tuple[1..]])
+                process.tuple_from_slices(&[&[value], &initial_inner_tuple[1..]])
             } else {
-                process_control_block.tuple_from_slice(&[value])
+                process.tuple_from_slice(&[value])
             }
         } else if index_zero_based < (length - 1) {
-            process_control_block.tuple_from_slices(&[
+            process.tuple_from_slices(&[
                 &initial_inner_tuple[..index_zero_based],
                 &[value],
                 &initial_inner_tuple[(index_zero_based + 1)..],
             ])
         } else {
-            process_control_block
-                .tuple_from_slices(&[&initial_inner_tuple[..index_zero_based], &[value]])
+            process.tuple_from_slices(&[&initial_inner_tuple[..index_zero_based], &[value]])
         }
         .map_err(|error| error.into())
     } else {
@@ -1490,7 +1367,7 @@ pub fn setelement_3(
     }
 }
 
-pub fn size_1(binary_or_tuple: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn size_1(binary_or_tuple: Term, process: &Process) -> Result {
     let option_size = match binary_or_tuple.to_typed_term().unwrap() {
         TypedTerm::Boxed(boxed) => match boxed.to_typed_term().unwrap() {
             TypedTerm::Tuple(tuple) => Some(tuple.len()),
@@ -1503,16 +1380,12 @@ pub fn size_1(binary_or_tuple: Term, process_control_block: &ProcessControlBlock
     };
 
     match option_size {
-        Some(size) => Ok(process_control_block.integer(size)?),
+        Some(size) => Ok(process.integer(size)?),
         None => Err(badarg!().into()),
     }
 }
 
-pub fn split_binary_2(
-    binary: Term,
-    position: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn split_binary_2(binary: Term, position: Term, process: &Process) -> Result {
     let index: usize = position.try_into()?;
 
     match binary.to_typed_term().unwrap() {
@@ -1521,7 +1394,7 @@ pub fn split_binary_2(
                 unboxed_typed_term @ TypedTerm::HeapBinary(_)
                 | unboxed_typed_term @ TypedTerm::ProcBin(_) => {
                     if index == 0 {
-                        let mut heap = process_control_block.acquire_heap();
+                        let mut heap = process.acquire_heap();
 
                         let empty_prefix = heap.subbinary_from_original(binary, index, 0, 0, 0)?;
 
@@ -1537,7 +1410,7 @@ pub fn split_binary_2(
                         };
 
                         if index < full_byte_length {
-                            let mut heap = process_control_block.acquire_heap();
+                            let mut heap = process.acquire_heap();
                             let prefix = heap.subbinary_from_original(binary, 0, 0, index, 0)?;
                             let suffix = heap.subbinary_from_original(
                                 binary,
@@ -1550,7 +1423,7 @@ pub fn split_binary_2(
                             heap.tuple_from_slice(&[prefix, suffix])
                                 .map_err(|error| error.into())
                         } else if index == full_byte_length {
-                            let mut heap = process_control_block.acquire_heap();
+                            let mut heap = process.acquire_heap();
                             let empty_suffix =
                                 heap.subbinary_from_original(binary, index, 0, 0, 0)?;
 
@@ -1565,7 +1438,7 @@ pub fn split_binary_2(
                 }
                 TypedTerm::SubBinary(subbinary) => {
                     if index == 0 {
-                        let mut heap = process_control_block.acquire_heap();
+                        let mut heap = process.acquire_heap();
                         let empty_prefix = heap.subbinary_from_original(
                             subbinary.original(),
                             subbinary.byte_offset() + index,
@@ -1583,7 +1456,7 @@ pub fn split_binary_2(
                         let total_byte_length = subbinary.total_byte_len();
 
                         if index < total_byte_length {
-                            let mut heap = process_control_block.acquire_heap();
+                            let mut heap = process.acquire_heap();
                             let original = subbinary.original();
                             let byte_offset = subbinary.byte_offset();
                             let bit_offset = subbinary.bit_offset();
@@ -1609,7 +1482,7 @@ pub fn split_binary_2(
                         } else if (index == total_byte_length)
                             & (subbinary.partial_byte_bit_len() == 0)
                         {
-                            let mut heap = process_control_block.acquire_heap();
+                            let mut heap = process.acquire_heap();
                             let empty_suffix = heap.subbinary_from_original(
                                 subbinary.original(),
                                 subbinary.byte_offset() + index,
@@ -1636,7 +1509,7 @@ pub fn start_timer_3(
     time: Term,
     destination: Term,
     message: Term,
-    arc_process_control_block: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> Result {
     start_timer(
         time,
@@ -1644,7 +1517,7 @@ pub fn start_timer_3(
         Timeout::TimeoutTuple,
         message,
         Default::default(),
-        arc_process_control_block,
+        arc_process,
     )
 }
 
@@ -1653,7 +1526,7 @@ pub fn start_timer_4(
     destination: Term,
     message: Term,
     options: Term,
-    arc_process_control_block: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> Result {
     let timer_start_options: timer::start::Options = options.try_into()?;
 
@@ -1663,15 +1536,11 @@ pub fn start_timer_4(
         Timeout::TimeoutTuple,
         message,
         timer_start_options,
-        arc_process_control_block,
+        arc_process,
     )
 }
 
-pub fn subtract_list_2(
-    minuend: Term,
-    subtrahend: Term,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+pub fn subtract_list_2(minuend: Term, subtrahend: Term, process: &Process) -> Result {
     match (
         minuend.to_typed_term().unwrap(),
         subtrahend.to_typed_term().unwrap(),
@@ -1704,7 +1573,7 @@ pub fn subtract_list_2(
                         };
                     }
 
-                    process_control_block
+                    process
                         .list_from_slice(&minuend_vec)
                         .map_err(|error| error.into())
                 }
@@ -1725,16 +1594,16 @@ pub fn tl_1(list: Term) -> Result {
     Ok(cons.tail)
 }
 
-pub fn tuple_size_1(tuple: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn tuple_size_1(tuple: Term, process: &Process) -> Result {
     let tuple: Boxed<Tuple> = tuple.try_into()?;
-    let size = process_control_block.integer(tuple.len())?;
+    let size = process.integer(tuple.len())?;
 
     Ok(size)
 }
 
-pub fn tuple_to_list_1(tuple: Term, process_control_block: &ProcessControlBlock) -> Result {
+pub fn tuple_to_list_1(tuple: Term, process: &Process) -> Result {
     let tuple: Boxed<Tuple> = tuple.try_into()?;
-    let mut heap = process_control_block.acquire_heap();
+    let mut heap = process.acquire_heap();
     let mut acc = Term::NIL;
 
     for element in tuple.iter().rev() {
@@ -1757,8 +1626,7 @@ pub fn unregister_1(name: Term) -> Result {
 pub fn whereis_1(name: Term) -> Result {
     let atom: Atom = name.try_into()?;
 
-    let option = registry::atom_to_process(&atom)
-        .map(|arc_process_control_block| arc_process_control_block.pid());
+    let option = registry::atom_to_process(&atom).map(|arc_process| arc_process.pid());
 
     let term = match option {
         Some(pid) => unsafe { pid.as_term() },
@@ -1780,7 +1648,7 @@ pub fn xor_2(left_boolean: Term, right_boolean: Term) -> Result {
 fn cancel_timer(
     timer_reference: Term,
     options: timer::cancel::Options,
-    process_control_block: &ProcessControlBlock,
+    process: &Process,
 ) -> Result {
     match timer_reference.to_typed_term().unwrap() {
         TypedTerm::Boxed(unboxed_timer_reference) => {
@@ -1789,7 +1657,7 @@ fn cancel_timer(
                     let canceled = timer::cancel(reference);
 
                     let term = if options.info {
-                        let mut heap = process_control_block.acquire_heap();
+                        let mut heap = process.acquire_heap();
                         let canceled_term = match canceled {
                             Some(milliseconds_remaining) => heap.integer(milliseconds_remaining)?,
                             None => false.into(),
@@ -1801,7 +1669,7 @@ fn cancel_timer(
                                 timer_reference,
                                 canceled_term,
                             ])?;
-                            process_control_block.send_from_self(cancel_timer_message);
+                            process.send_from_self(cancel_timer_message);
 
                             atom_unchecked("ok")
                         } else {
@@ -1892,17 +1760,13 @@ fn next_decimal_digit(cons: Boxed<Cons>) -> std::result::Result<(u8, Term), Exce
     }
 }
 
-fn read_timer(
-    timer_reference: Term,
-    options: timer::read::Options,
-    process_control_block: &ProcessControlBlock,
-) -> Result {
+fn read_timer(timer_reference: Term, options: timer::read::Options, process: &Process) -> Result {
     match timer_reference.to_typed_term().unwrap() {
         TypedTerm::Boxed(unboxed_timer_reference) => {
             match unboxed_timer_reference.to_typed_term().unwrap() {
                 TypedTerm::Reference(ref local_reference) => {
                     let read = timer::read(local_reference);
-                    let mut heap = process_control_block.acquire_heap();
+                    let mut heap = process.acquire_heap();
 
                     let read_term = match read {
                         Some(milliseconds_remaining) => heap.integer(milliseconds_remaining)?,
@@ -1915,7 +1779,7 @@ fn read_timer(
                             timer_reference,
                             read_term,
                         ])?;
-                        process_control_block.send_from_self(read_timer_message);
+                        process.send_from_self(read_timer_message);
 
                         atom_unchecked("ok")
                     } else {
@@ -1975,7 +1839,7 @@ fn start_timer(
     timeout: Timeout,
     message: Term,
     options: timer::start::Options,
-    arc_process_control_block: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> Result {
     if time.is_integer() {
         let reference_frame_milliseconds: Milliseconds = time.try_into()?;
@@ -1994,22 +1858,22 @@ fn start_timer(
                 timer::Destination::Name(destination_atom),
                 timeout,
                 message,
-                &arc_process_control_block,
+                &arc_process,
             )
             .map_err(|error| error.into()),
             // PIDs are looked up at time of create.  If they don't exist, they still return a
             // LocalReference.
             TypedTerm::Pid(destination_pid) => {
-                match pid_to_self_or_process(destination_pid, &arc_process_control_block) {
-                    Some(pid_arc_process_control_block) => timer::start(
+                match pid_to_self_or_process(destination_pid, &arc_process) {
+                    Some(pid_arc_process) => timer::start(
                         absolute_milliseconds,
-                        timer::Destination::Process(Arc::downgrade(&pid_arc_process_control_block)),
+                        timer::Destination::Process(Arc::downgrade(&pid_arc_process)),
                         timeout,
                         message,
-                        &arc_process_control_block,
+                        &arc_process,
                     )
                     .map_err(|error| error.into()),
-                    None => make_ref_0(&arc_process_control_block),
+                    None => make_ref_0(&arc_process),
                 }
             }
             _ => Err(badarg!().into()),

--- a/lumen_runtime/src/otp/erlang/add_2.rs
+++ b/lumen_runtime/src/otp/erlang/add_2.rs
@@ -11,18 +11,18 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 /// `+/2` infix operator
-pub fn native(process: &ProcessControlBlock, augend: Term, addend: Term) -> exception::Result {
+pub fn native(process: &Process, augend: Term, addend: Term) -> exception::Result {
     number_infix_operator!(augend, addend, process, checked_add, +)
 }
 
 /// `+/2` infix operator
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     augend: Term,
     addend: Term,
@@ -36,7 +36,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let augend = arc_process.stack_pop().unwrap();
@@ -46,7 +46,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(sum) => {
             arc_process.return_from_call(sum)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/add_2/test.rs
+++ b/lumen_runtime/src/otp/erlang/add_2/test.rs
@@ -8,7 +8,7 @@ use proptest::test_runner::{Config, TestRunner};
 use proptest::{prop_assert, prop_assert_eq};
 
 use liblumen_alloc::badarith;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Float, SmallInteger, Term};
 
 use crate::otp::erlang::add_2::native;

--- a/lumen_runtime/src/otp/erlang/add_2/test/with_big_integer_augend.rs
+++ b/lumen_runtime/src/otp/erlang/add_2/test/with_big_integer_augend.rs
@@ -153,7 +153,7 @@ fn with_float_addend_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let augend = process.integer(SmallInteger::MAX_VALUE + 1).unwrap();

--- a/lumen_runtime/src/otp/erlang/add_2/test/with_float_augend.rs
+++ b/lumen_runtime/src/otp/erlang/add_2/test/with_float_augend.rs
@@ -136,7 +136,7 @@ fn with_float_addend_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let augend = process.float(2.0).unwrap();

--- a/lumen_runtime/src/otp/erlang/add_2/test/with_small_integer_augend.rs
+++ b/lumen_runtime/src/otp/erlang/add_2/test/with_small_integer_augend.rs
@@ -121,7 +121,7 @@ fn with_float_addend_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let augend = process.integer(2).unwrap();

--- a/lumen_runtime/src/otp/erlang/apply_3.rs
+++ b/lumen_runtime/src/otp/erlang/apply_3.rs
@@ -11,7 +11,7 @@ use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::exception::Exception;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, Code};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 #[cfg(test)]
 use liblumen_alloc::erts::term::TypedTerm;
 use liblumen_alloc::erts::term::{Atom, Term};
@@ -53,7 +53,7 @@ pub fn set_code(code: Code) {
 }
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     module: Term,
     function: Term,
@@ -71,7 +71,7 @@ pub fn place_frame_with_arguments(
 
 /// Treats all MFAs as undefined.
 #[cfg(not(test))]
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     // arguments are consumed, but unused
     let module = arc_process.stack_pop().unwrap();
     let function = arc_process.stack_pop().unwrap();
@@ -89,7 +89,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
 }
 
 #[cfg(test)]
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     let module = arc_process.stack_pop().unwrap();
     let function = arc_process.stack_pop().unwrap();
     let argument_list = arc_process.stack_pop().unwrap();
@@ -123,7 +123,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
                         argument_vec[0],
                     )?;
 
-                    ProcessControlBlock::call_code(arc_process)
+                    Process::call_code(arc_process)
                 }
                 _ => undef(arc_process, module, function, argument_list),
             },
@@ -131,7 +131,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
                 0 => {
                     erlang::self_0::place_frame(arc_process, Placement::Replace);
 
-                    ProcessControlBlock::call_code(arc_process)
+                    Process::call_code(arc_process)
                 }
                 _ => undef(arc_process, module, function, argument_list),
             },
@@ -159,7 +159,7 @@ pub(crate) fn module_function_arity() -> Arc<ModuleFunctionArity> {
 
 #[cfg(test)]
 fn undef(
-    arc_process: &Arc<ProcessControlBlock>,
+    arc_process: &Arc<Process>,
     module: Term,
     function: Term,
     arguments: Term,

--- a/lumen_runtime/src/otp/erlang/binary_to_integer_1.rs
+++ b/lumen_runtime/src/otp/erlang/binary_to_integer_1.rs
@@ -14,12 +14,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::{badarg, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     binary: Term,
 ) -> Result<(), Alloc> {
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let binary = arc_process.stack_pop().unwrap();
@@ -40,7 +40,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(boolean) => {
             arc_process.return_from_call(boolean)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -62,7 +62,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, binary: Term) -> exception::Result {
+fn native(process: &Process, binary: Term) -> exception::Result {
     let string: String = binary.try_into()?;
 
     match BigInt::parse_bytes(string.as_bytes(), 10) {

--- a/lumen_runtime/src/otp/erlang/convert_time_unit_3.rs
+++ b/lumen_runtime/src/otp/erlang/convert_time_unit_3.rs
@@ -14,14 +14,14 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use crate::time;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     time: Term,
     from_unit: Term,
@@ -37,7 +37,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let time = arc_process.stack_pop().unwrap();
@@ -48,7 +48,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(child_pid) => {
             arc_process.return_from_call(child_pid)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -70,12 +70,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(
-    process: &ProcessControlBlock,
-    time: Term,
-    from_unit: Term,
-    to_unit: Term,
-) -> exception::Result {
+fn native(process: &Process, time: Term, from_unit: Term, to_unit: Term) -> exception::Result {
     let time_big_int: BigInt = time.try_into()?;
     let from_unit_unit: time::Unit = from_unit.try_into()?;
     let to_unit_unit: time::Unit = to_unit.try_into()?;

--- a/lumen_runtime/src/otp/erlang/convert_time_unit_3/test.rs
+++ b/lumen_runtime/src/otp/erlang/convert_time_unit_3/test.rs
@@ -9,7 +9,7 @@ use proptest::test_runner::{Config, TestRunner};
 use proptest::{prop_assert_eq, prop_oneof};
 
 use liblumen_alloc::badarg;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Term, TypedTerm};
 
 use crate::otp::erlang::convert_time_unit_3::native;
@@ -516,7 +516,7 @@ fn hertz() -> BoxedStrategy<Unit> {
     (1..=std::usize::MAX).prop_map(|hertz| Hertz(hertz)).boxed()
 }
 
-fn is_not_unit_term(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn is_not_unit_term(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term::is_not_integer(arc_process)
         .prop_filter("Term must not be a unit name", |term| {
             match term.to_typed_term().unwrap() {
@@ -559,7 +559,7 @@ fn unit() -> BoxedStrategy<Unit> {
     .boxed()
 }
 
-fn unit_term(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn unit_term(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     unit()
         .prop_map(move |unit| unit.to_term(&arc_process).unwrap())
         .boxed()

--- a/lumen_runtime/src/otp/erlang/demonitor_2.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_2.rs
@@ -14,7 +14,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 
 use liblumen_alloc::erts::term::{Atom, Boxed, Reference, Term};
 use liblumen_alloc::ModuleFunctionArity;
@@ -24,7 +24,7 @@ use crate::process::monitor::is_down;
 use crate::registry::pid_to_process;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     reference: Term,
     options: Term,
@@ -38,7 +38,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let reference = arc_process.stack_pop().unwrap();
@@ -48,14 +48,14 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(true_term) => {
             arc_process.return_from_call(true_term)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
 }
 
 fn demonitor(
-    monitoring_process: &ProcessControlBlock,
+    monitoring_process: &Process,
     reference: &Reference,
     Options { flush, info }: Options,
 ) -> exception::Result {
@@ -91,7 +91,7 @@ fn demonitor(
     }
 }
 
-fn flush(monitoring_process: &ProcessControlBlock, reference: &Reference) -> bool {
+fn flush(monitoring_process: &Process, reference: &Reference) -> bool {
     monitoring_process
         .mailbox
         .lock()
@@ -115,7 +115,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, reference: Term, options: Term) -> exception::Result {
+fn native(process: &Process, reference: Term, options: Term) -> exception::Result {
     let reference_reference: Boxed<Reference> = reference.try_into()?;
     let options_options: Options = options.try_into()?;
 

--- a/lumen_runtime/src/otp/erlang/demonitor_2/test.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_2/test.rs
@@ -5,7 +5,7 @@ use proptest::strategy::{BoxedStrategy, Strategy};
 use proptest::test_runner::{Config, TestRunner};
 
 use liblumen_alloc::badarg;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Term, TypedTerm};
 
 use crate::otp::erlang::demonitor_2::native;

--- a/lumen_runtime/src/otp/erlang/demonitor_2/test/with_reference.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_2/test/with_reference.rs
@@ -61,7 +61,7 @@ fn with_unknown_option_errors_badarg() {
     });
 }
 
-fn unknown_option(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn unknown_option(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process)
         .prop_filter("Option cannot be flush or info", |option| {
             match option.to_typed_term().unwrap() {

--- a/lumen_runtime/src/otp/erlang/demonitor_2/test/with_reference/with_flush_and_info_options.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_2/test/with_reference/with_flush_and_info_options.rs
@@ -21,7 +21,7 @@ fn without_monitor_returns_false() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .list_from_slice(&[atom_unchecked("flush"), atom_unchecked("info")])
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/demonitor_2/test/with_reference/with_flush_option.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_2/test/with_reference/with_flush_option.rs
@@ -21,6 +21,6 @@ fn without_monitor_returns_true() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process.list_from_slice(&[atom_unchecked("flush")]).unwrap()
 }

--- a/lumen_runtime/src/otp/erlang/demonitor_2/test/with_reference/with_info_option.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_2/test/with_reference/with_info_option.rs
@@ -21,6 +21,6 @@ fn without_monitor_returns_false() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process.list_from_slice(&[atom_unchecked("info")]).unwrap()
 }

--- a/lumen_runtime/src/otp/erlang/exit_1.rs
+++ b/lumen_runtime/src/otp/erlang/exit_1.rs
@@ -11,12 +11,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::{exit, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     reason: Term,
 ) -> Result<(), Alloc> {
@@ -28,7 +28,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let reason = arc_process.stack_pop().unwrap();

--- a/lumen_runtime/src/otp/erlang/is_function_1.rs
+++ b/lumen_runtime/src/otp/erlang/is_function_1.rs
@@ -11,12 +11,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     term: Term,
 ) -> Result<(), Alloc> {
@@ -28,7 +28,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let term = arc_process.stack_pop().unwrap();
@@ -37,7 +37,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(boolean) => {
             arc_process.return_from_call(boolean)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/is_function_2.rs
+++ b/lumen_runtime/src/otp/erlang/is_function_2.rs
@@ -12,12 +12,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     term: Term,
     arity: Term,
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let term = arc_process.stack_pop().unwrap();
@@ -41,7 +41,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(boolean) => {
             arc_process.return_from_call(boolean)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/is_map_key_2.rs
+++ b/lumen_runtime/src/otp/erlang/is_map_key_2.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use crate::otp::maps;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     key: Term,
     map: Term,

--- a/lumen_runtime/src/otp/erlang/link_1.rs
+++ b/lumen_runtime/src/otp/erlang/link_1.rs
@@ -11,14 +11,14 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term, TypedTerm};
 use liblumen_alloc::{badarg, error, ModuleFunctionArity};
 
 use crate::registry::pid_to_process;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     pid_or_port: Term,
 ) -> Result<(), Alloc> {
@@ -30,7 +30,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let pid_or_port = arc_process.stack_pop().unwrap();
@@ -39,7 +39,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(true_term) => {
             arc_process.return_from_call(true_term)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -61,7 +61,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, pid_or_port: Term) -> exception::Result {
+fn native(process: &Process, pid_or_port: Term) -> exception::Result {
     match pid_or_port.to_typed_term().unwrap() {
         TypedTerm::Pid(pid) => {
             if pid == process.pid() {

--- a/lumen_runtime/src/otp/erlang/link_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/link_1/test.rs
@@ -5,7 +5,7 @@ use proptest::strategy::Strategy;
 use proptest::test_runner::{Config, TestRunner};
 
 use liblumen_alloc::badarg;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 
 use crate::otp::erlang::link_1::native;
 use crate::scheduler::{with_process, with_process_arc};
@@ -30,6 +30,6 @@ fn without_pid_or_port_errors_badarg() {
     });
 }
 
-fn link_count(process: &ProcessControlBlock) -> usize {
+fn link_count(process: &Process) -> usize {
     process.linked_pid_set.lock().len()
 }

--- a/lumen_runtime/src/otp/erlang/monitor_2/test.rs
+++ b/lumen_runtime/src/otp/erlang/monitor_2/test.rs
@@ -7,7 +7,7 @@ use proptest::strategy::{BoxedStrategy, Strategy};
 use proptest::test_runner::{Config, TestRunner};
 
 use liblumen_alloc::badarg;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Term, TypedTerm};
 
 use crate::otp::erlang::monitor_2::native;
@@ -30,7 +30,7 @@ fn without_supported_type_errors_badarg() {
     });
 }
 
-fn unsupported_type(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn unsupported_type(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process)
         .prop_filter("Type cannot be :process", |r#type| {
             match r#type.to_typed_term().unwrap() {

--- a/lumen_runtime/src/otp/erlang/monitor_2/test/with_process_type.rs
+++ b/lumen_runtime/src/otp/erlang/monitor_2/test/with_process_type.rs
@@ -34,7 +34,7 @@ fn without_process_identifier_errors_badarg() {
     });
 }
 
-fn is_not_process_identifier(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn is_not_process_identifier(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process)
         .prop_filter(
             "Process identifier cannot be a pid, atom, or {atom, atom}",

--- a/lumen_runtime/src/otp/erlang/monotonic_time_0.rs
+++ b/lumen_runtime/src/otp/erlang/monotonic_time_0.rs
@@ -6,32 +6,32 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::Atom;
 use liblumen_alloc::ModuleFunctionArity;
 
 use crate::time::{monotonic, Unit::Native};
 
-pub fn native(process_control_block: &ProcessControlBlock) -> exception::Result {
+pub fn native(process: &Process) -> exception::Result {
     let big_int = monotonic::time(Native);
 
-    Ok(process_control_block.integer(big_int)?)
+    Ok(process.integer(big_int)?)
 }
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     match native(arc_process) {
         Ok(time) => {
             arc_process.return_from_call(time)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/number_or_badarith_1.rs
+++ b/lumen_runtime/src/otp/erlang/number_or_badarith_1.rs
@@ -12,13 +12,13 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 /// `+/1` prefix operator.
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     term: Term,
 ) -> Result<(), Alloc> {
@@ -30,7 +30,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let term = arc_process.stack_pop().unwrap();
@@ -39,7 +39,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(sum) => {
             arc_process.return_from_call(sum)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/process_flag_2.rs
+++ b/lumen_runtime/src/otp/erlang/process_flag_2.rs
@@ -12,12 +12,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::{badarg, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     flag: Term,
     value: Term,
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let flag = arc_process.stack_pop().unwrap();
@@ -41,7 +41,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(old_value) => {
             arc_process.return_from_call(old_value)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -63,7 +63,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, flag: Term, value: Term) -> exception::Result {
+fn native(process: &Process, flag: Term, value: Term) -> exception::Result {
     let flag_atom: Atom = flag.try_into()?;
 
     match flag_atom.name() {

--- a/lumen_runtime/src/otp/erlang/process_info_2.rs
+++ b/lumen_runtime/src/otp/erlang/process_info_2.rs
@@ -13,12 +13,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Pid, Term};
 use liblumen_alloc::{badarg, AsTerm, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     pid: Term,
     item: Term,
@@ -32,7 +32,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let pid = arc_process.stack_pop().unwrap();
@@ -42,7 +42,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(info) => {
             arc_process.return_from_call(info)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -64,7 +64,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, pid: Term, item: Term) -> exception::Result {
+fn native(process: &Process, pid: Term, item: Term) -> exception::Result {
     let pid_pid: Pid = pid.try_into()?;
     let item_atom: Atom = item.try_into()?;
 
@@ -78,7 +78,7 @@ fn native(process: &ProcessControlBlock, pid: Term, item: Term) -> exception::Re
     }
 }
 
-fn process_info(process: &ProcessControlBlock, item: Atom) -> exception::Result {
+fn process_info(process: &Process, item: Atom) -> exception::Result {
     match item.name() {
         "backtrace" => unimplemented!(),
         "binary" => unimplemented!(),
@@ -117,7 +117,7 @@ fn process_info(process: &ProcessControlBlock, item: Atom) -> exception::Result 
     }
 }
 
-fn registered_name(process: &ProcessControlBlock) -> exception::Result {
+fn registered_name(process: &Process) -> exception::Result {
     match *process.registered_name.read() {
         Some(registered_name) => {
             let tag = atom_unchecked("registered_name");

--- a/lumen_runtime/src/otp/erlang/process_info_2/test/with_local_pid.rs
+++ b/lumen_runtime/src/otp/erlang/process_info_2/test/with_local_pid.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use proptest::strategy::{BoxedStrategy, Strategy};
 
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Term, TypedTerm};
 
 #[test]
@@ -23,7 +23,7 @@ fn without_supported_item_errors_badarg() {
     });
 }
 
-fn unsupported_item(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn unsupported_item(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process)
         .prop_filter("Item cannot be supported", |item| {
             match item.to_typed_term().unwrap() {

--- a/lumen_runtime/src/otp/erlang/self_0.rs
+++ b/lumen_runtime/src/otp/erlang/self_0.rs
@@ -4,23 +4,23 @@ mod test;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
 // Private
 
-pub(crate) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub(crate) fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let self_pid = native(arc_process);
     arc_process.return_from_call(self_pid)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {
@@ -39,6 +39,6 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process_control_block: &ProcessControlBlock) -> Term {
-    process_control_block.pid_term()
+fn native(process: &Process) -> Term {
+    process.pid_term()
 }

--- a/lumen_runtime/src/otp/erlang/send_2.rs
+++ b/lumen_runtime/src/otp/erlang/send_2.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     destination: Term,
     message: Term,
@@ -22,7 +22,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let destination = arc_process.stack_pop().unwrap();
@@ -32,7 +32,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(sent) => {
             arc_process.return_from_call(sent)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/spawn_3.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_3.rs
@@ -11,29 +11,23 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use crate::otp::erlang::spawn_apply_3;
 
 pub fn native(
-    process_control_block: &ProcessControlBlock,
+    process: &Process,
     module: Term,
     function: Term,
     arguments: Term,
 ) -> exception::Result {
-    spawn_apply_3::native(
-        process_control_block,
-        Default::default(),
-        module,
-        function,
-        arguments,
-    )
+    spawn_apply_3::native(process, Default::default(), module, function, arguments)
 }
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     module: Term,
     function: Term,
@@ -49,7 +43,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let module = arc_process.stack_pop().unwrap();
@@ -60,7 +54,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(child_pid) => {
             arc_process.return_from_call(child_pid)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -54,7 +54,7 @@ fn without_loaded_module_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -54,7 +54,7 @@ fn without_exported_function_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -43,7 +43,7 @@ fn with_arity_when_run_exits_normal_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &exit!(atom_unchecked("normal")));
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());
@@ -101,7 +101,7 @@ fn without_arity_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -56,7 +56,7 @@ fn without_loaded_module_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -60,7 +60,7 @@ fn without_arity_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -44,7 +44,7 @@ fn with_valid_arguments_when_run_exits_normal_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &exit!(atom_unchecked("normal")));
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());
@@ -102,7 +102,7 @@ fn without_valid_arguments_when_run_exits_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &badarith!());
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting())

--- a/lumen_runtime/src/otp/erlang/spawn_apply_3.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_apply_3.rs
@@ -2,14 +2,14 @@ use std::convert::TryInto;
 
 use liblumen_alloc::badarg;
 use liblumen_alloc::erts::exception;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 
 use crate::process::spawn::options::Options;
 use crate::scheduler::Scheduler;
 
 pub(in crate::otp::erlang) fn native(
-    process_control_block: &ProcessControlBlock,
+    process: &Process,
     options: Options,
     module: Term,
     function: Term,
@@ -19,13 +19,8 @@ pub(in crate::otp::erlang) fn native(
     let function_atom: Atom = function.try_into()?;
 
     if arguments.is_proper_list() {
-        let arc_process = Scheduler::spawn_apply_3(
-            process_control_block,
-            options,
-            module_atom,
-            function_atom,
-            arguments,
-        )?;
+        let arc_process =
+            Scheduler::spawn_apply_3(process, options, module_atom, function_atom, arguments)?;
 
         Ok(arc_process.pid_term())
     } else {

--- a/lumen_runtime/src/otp/erlang/spawn_link_3.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_3.rs
@@ -11,7 +11,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -19,7 +19,7 @@ use crate::otp::erlang::spawn_apply_3;
 use crate::process::spawn::options::Options;
 
 pub fn native(
-    process_control_block: &ProcessControlBlock,
+    process: &Process,
     module: Term,
     function: Term,
     arguments: Term,
@@ -27,11 +27,11 @@ pub fn native(
     let mut options: Options = Default::default();
     options.link = true;
 
-    spawn_apply_3::native(process_control_block, options, module, function, arguments)
+    spawn_apply_3::native(process, options, module, function, arguments)
 }
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     module: Term,
     function: Term,
@@ -47,7 +47,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let module = arc_process.stack_pop().unwrap();
@@ -58,7 +58,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(child_pid) => {
             arc_process.return_from_call(child_pid)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -54,7 +54,7 @@ fn without_loaded_module_when_run_exits_undef_and_parent_exits() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(parent_arc_process.is_exiting())

--- a/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -54,6 +54,6 @@ fn without_exported_function_when_run_exits_undef_and_parent_exits() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 }

--- a/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -43,7 +43,7 @@ fn with_arity_when_run_exits_normal_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &exit!(atom_unchecked("normal")));
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting())
@@ -100,7 +100,7 @@ fn without_arity_when_run_exits_undef_and_exits_parent() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -56,7 +56,7 @@ fn without_loaded_module_when_run_exits_undef_and_parent_exits() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(child_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -60,7 +60,7 @@ fn without_arity_when_run_exits_undef_and_parent_exits() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(child_arc_process.is_exiting())

--- a/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -44,7 +44,7 @@ fn with_valid_arguments_when_run_exits_normal_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &exit!(atom_unchecked("normal")));
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 }
 
@@ -100,7 +100,7 @@ fn without_valid_arguments_when_run_exits_and_parent_exits() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &badarith!());
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(parent_arc_process.is_exiting())

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4.rs
@@ -12,7 +12,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -20,7 +20,7 @@ use crate::otp::erlang::spawn_apply_3;
 use crate::process::spawn::options::Options;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     module: Term,
     function: Term,
@@ -38,7 +38,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let module = arc_process.stack_pop().unwrap();
@@ -50,7 +50,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(child_pid) => {
             arc_process.return_from_call(child_pid)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -73,7 +73,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
 }
 
 fn native(
-    process_control_block: &ProcessControlBlock,
+    process: &Process,
     module: Term,
     function: Term,
     arguments: Term,
@@ -81,11 +81,5 @@ fn native(
 ) -> exception::Result {
     let options_options: Options = options.try_into()?;
 
-    spawn_apply_3::native(
-        process_control_block,
-        options_options,
-        module,
-        function,
-        arguments,
-    )
+    spawn_apply_3::native(process, options_options, module, function, arguments)
 }

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test.rs
@@ -10,7 +10,7 @@ use proptest::test_runner::{Config, TestRunner};
 use liblumen_alloc::erts::exception::runtime;
 use liblumen_alloc::erts::process::{Priority, Status};
 use liblumen_alloc::erts::term::{atom_unchecked, AsTerm, Atom, Pid, Term};
-use liblumen_alloc::{badarg, badarith, exit, undef, ModuleFunctionArity, ProcessControlBlock};
+use liblumen_alloc::{badarg, badarith, exit, undef, ModuleFunctionArity, Process};
 
 use crate::otp::erlang::apply_3;
 use crate::otp::erlang::spawn_opt_4::native;

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -54,7 +54,7 @@ fn without_loaded_module_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -54,7 +54,7 @@ fn without_exported_function_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -43,7 +43,7 @@ fn with_arity_when_run_exits_normal_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &exit!(atom_unchecked("normal")));
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());
@@ -101,7 +101,7 @@ fn without_arity_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -56,7 +56,7 @@ fn without_loaded_module_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -60,7 +60,7 @@ fn without_arity_when_run_exits_undef_and_parent_does_not_exit() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -44,7 +44,7 @@ fn with_valid_arguments_when_run_exits_normal_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &exit!(atom_unchecked("normal")));
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting());
@@ -102,7 +102,7 @@ fn without_valid_arguments_when_run_exits_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &badarith!());
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting())

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list.rs
@@ -31,6 +31,6 @@ fn without_atom_module_errors_badarg() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process.list_from_slice(&[atom_unchecked("link")]).unwrap()
 }

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -60,7 +60,7 @@ fn without_loaded_module_when_run_exits_undef_and_parent_exits() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(parent_arc_process.is_exiting())

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -60,6 +60,6 @@ fn without_exported_function_when_run_exits_undef_and_parent_exits() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 }

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -49,7 +49,7 @@ fn with_arity_when_run_exits_normal_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &exit!(atom_unchecked("normal")));
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(!parent_arc_process.is_exiting())
@@ -112,7 +112,7 @@ fn without_arity_when_run_exits_undef_and_exits_parent() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(parent_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -62,7 +62,7 @@ fn without_loaded_module_when_run_exits_undef_and_parent_exits() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(child_arc_process.is_exiting());

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -66,7 +66,7 @@ fn without_arity_when_run_exits_undef_and_parent_exits() {
 
             assert_eq!(runtime_exception, &runtime_undef);
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(child_arc_process.is_exiting())

--- a/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -50,7 +50,7 @@ fn with_valid_arguments_when_run_exits_normal_and_parent_does_not_exit() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &exit!(atom_unchecked("normal")));
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 }
 
@@ -112,7 +112,7 @@ fn without_valid_arguments_when_run_exits_and_parent_exits() {
         Status::Exiting(ref runtime_exception) => {
             assert_eq!(runtime_exception, &badarith!());
         }
-        ref status => panic!("ProcessControlBlock status ({:?}) is not exiting.", status),
+        ref status => panic!("Process status ({:?}) is not exiting.", status),
     };
 
     assert!(parent_arc_process.is_exiting())

--- a/lumen_runtime/src/otp/erlang/subtract_2.rs
+++ b/lumen_runtime/src/otp/erlang/subtract_2.rs
@@ -11,18 +11,18 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 /// `-/2` infix operator
-pub fn native(process: &ProcessControlBlock, minuend: Term, subtrahend: Term) -> exception::Result {
+pub fn native(process: &Process, minuend: Term, subtrahend: Term) -> exception::Result {
     number_infix_operator!(minuend, subtrahend, process, checked_sub, -)
 }
 
 /// `-/2` infix operator
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     minuend: Term,
     subtrahend: Term,
@@ -36,7 +36,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let minuend = arc_process.stack_pop().unwrap();
@@ -46,7 +46,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(sum) => {
             arc_process.return_from_call(sum)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/erlang/subtract_2/test.rs
+++ b/lumen_runtime/src/otp/erlang/subtract_2/test.rs
@@ -5,7 +5,7 @@ use proptest::test_runner::{Config, TestRunner};
 use proptest::{prop_assert, prop_assert_eq};
 
 use liblumen_alloc::badarith;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{SmallInteger, Term};
 
 use crate::otp::erlang::subtract_2::native;

--- a/lumen_runtime/src/otp/erlang/subtract_2/test/with_float_minuend.rs
+++ b/lumen_runtime/src/otp/erlang/subtract_2/test/with_float_minuend.rs
@@ -76,7 +76,7 @@ fn with_float_subtrahend_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let minuend = process.float(2.0).unwrap();

--- a/lumen_runtime/src/otp/erlang/subtract_2/test/with_integer_minuend/big.rs
+++ b/lumen_runtime/src/otp/erlang/subtract_2/test/with_integer_minuend/big.rs
@@ -43,7 +43,7 @@ fn with_float_subtrahend_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let minuend: Term = process.integer(SmallInteger::MAX_VALUE + 1).unwrap();

--- a/lumen_runtime/src/otp/erlang/subtract_2/test/with_integer_minuend/small.rs
+++ b/lumen_runtime/src/otp/erlang/subtract_2/test/with_integer_minuend/small.rs
@@ -61,7 +61,7 @@ fn with_float_subtrahend_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let minuend = process.integer(2).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests.rs
+++ b/lumen_runtime/src/otp/erlang/tests.rs
@@ -125,11 +125,7 @@ enum FirstSecond {
     Second,
 }
 
-fn cancel_timer_message(
-    timer_reference: Term,
-    result: Term,
-    process: &ProcessControlBlock,
-) -> Term {
+fn cancel_timer_message(timer_reference: Term, result: Term, process: &Process) -> Term {
     timer_message("cancel_timer", timer_reference, result, process)
 }
 
@@ -160,38 +156,33 @@ fn count_ones_in_big_integer(big_integer: Boxed<BigInteger>) -> u32 {
 
 fn errors_badarg<F>(actual: F)
 where
-    F: FnOnce(&ProcessControlBlock) -> Result,
+    F: FnOnce(&Process) -> Result,
 {
     with_process(|process| assert_badarg!(actual(&process)))
 }
 
 fn errors_badarith<F>(actual: F)
 where
-    F: FnOnce(&ProcessControlBlock) -> Result,
+    F: FnOnce(&Process) -> Result,
 {
     with_process(|process| assert_badarith!(actual(&process)))
 }
 
-fn list_term(process: &ProcessControlBlock) -> Term {
+fn list_term(process: &Process) -> Term {
     let head_term = atom_unchecked("head");
 
     process.cons(head_term, Term::NIL).unwrap()
 }
 
-fn read_timer_message(timer_reference: Term, result: Term, process: &ProcessControlBlock) -> Term {
+fn read_timer_message(timer_reference: Term, result: Term, process: &Process) -> Term {
     timer_message("read_timer", timer_reference, result, process)
 }
 
-fn timeout_message(timer_reference: Term, message: Term, process: &ProcessControlBlock) -> Term {
+fn timeout_message(timer_reference: Term, message: Term, process: &Process) -> Term {
     timer_message("timeout", timer_reference, message, process)
 }
 
-fn timer_message(
-    tag: &str,
-    timer_reference: Term,
-    message: Term,
-    process: &ProcessControlBlock,
-) -> Term {
+fn timer_message(tag: &str, timer_reference: Term, message: Term, process: &Process) -> Term {
     process
         .tuple_from_slice(&[atom_unchecked(tag), timer_reference, message])
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_function_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_equal_after_conversion_2/with_function_left.rs
@@ -57,7 +57,7 @@ fn with_same_value_function_right_returns_true() {
                     strategy::module_function_arity::arity(),
                 )
                     .prop_map(move |(module, function, arity)| {
-                        let code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())
@@ -115,7 +115,7 @@ fn with_different_function_right_returns_false() {
                             function,
                             arity,
                         });
-                        let left_code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let left_code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())
@@ -129,7 +129,7 @@ fn with_different_function_right_returns_false() {
                             function,
                             arity,
                         });
-                        let right_code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let right_code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_function_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_equal_2/with_function_left.rs
@@ -49,7 +49,7 @@ fn with_same_value_function_right_returns_true() {
                     strategy::module_function_arity::arity(),
                 )
                     .prop_map(move |(module, function, arity)| {
-                        let code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())
@@ -103,7 +103,7 @@ fn with_different_function_right_returns_false() {
                             function,
                             arity,
                         });
-                        let left_code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let left_code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())
@@ -117,7 +117,7 @@ fn with_different_function_right_returns_false() {
                             function,
                             arity,
                         });
-                        let right_code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let right_code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())

--- a/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_function_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_exactly_not_equal_2/with_function_left.rs
@@ -52,7 +52,7 @@ fn with_same_value_function_right_returns_false() {
                     strategy::module_function_arity::arity(),
                 )
                     .prop_map(move |(module, function, arity)| {
-                        let code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())
@@ -107,7 +107,7 @@ fn with_different_function_right_returns_true() {
                             function,
                             arity,
                         });
-                        let left_code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let left_code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())
@@ -121,7 +121,7 @@ fn with_different_function_right_returns_true() {
                             function,
                             arity,
                         });
-                        let right_code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let right_code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())

--- a/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_function_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/are_not_equal_after_conversion_2/with_function_left.rs
@@ -55,7 +55,7 @@ fn with_same_value_function_right_returns_false() {
                     strategy::module_function_arity::arity(),
                 )
                     .prop_map(move |(module, function, arity)| {
-                        let code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())
@@ -113,7 +113,7 @@ fn with_different_function_right_returns_true() {
                             function,
                             arity,
                         });
-                        let left_code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let left_code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())
@@ -127,7 +127,7 @@ fn with_different_function_right_returns_true() {
                             function,
                             arity,
                         });
-                        let right_code = |arc_process: &Arc<ProcessControlBlock>| {
+                        let right_code = |arc_process: &Arc<Process>| {
                             arc_process.wait();
 
                             Ok(())

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_integer_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_integer_2.rs
@@ -117,13 +117,13 @@ fn base() -> BoxedStrategy<u8> {
     (2_u8..=36_u8).boxed()
 }
 
-fn term_is_base(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn term_is_base(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     base()
         .prop_map(move |base| arc_process.integer(base).unwrap())
         .boxed()
 }
 
-fn term_is_not_base(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn term_is_not_base(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process)
         .prop_filter("Cannot be a base (2-36)", |term| {
             match term.to_typed_term().unwrap() {

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_term_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_term_1.rs
@@ -176,7 +176,7 @@ fn with_binary_encoding_small_atom_utf8_returns_atom() {
 
 fn with_binary_returns_term<T>(byte_vec: Vec<u8>, term: T)
 where
-    T: Fn(&ProcessControlBlock) -> Term,
+    T: Fn(&Process) -> Term,
 {
     with_process_arc(|arc_process| {
         TestRunner::new(Config::with_source_file(file!()))

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_term_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_term_2.rs
@@ -53,7 +53,7 @@ fn with_used_with_binary_returns_how_many_bytes_were_consumed_along_with_term() 
             .unwrap();
     });
 
-    fn options(process: &ProcessControlBlock) -> Term {
+    fn options(process: &Process) -> Term {
         process.cons(atom_unchecked("used"), Term::NIL).unwrap()
     }
 }

--- a/lumen_runtime/src/otp/erlang/tests/binary_to_term_2/with_safe.rs
+++ b/lumen_runtime/src/otp/erlang/tests/binary_to_term_2/with_safe.rs
@@ -102,6 +102,6 @@ fn with_binary_encoding_small_atom_utf8_that_does_not_exist_errors_badarg() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process.cons(atom_unchecked("safe"), Term::NIL).unwrap()
 }

--- a/lumen_runtime/src/otp/erlang/tests/bsl_2/with_big_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsl_2/with_big_integer_integer.rs
@@ -89,7 +89,7 @@ fn with_positive_returns_big_integer() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let integer = process

--- a/lumen_runtime/src/otp/erlang/tests/bsr_2/with_big_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsr_2/with_big_integer_integer.rs
@@ -53,7 +53,7 @@ fn with_positive_with_underflow_returns_zero() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let integer = process

--- a/lumen_runtime/src/otp/erlang/tests/bsr_2/with_small_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bsr_2/with_small_integer_integer.rs
@@ -64,7 +64,7 @@ fn with_positive_with_underflow_returns_zero() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let integer = process.integer(0b10).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/bxor_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/bxor_2/with_big_integer_left.rs
@@ -63,7 +63,7 @@ fn with_big_integer_right_returns_big_integer() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let left = process

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer/in_different_thread.rs
@@ -72,7 +72,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_1/with_local_reference/with_timer/in_same_thread.rs
@@ -75,7 +75,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_empty_list_options/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_empty_list_options/with_local_reference/with_timer/in_different_thread.rs
@@ -70,7 +70,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_empty_list_options/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_empty_list_options/with_local_reference/with_timer/in_same_thread.rs
@@ -73,7 +73,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options.rs
@@ -5,15 +5,15 @@ mod with_async_true;
 mod with_invalid_option;
 mod without_async;
 
-fn async_option(value: bool, process: &ProcessControlBlock) -> Term {
+fn async_option(value: bool, process: &Process) -> Term {
     option("async", value, process)
 }
 
-fn info_option(value: bool, process: &ProcessControlBlock) -> Term {
+fn info_option(value: bool, process: &Process) -> Term {
     option("info", value, process)
 }
 
-fn option(key: &str, value: bool, process: &ProcessControlBlock) -> Term {
+fn option(key: &str, value: bool, process: &Process) -> Term {
     process
         .tuple_from_slice(&[atom_unchecked(key), value.into()])
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false.rs
@@ -4,7 +4,7 @@ mod with_info_false;
 mod with_info_true;
 mod without_info;
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(async_option(false, process), Term::NIL)
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_false.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_false.rs
@@ -66,7 +66,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
     with_timer_reference_errors_badarg(|process| bitstring!(1 :: 1, process));
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(info_option(false, process), super::options(process))
         .unwrap()
@@ -74,7 +74,7 @@ fn options(process: &ProcessControlBlock) -> Term {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_false/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_false/with_local_reference/with_timer/in_different_thread.rs
@@ -70,7 +70,7 @@ fn with_timeout_returns_ok_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_false/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_false/with_local_reference/with_timer/in_same_thread.rs
@@ -68,7 +68,7 @@ fn with_timeout_returns_ok_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_true.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_true.rs
@@ -66,7 +66,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
     with_timer_reference_errors_badarg(|process| bitstring!(1 :: 1, process));
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(info_option(true, process), super::options(process))
         .unwrap()
@@ -74,7 +74,7 @@ fn options(process: &ProcessControlBlock) -> Term {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_true/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_true/with_local_reference/with_timer/in_different_thread.rs
@@ -73,7 +73,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_true/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/with_info_true/with_local_reference/with_timer/in_same_thread.rs
@@ -75,7 +75,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/without_info.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/without_info.rs
@@ -68,7 +68,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/without_info/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/without_info/with_local_reference/with_timer/in_different_thread.rs
@@ -73,7 +73,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/without_info/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_false/without_info/with_local_reference/with_timer/in_same_thread.rs
@@ -75,7 +75,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true.rs
@@ -4,7 +4,7 @@ mod with_info_false;
 mod with_info_true;
 mod without_info;
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(async_option(true, process), Term::NIL)
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_false.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_false.rs
@@ -66,7 +66,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
     with_timer_reference_errors_badarg(|process| bitstring!(1 :: 1, process));
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(info_option(false, process), super::options(process))
         .unwrap()
@@ -74,7 +74,7 @@ fn options(process: &ProcessControlBlock) -> Term {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_false/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_false/with_local_reference/with_timer/in_different_thread.rs
@@ -70,7 +70,7 @@ fn with_timeout_returns_ok_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_false/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_false/with_local_reference/with_timer/in_same_thread.rs
@@ -70,7 +70,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_true.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_true.rs
@@ -66,7 +66,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
     with_timer_reference_errors_badarg(|process| bitstring!(1 :: 1, process));
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(info_option(true, process), super::options(process))
         .unwrap()
@@ -74,7 +74,7 @@ fn options(process: &ProcessControlBlock) -> Term {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_true/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_true/with_local_reference/with_timer/in_different_thread.rs
@@ -92,7 +92,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_true/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/with_info_true/with_local_reference/with_timer/in_same_thread.rs
@@ -93,7 +93,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/without_info.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/without_info.rs
@@ -68,7 +68,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/without_info/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/without_info/with_local_reference/with_timer/in_different_thread.rs
@@ -92,7 +92,7 @@ fn with_timeout_returns_ok_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/without_info/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_async_true/without_info/with_local_reference/with_timer/in_same_thread.rs
@@ -93,7 +93,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_invalid_option.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/with_invalid_option.rs
@@ -71,7 +71,7 @@ fn with_subbinary_option_errors_badarg() {
 
 fn with_option_errors_badarg<O>(option: O)
 where
-    O: FnOnce(&ProcessControlBlock) -> Term,
+    O: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         let timer_reference = process.next_reference().unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async.rs
@@ -4,6 +4,6 @@ mod with_info_false;
 mod with_info_true;
 mod without_info;
 
-fn options(_process: &ProcessControlBlock) -> Term {
+fn options(_process: &Process) -> Term {
     Term::NIL
 }

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_false.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_false.rs
@@ -66,7 +66,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
     with_timer_reference_errors_badarg(|process| bitstring!(1 :: 1, process));
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(info_option(false, process), super::options(process))
         .unwrap()
@@ -74,7 +74,7 @@ fn options(process: &ProcessControlBlock) -> Term {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_false/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_false/with_local_reference/with_timer/in_different_thread.rs
@@ -70,7 +70,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_false/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_false/with_local_reference/with_timer/in_same_thread.rs
@@ -70,7 +70,7 @@ fn with_timeout_returns_ok_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_true.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_true.rs
@@ -66,7 +66,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
     with_timer_reference_errors_badarg(|process| bitstring!(1 :: 1, process));
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(info_option(true, process), super::options(process))
         .unwrap()
@@ -74,7 +74,7 @@ fn options(process: &ProcessControlBlock) -> Term {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_true/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_true/with_local_reference/with_timer/in_different_thread.rs
@@ -73,7 +73,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_true/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/with_info_true/with_local_reference/with_timer/in_same_thread.rs
@@ -75,7 +75,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/without_info.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/without_info.rs
@@ -68,7 +68,7 @@ fn with_subbinary_timer_reference_errors_badarg() {
 
 fn with_timer_reference_errors_badarg<T>(timer_reference: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         assert_badarg!(erlang::cancel_timer_2(

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/without_info/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/without_info/with_local_reference/with_timer/in_different_thread.rs
@@ -74,7 +74,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/without_info/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/cancel_timer_2/with_reference_timer_reference/with_list_options/without_async/without_info/with_local_reference/with_timer/in_same_thread.rs
@@ -75,7 +75,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/div_2/with_big_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/div_2/with_big_integer_dividend.rs
@@ -57,7 +57,7 @@ fn with_big_integer_divisor_without_underflow_returns_big_integer() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let dividend: Term = process.integer(SmallInteger::MAX_VALUE + 1).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/divide_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2.rs
@@ -96,7 +96,7 @@ fn with_number_dividend_without_zero_number_divisor_returns_float() {
     });
 }
 
-fn number_is_not_zero(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn number_is_not_zero(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term::is_number(arc_process)
         .prop_filter("Number must not be zero", |number| {
             match number.to_typed_term().unwrap() {
@@ -119,7 +119,7 @@ fn number_is_not_zero(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Te
         .boxed()
 }
 
-fn zero(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn zero(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         Just(arc_process.integer(0).unwrap()),
         Just(arc_process.float(0.0).unwrap())

--- a/lumen_runtime/src/otp/erlang/tests/divide_2/with_float_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/divide_2/with_float_dividend.rs
@@ -40,7 +40,7 @@ fn with_float_divisor_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let dividend = process.float(2.0).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2.rs
@@ -32,8 +32,8 @@ fn with_same_left_and_right_returns_true() {
 
 fn is_equal_or_less_than<L, R>(left: L, right: R, expected: bool)
 where
-    L: FnOnce(&ProcessControlBlock) -> Term,
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    L: FnOnce(&Process) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     with_process(|process| {
         let left = left(&process);

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_atom_left.rs
@@ -60,7 +60,7 @@ fn without_number_or_atom_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(|_| atom_unchecked("left"), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_big_integer_left.rs
@@ -73,7 +73,7 @@ fn without_number_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(
         |process| process.integer(SmallInteger::MAX_VALUE + 1).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_empty_list_left.rs
@@ -41,7 +41,7 @@ fn with_list_or_bitstring_right_returns_true() {
         .unwrap();
 }
 
-fn list_or_bitstring(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn list_or_bitstring(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         strategy::term::is_list(arc_process.clone()),
         strategy::term::is_bitstring(arc_process)

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_external_pid_left.rs
@@ -66,7 +66,7 @@ fn with_tuple_map_list_or_bitstring_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(
         |process| process.external_pid_with_node_id(1, 2, 3).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_float_left.rs
@@ -67,7 +67,7 @@ fn without_number_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(|process| process.float(1.0).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_heap_binary_left.rs
@@ -168,7 +168,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(
         |process| process.binary_from_bytes(&[1, 1]).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_list_left.rs
@@ -91,7 +91,7 @@ fn with_bitstring_right_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_local_pid_left.rs
@@ -63,7 +63,7 @@ fn with_list_or_bitstring_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(|_| make_pid(0, 1).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_local_reference_left.rs
@@ -57,7 +57,7 @@ fn with_function_port_pid_tuple_map_list_or_bitstring_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(|process| process.reference(1).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_map_left.rs
@@ -148,7 +148,7 @@ fn with_list_or_bitstring_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_small_integer_left.rs
@@ -72,7 +72,7 @@ fn without_number_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(|process| process.integer(0).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_subbinary_left.rs
@@ -158,7 +158,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(|process| bitstring!(1, 1 :: 2, &process), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_equal_or_less_than_2/with_tuple_left.rs
@@ -104,7 +104,7 @@ fn with_map_list_or_bitstring_returns_true() {
 
 fn is_equal_or_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_equal_or_less_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2.rs
@@ -29,8 +29,8 @@ fn with_same_left_and_right_returns_false() {
 
 fn is_greater_than<L, R>(left: L, right: R, expected: bool)
 where
-    L: FnOnce(&ProcessControlBlock) -> Term,
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    L: FnOnce(&Process) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     with_process(|process| {
         let left = left(&process);

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_atom_left.rs
@@ -65,7 +65,7 @@ fn without_number_or_atom_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(|_| atom_unchecked("left"), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_big_integer_left.rs
@@ -73,7 +73,7 @@ fn without_number_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(
         |process| process.integer(SmallInteger::MAX_VALUE + 1).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_empty_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_empty_list_left.rs
@@ -45,7 +45,7 @@ fn with_non_empty_list_or_bitstring_right_returns_false() {
     });
 }
 
-fn non_empty_list_or_bitstring(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn non_empty_list_or_bitstring(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         strategy::term::list::non_empty_maybe_improper(arc_process.clone()),
         strategy::term::is_bitstring(arc_process)

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_external_pid_left.rs
@@ -66,7 +66,7 @@ fn with_tuple_map_list_or_bitstring_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(
         |process| process.external_pid_with_node_id(1, 2, 3).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_float_left.rs
@@ -57,7 +57,7 @@ fn without_number_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(|process| process.float(1.0).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_heap_binary_left.rs
@@ -174,7 +174,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(
         |process| process.binary_from_bytes(&[1, 1]).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_list_left.rs
@@ -91,7 +91,7 @@ fn with_bitstring_right_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_local_pid_left.rs
@@ -70,7 +70,7 @@ fn with_tuple_map_list_or_bitstring_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(|_| make_pid(0, 1).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_local_reference_left.rs
@@ -62,7 +62,7 @@ fn with_function_port_pid_tuple_map_list_or_bitstring_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(|process| process.reference(1).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_map_left.rs
@@ -150,7 +150,7 @@ fn with_list_or_bitstring_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_small_integer_left.rs
@@ -72,7 +72,7 @@ fn without_number_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(|process| process.integer(0).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_subbinary_left.rs
@@ -172,7 +172,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(|process| bitstring!(1, 1 :: 2, &process), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_2/with_tuple_left.rs
@@ -109,7 +109,7 @@ fn with_map_list_or_bitstring_returns_false() {
 
 fn is_greater_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2.rs
@@ -32,8 +32,8 @@ fn with_same_left_and_right_returns_true() {
 
 fn is_greater_than_or_equal<L, R>(left: L, right: R, expected: bool)
 where
-    L: FnOnce(&ProcessControlBlock) -> Term,
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    L: FnOnce(&Process) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     with_process(|process| {
         let left = left(&process);

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_atom_left.rs
@@ -63,7 +63,7 @@ fn without_number_or_atom_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(|_| atom_unchecked("left"), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_big_integer_left.rs
@@ -76,7 +76,7 @@ fn without_number_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(
         |process| process.integer(SmallInteger::MAX_VALUE + 1).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_external_pid_left.rs
@@ -69,7 +69,7 @@ fn with_tuple_map_list_or_bitstring_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(
         |process| process.external_pid_with_node_id(1, 2, 3).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_float_left.rs
@@ -65,7 +65,7 @@ fn without_number_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(|process| process.float(1.0).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_heap_binary_left.rs
@@ -169,7 +169,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(
         |process| process.binary_from_bytes(&[1, 1]).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_list_left.rs
@@ -89,7 +89,7 @@ fn with_bitstring_right_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_local_pid_left.rs
@@ -66,7 +66,7 @@ fn with_list_or_bitstring_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(|_| make_pid(0, 1).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_local_reference_left.rs
@@ -60,7 +60,7 @@ fn with_function_port_pid_tuple_map_list_or_bitstring_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(|process| process.reference(1).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_map_left.rs
@@ -148,7 +148,7 @@ fn with_list_or_bitstring_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_small_integer_left.rs
@@ -70,7 +70,7 @@ fn without_number_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(|process| process.integer(0).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_subbinary_left.rs
@@ -161,7 +161,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(|process| bitstring!(1, 1 :: 2, &process), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_greater_than_or_equal_2/with_tuple_left.rs
@@ -107,7 +107,7 @@ fn with_map_list_or_bitstring_returns_false() {
 
 fn is_greater_than_or_equal<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_greater_than_or_equal(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2.rs
@@ -29,8 +29,8 @@ fn with_same_left_and_right_returns_false() {
 
 fn is_less_than<L, R>(left: L, right: R, expected: bool)
 where
-    L: FnOnce(&ProcessControlBlock) -> Term,
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    L: FnOnce(&Process) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     with_process(|process| {
         let left = left(&process);

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_atom_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_atom_left.rs
@@ -60,7 +60,7 @@ fn without_number_or_atom_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(|_| atom_unchecked("left"), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_big_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_big_integer_left.rs
@@ -73,7 +73,7 @@ fn without_number_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(
         |process| process.integer(SmallInteger::MAX_VALUE + 1).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_external_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_external_pid_left.rs
@@ -66,7 +66,7 @@ fn with_tuple_map_list_or_bitstring_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(
         |process| process.external_pid_with_node_id(1, 2, 3).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_float_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_float_left.rs
@@ -57,7 +57,7 @@ fn without_number_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(|process| process.float(1.0).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_heap_binary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_heap_binary_left.rs
@@ -173,7 +173,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(
         |process| process.binary_from_bytes(&[1, 1]).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_list_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_list_left.rs
@@ -91,7 +91,7 @@ fn with_bitstring_right_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_local_pid_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_local_pid_left.rs
@@ -68,7 +68,7 @@ fn with_tuple_map_list_or_bitstring_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(|_| make_pid(0, 1).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_local_reference_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_local_reference_left.rs
@@ -62,7 +62,7 @@ fn with_function_port_pid_tuple_map_list_or_bitstring_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(|process| process.reference(1).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_map_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_map_left.rs
@@ -148,7 +148,7 @@ fn with_list_or_bitstring_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_small_integer_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_small_integer_left.rs
@@ -72,7 +72,7 @@ fn without_number_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(|process| process.integer(0).unwrap(), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_subbinary_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_subbinary_left.rs
@@ -163,7 +163,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(|process| bitstring!(1, 1 :: 2, &process), right, expected);
 }

--- a/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_tuple_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/is_less_than_2/with_tuple_left.rs
@@ -109,7 +109,7 @@ fn with_map_list_or_bitstring_returns_true() {
 
 fn is_less_than<R>(right: R, expected: bool)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::is_less_than(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1.rs
@@ -88,16 +88,13 @@ fn with_recursive_lists_of_binaries_and_bytes_ending_in_binary_or_empty_list_ret
     });
 }
 
-fn byte(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn byte(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     any::<u8>()
         .prop_map(move |byte| arc_process.integer(byte).unwrap())
         .boxed()
 }
 
-fn container(
-    element: BoxedStrategy<Term>,
-    arc_process: Arc<ProcessControlBlock>,
-) -> BoxedStrategy<Term> {
+fn container(element: BoxedStrategy<Term>, arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (
         proptest::collection::vec(element, 0..=3),
         tail(arc_process.clone()),
@@ -110,7 +107,7 @@ fn container(
         .boxed()
 }
 
-fn leaf(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn leaf(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         strategy::term::is_binary(arc_process.clone()),
         byte(arc_process),
@@ -118,7 +115,7 @@ fn leaf(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
     .boxed()
 }
 
-fn recursive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn recursive(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     leaf(arc_process.clone())
         .prop_recursive(3, 3 * 4, 3, move |element| {
             container(element, arc_process.clone())
@@ -126,11 +123,11 @@ fn recursive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
         .boxed()
 }
 
-fn tail(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn tail(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![strategy::term::is_binary(arc_process), Just(Term::NIL)].boxed()
 }
 
-fn top(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn top(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (
         proptest::collection::vec(recursive(arc_process.clone()), 1..=4),
         tail(arc_process.clone()),

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list.rs
@@ -58,7 +58,7 @@ fn with_subbinary_with_bit_count_errors_badarg() {
     });
 }
 
-fn is_not_byte_binary_nor_list(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn is_not_byte_binary_nor_list(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process.clone())
         .prop_filter("Element must not be a binary or byte", move |element| {
             !(element.is_binary()

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_binary_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_binary_subbinary.rs
@@ -121,7 +121,7 @@ fn with_subbinary_without_bitcount_returns_binary() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let original = process

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_byte.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_byte.rs
@@ -147,7 +147,7 @@ fn with_subbinary_with_bitcount_errors_badarg() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(u8, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u8, Term, &Process) -> (),
 {
     with_process(|process| {
         let head_byte: u8 = 0;

--- a/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_heap_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_binary_1/with_list/with_heap_binary.rs
@@ -114,7 +114,7 @@ fn with_subbinary_without_bitcount_returns_binary() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = process.binary_from_bytes(&[0, 1]).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1.rs
@@ -89,16 +89,13 @@ fn with_recursive_lists_of_bitstrings_and_bytes_ending_in_bitstring_or_empty_lis
     });
 }
 
-fn byte(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn byte(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     any::<u8>()
         .prop_map(move |byte| arc_process.integer(byte).unwrap())
         .boxed()
 }
 
-fn container(
-    element: BoxedStrategy<Term>,
-    arc_process: Arc<ProcessControlBlock>,
-) -> BoxedStrategy<Term> {
+fn container(element: BoxedStrategy<Term>, arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (
         proptest::collection::vec(element, 0..=3),
         tail(arc_process.clone()),
@@ -111,7 +108,7 @@ fn container(
         .boxed()
 }
 
-fn leaf(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn leaf(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         strategy::term::is_bitstring(arc_process.clone()),
         byte(arc_process),
@@ -119,7 +116,7 @@ fn leaf(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
     .boxed()
 }
 
-fn recursive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn recursive(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     leaf(arc_process.clone())
         .prop_recursive(3, 3 * 4, 3, move |element| {
             container(element, arc_process.clone())
@@ -127,11 +124,11 @@ fn recursive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
         .boxed()
 }
 
-fn tail(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn tail(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![strategy::term::is_bitstring(arc_process), Just(Term::NIL)].boxed()
 }
 
-fn top(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn top(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (
         proptest::collection::vec(recursive(arc_process.clone()), 1..=4),
         tail(arc_process.clone()),

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list.rs
@@ -43,7 +43,7 @@ fn with_empty_list_returns_empty_binary() {
     })
 }
 
-fn is_not_byte_bitstring_nor_list(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn is_not_byte_bitstring_nor_list(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process.clone())
         .prop_filter("Element must not be a binary or byte", move |element| {
             !(element.is_bitstring()

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_0_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_0_bit_subbinary.rs
@@ -199,7 +199,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -210,7 +210,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let original = process.binary_from_bytes(&[0b0000_0001]).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_1_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_1_bit_subbinary.rs
@@ -193,7 +193,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -204,7 +204,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = bitstring!(1, 0b1 :: 1, &process);

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_2_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_2_bit_subbinary.rs
@@ -193,7 +193,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -204,7 +204,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = bitstring!(1, 0b11 :: 2, &process);

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_3_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_3_bit_subbinary.rs
@@ -194,7 +194,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -205,7 +205,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = bitstring!(1, 0b101 :: 3, &process);

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_4_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_4_bit_subbinary.rs
@@ -212,7 +212,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -223,7 +223,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = bitstring!(1, 0b0101 :: 4, &process);

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_5_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_5_bit_subbinary.rs
@@ -212,7 +212,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -223,7 +223,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = bitstring!(1, 0b10101 :: 5, &process);

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_6_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_6_bit_subbinary.rs
@@ -205,7 +205,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -216,7 +216,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = bitstring!(1, 0b010101 :: 6, &process);

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_7_bit_subbinary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_7_bit_subbinary.rs
@@ -204,7 +204,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -215,7 +215,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = bitstring!(1, 0b1010101 :: 7, &process);

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_byte.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_byte.rs
@@ -188,7 +188,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|_, head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -199,7 +199,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(u8, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u8, Term, &Process) -> (),
 {
     with_process(|process| {
         let head_byte: u8 = 0;

--- a/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_heap_binary.rs
+++ b/lumen_runtime/src/otp/erlang/tests/list_to_bitstring_1/with_list/with_heap_binary.rs
@@ -189,7 +189,7 @@ fn with_subbinary_with_bit_count_7_returns_subbinary() {
 
 fn with_tail_errors_badarg<T>(tail: T)
 where
-    T: FnOnce(&ProcessControlBlock) -> Term,
+    T: FnOnce(&Process) -> Term,
 {
     with(|head, process| {
         let iolist = process.cons(head, tail(&process)).unwrap();
@@ -200,7 +200,7 @@ where
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let head = process.binary_from_bytes(&[0, 1]).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/max_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2.rs
@@ -59,8 +59,8 @@ fn max_is_second_if_first_is_less_than_second() {
 
 fn max<F, S>(first: F, second: S, which: FirstSecond)
 where
-    F: FnOnce(&ProcessControlBlock) -> Term,
-    S: FnOnce(Term, &ProcessControlBlock) -> Term,
+    F: FnOnce(&Process) -> Term,
+    S: FnOnce(Term, &Process) -> Term,
 {
     with_process(|process| {
         let first = first(&process);

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_atom_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_atom_first.rs
@@ -63,7 +63,7 @@ fn without_number_or_atom_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(|_| atom_unchecked("first"), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_big_integer_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_big_integer_first.rs
@@ -78,7 +78,7 @@ fn without_second_number_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(
         |process| process.integer(SmallInteger::MAX_VALUE + 1).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_external_pid_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_external_pid_first.rs
@@ -71,7 +71,7 @@ fn with_tuple_map_list_or_bitstring_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(
         |process| process.external_pid_with_node_id(1, 2, 3).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_float_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_float_first.rs
@@ -57,7 +57,7 @@ fn without_number_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(|process| process.float(1.0).unwrap(), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_heap_binary_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_heap_binary_first.rs
@@ -176,7 +176,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(
         |process| process.binary_from_bytes(&[1, 1]).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_list_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_list_first.rs
@@ -91,7 +91,7 @@ fn with_bitstring_second_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_local_pid_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_local_pid_first.rs
@@ -68,7 +68,7 @@ fn with_list_or_bitstring_second_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(|_| make_pid(0, 1).unwrap(), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_local_reference_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_local_reference_first.rs
@@ -62,7 +62,7 @@ fn with_function_port_pid_tuple_map_list_or_bitstring_second_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(|process| process.reference(1).unwrap(), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_map_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_map_first.rs
@@ -153,7 +153,7 @@ fn with_list_or_bitstring_second_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_small_integer_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_small_integer_first.rs
@@ -72,7 +72,7 @@ fn without_number_second_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(|process| process.integer(0).unwrap(), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_subbinary_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_subbinary_first.rs
@@ -169,7 +169,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(|process| bitstring!(1, 1 :: 2, &process), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/max_2/with_tuple_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/max_2/with_tuple_first.rs
@@ -109,7 +109,7 @@ fn with_map_list_or_bitstring_second_returns_second() {
 
 fn max<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::max(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/min_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2.rs
@@ -59,8 +59,8 @@ fn min_is_second_if_first_is_greater_than_second() {
 
 fn min<F, S>(first: F, second: S, which: FirstSecond)
 where
-    F: FnOnce(&ProcessControlBlock) -> Term,
-    S: FnOnce(Term, &ProcessControlBlock) -> Term,
+    F: FnOnce(&Process) -> Term,
+    S: FnOnce(Term, &Process) -> Term,
 {
     with_process(|process| {
         let first = first(&process);

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_atom_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_atom_first.rs
@@ -63,7 +63,7 @@ fn without_number_or_atom_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(|_| atom_unchecked("first"), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_big_integer_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_big_integer_first.rs
@@ -78,7 +78,7 @@ fn without_second_number_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(
         |process| process.integer(SmallInteger::MAX_VALUE + 1).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_external_pid_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_external_pid_first.rs
@@ -71,7 +71,7 @@ fn with_tuple_map_list_or_bitstring_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(
         |process| process.external_pid_with_node_id(1, 2, 3).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_float_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_float_first.rs
@@ -57,7 +57,7 @@ fn without_number_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(|process| process.float(1.0).unwrap(), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_heap_binary_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_heap_binary_first.rs
@@ -179,7 +179,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(
         |process| process.binary_from_bytes(&[1, 1]).unwrap(),

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_list_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_list_first.rs
@@ -91,7 +91,7 @@ fn with_bitstring_second_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_local_pid_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_local_pid_first.rs
@@ -68,7 +68,7 @@ fn with_list_or_bitstring_second_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(|_| make_pid(0, 1).unwrap(), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_local_reference_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_local_reference_first.rs
@@ -62,7 +62,7 @@ fn with_function_port_pid_tuple_map_list_or_bitstring_second_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(|process| process.reference(1).unwrap(), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_map_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_map_first.rs
@@ -148,7 +148,7 @@ fn with_list_or_bitstring_second_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_small_integer_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_small_integer_first.rs
@@ -72,7 +72,7 @@ fn without_number_second_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(|process| process.integer(0).unwrap(), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_subbinary_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_subbinary_first.rs
@@ -172,7 +172,7 @@ fn with_subbinary_with_value_with_shorter_length_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(|process| bitstring!(1, 1 :: 2, &process), second, which);
 }

--- a/lumen_runtime/src/otp/erlang/tests/min_2/with_tuple_first.rs
+++ b/lumen_runtime/src/otp/erlang/tests/min_2/with_tuple_first.rs
@@ -109,7 +109,7 @@ fn with_map_list_or_bitstring_second_returns_first() {
 
 fn min<R>(second: R, which: FirstSecond)
 where
-    R: FnOnce(Term, &ProcessControlBlock) -> Term,
+    R: FnOnce(Term, &Process) -> Term,
 {
     super::min(
         |process| {

--- a/lumen_runtime/src/otp/erlang/tests/monotonic_time_1.rs
+++ b/lumen_runtime/src/otp/erlang/tests/monotonic_time_1.rs
@@ -29,7 +29,7 @@ fn without_atom_or_integer_errors_badarg() {
 
 fn errors_badarg<U>(unit: U)
 where
-    U: FnOnce(&ProcessControlBlock) -> Term,
+    U: FnOnce(&Process) -> Term,
 {
     super::errors_badarg(|process| erlang::monotonic_time_1(unit(&process), process));
 }

--- a/lumen_runtime/src/otp/erlang/tests/multiply_2/with_big_integer_multiplier.rs
+++ b/lumen_runtime/src/otp/erlang/tests/multiply_2/with_big_integer_multiplier.rs
@@ -88,7 +88,7 @@ fn with_float_multiplicand_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let multiplier: Term = process.integer(SmallInteger::MAX_VALUE + 1).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/multiply_2/with_float_multiplier.rs
+++ b/lumen_runtime/src/otp/erlang/tests/multiply_2/with_float_multiplier.rs
@@ -85,7 +85,7 @@ fn with_float_multiplicand_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let multiplier = process.float(2.0).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/multiply_2/with_small_integer_multiplier.rs
+++ b/lumen_runtime/src/otp/erlang/tests/multiply_2/with_small_integer_multiplier.rs
@@ -131,7 +131,7 @@ fn with_float_multiplicand_with_overflow_returns_max_float() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let multiplier = process.integer(2).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/orelse_2/with_false_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/orelse_2/with_false_left.rs
@@ -82,7 +82,7 @@ fn with_subbinary_right_returns_true() {
 
 fn with_right_returns_right<R>(right: R)
 where
-    R: FnOnce(&ProcessControlBlock) -> Term,
+    R: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         let left = false.into();

--- a/lumen_runtime/src/otp/erlang/tests/orelse_2/with_true_left.rs
+++ b/lumen_runtime/src/otp/erlang/tests/orelse_2/with_true_left.rs
@@ -82,7 +82,7 @@ fn with_subbinary_right_returns_true() {
 
 fn with_right_returns_true<R>(right: R)
 where
-    R: FnOnce(&ProcessControlBlock) -> Term,
+    R: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         let left = true.into();

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_1/with_local_reference/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_1/with_local_reference/with_timer/in_different_thread.rs
@@ -73,7 +73,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_1/with_local_reference/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_1/with_local_reference/with_timer/in_same_thread.rs
@@ -73,7 +73,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2.rs
@@ -49,7 +49,7 @@ fn with_reference_without_list_options_errors_badarg() {
     });
 }
 
-fn async_option(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn async_option(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term::is_boolean()
         .prop_map(move |async_value| {
             arc_process
@@ -59,7 +59,7 @@ fn async_option(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
         .boxed()
 }
 
-fn options(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn options(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         Just(Term::NIL),
         async_option(arc_process.clone()).prop_map(move |async_option| {

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_empty_list_options/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_empty_list_options/with_timer/in_different_thread.rs
@@ -73,7 +73,7 @@ fn with_timeout_returns_false() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_empty_list_options/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_empty_list_options/with_timer/in_same_thread.rs
@@ -73,7 +73,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options.rs
@@ -5,11 +5,11 @@ mod with_async_true;
 mod with_invalid_option;
 mod without_async;
 
-fn async_option(value: bool, process: &ProcessControlBlock) -> Term {
+fn async_option(value: bool, process: &Process) -> Term {
     option("async", value, process)
 }
 
-fn option(key: &str, value: bool, process: &ProcessControlBlock) -> Term {
+fn option(key: &str, value: bool, process: &Process) -> Term {
     process
         .tuple_from_slice(&[atom_unchecked(key), value.into()])
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_false.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_false.rs
@@ -14,7 +14,7 @@ fn without_timer_returns_false() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(async_option(false, process), Term::NIL)
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_false/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_false/with_timer/in_different_thread.rs
@@ -75,7 +75,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_false/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_false/with_timer/in_same_thread.rs
@@ -77,7 +77,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_true.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_true.rs
@@ -18,7 +18,7 @@ fn without_timer_returns_ok_and_sends_read_timer_message() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(async_option(true, process), Term::NIL)
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_true/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_true/with_timer/in_different_thread.rs
@@ -107,7 +107,7 @@ fn with_timeout_returns_ok_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_true/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_async_true/with_timer/in_same_thread.rs
@@ -108,7 +108,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_invalid_option.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/with_invalid_option.rs
@@ -97,7 +97,7 @@ fn with_subbinary_option_errors_badarg() {
 
 fn with_option_errors_badarg<O>(option: O)
 where
-    O: FnOnce(&ProcessControlBlock) -> Term,
+    O: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         let timer_reference = process.next_reference().unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/without_async.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/without_async.rs
@@ -14,6 +14,6 @@ fn without_timer_returns_false() {
     });
 }
 
-fn options(_process: &ProcessControlBlock) -> Term {
+fn options(_process: &Process) -> Term {
     Term::NIL
 }

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/without_async/with_timer/in_different_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/without_async/with_timer/in_different_thread.rs
@@ -75,7 +75,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, &Barrier, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, &Barrier, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/without_async/with_timer/in_same_thread.rs
+++ b/lumen_runtime/src/otp/erlang/tests/read_timer_2/with_reference/with_list_options/without_async/with_timer/in_same_thread.rs
@@ -76,7 +76,7 @@ fn with_timeout_returns_false_after_timeout_message_was_sent() {
 
 fn with_timer<F>(f: F)
 where
-    F: FnOnce(u64, Term, Term, &ProcessControlBlock) -> (),
+    F: FnOnce(u64, Term, Term, &Process) -> (),
 {
     let same_thread_process_arc = process::test(&process::test_init());
     let milliseconds: u64 = 100;

--- a/lumen_runtime/src/otp/erlang/tests/rem_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/rem_2.rs
@@ -132,7 +132,7 @@ fn with_subbinary_dividend_errors_badarith() {
 
 fn with_dividend_errors_badarith<M>(dividend: M)
 where
-    M: FnOnce(&ProcessControlBlock) -> Term,
+    M: FnOnce(&Process) -> Term,
 {
     super::errors_badarith(|process| {
         let dividend = dividend(&process);

--- a/lumen_runtime/src/otp/erlang/tests/rem_2/with_big_integer_dividend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/rem_2/with_big_integer_dividend.rs
@@ -42,7 +42,7 @@ fn with_big_integer_divisor_without_underflow_returns_big_integer() {
 
 fn with<F>(f: F)
 where
-    F: FnOnce(Term, &ProcessControlBlock) -> (),
+    F: FnOnce(Term, &Process) -> (),
 {
     with_process(|process| {
         let dividend: Term = process.integer(SmallInteger::MAX_VALUE + 1).unwrap();

--- a/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_2/with_tuple_destination/with_arity_2.rs
@@ -94,7 +94,7 @@ fn with_subbinary_name_errors_badarg() {
 
 fn with_name_errors_badarg<N>(name: N)
 where
-    N: FnOnce(&ProcessControlBlock) -> Term,
+    N: FnOnce(&Process) -> Term,
 {
     with_process(|process| {
         let destination = process

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_proper_list_options.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_proper_list_options.rs
@@ -34,7 +34,7 @@ fn without_atom_pid_or_tuple_destination_errors_badarg() {
         .unwrap();
 }
 
-fn valid_options(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn valid_options(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     let noconnect = atom_unchecked("noconnect");
     let nosuspend = atom_unchecked("nosuspend");
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_proper_list_options/non_empty/with_noconnect.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_proper_list_options/non_empty/with_noconnect.rs
@@ -2,7 +2,7 @@ use super::*;
 
 mod with_tuple_destination;
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(atom_unchecked("noconnect"), Term::NIL)
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_proper_list_options/non_empty/with_noconnect_and_nosuspend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_proper_list_options/non_empty/with_noconnect_and_nosuspend.rs
@@ -2,7 +2,7 @@ use super::*;
 
 mod with_tuple_destination;
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     let noconnect = atom_unchecked("noconnect");
     let nosuspend = atom_unchecked("nosuspend");
 

--- a/lumen_runtime/src/otp/erlang/tests/send_3/with_proper_list_options/non_empty/with_nosuspend.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_3/with_proper_list_options/non_empty/with_nosuspend.rs
@@ -2,7 +2,7 @@ use super::*;
 
 mod with_tuple_destination;
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process
         .cons(atom_unchecked("nosuspend"), Term::NIL)
         .unwrap()

--- a/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_abs.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_abs.rs
@@ -39,7 +39,7 @@ fn without_atom_errors_badarg() {
     });
 }
 
-fn options(abs: Term, process: &ProcessControlBlock) -> Term {
+fn options(abs: Term, process: &Process) -> Term {
     process
         .cons(
             process

--- a/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_abs/with_atom/with_false.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_abs/with_atom/with_false.rs
@@ -36,6 +36,6 @@ fn without_non_negative_integer_time_errors_badarg() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     super::options(false.into(), process)
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_abs/with_atom/with_true.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_abs/with_atom/with_true.rs
@@ -36,6 +36,6 @@ fn without_non_negative_integer_time_errors_badarg() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     super::options(true.into(), process)
 }

--- a/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_abs/with_atom/without_boolean.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_abs/with_atom/without_boolean.rs
@@ -38,7 +38,7 @@ fn without_non_negative_integer_time_error_badarg() {
     });
 }
 
-fn options(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn options(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process.clone())
         .prop_map(move |value| super::options(value, &arc_process))
         .boxed()

--- a/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_invalid_option.rs
+++ b/lumen_runtime/src/otp/erlang/tests/send_after_4/with_proper_list_options/with_list_options/with_invalid_option.rs
@@ -36,6 +36,6 @@ fn without_non_negative_integer_time_errors_badarg() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process.cons(atom_unchecked("invalid"), Term::NIL).unwrap()
 }

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_abs.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_abs.rs
@@ -39,7 +39,7 @@ fn without_atom_errors_badarg() {
     });
 }
 
-fn options(abs: Term, process: &ProcessControlBlock) -> Term {
+fn options(abs: Term, process: &Process) -> Term {
     process
         .cons(
             process

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_abs/with_atom/with_false.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_abs/with_atom/with_false.rs
@@ -36,6 +36,6 @@ fn without_non_negative_integer_time_errors_badarg() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     super::options(false.into(), process)
 }

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_abs/with_atom/with_true.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_abs/with_atom/with_true.rs
@@ -36,6 +36,6 @@ fn without_non_negative_integer_time_errors_badarg() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     super::options(true.into(), process)
 }

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_abs/with_atom/without_boolean.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_abs/with_atom/without_boolean.rs
@@ -38,7 +38,7 @@ fn without_non_negative_integer_time_error_badarg() {
     });
 }
 
-fn options(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+fn options(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process.clone())
         .prop_map(move |value| super::options(value, &arc_process))
         .boxed()

--- a/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_invalid_option.rs
+++ b/lumen_runtime/src/otp/erlang/tests/start_timer_4/with_proper_list_options/with_list_options/with_invalid_option.rs
@@ -36,6 +36,6 @@ fn without_non_negative_integer_time_errors_badarg() {
     });
 }
 
-fn options(process: &ProcessControlBlock) -> Term {
+fn options(process: &Process) -> Term {
     process.cons(atom_unchecked("invalid"), Term::NIL).unwrap()
 }

--- a/lumen_runtime/src/otp/erlang/unlink_1.rs
+++ b/lumen_runtime/src/otp/erlang/unlink_1.rs
@@ -11,14 +11,14 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term, TypedTerm};
 use liblumen_alloc::{badarg, ModuleFunctionArity};
 
 use crate::registry::pid_to_process;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     pid_or_port: Term,
 ) -> Result<(), Alloc> {
@@ -30,7 +30,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let pid_or_port = arc_process.stack_pop().unwrap();
@@ -39,7 +39,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(true_term) => {
             arc_process.return_from_call(true_term)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -61,7 +61,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, pid_or_port: Term) -> exception::Result {
+fn native(process: &Process, pid_or_port: Term) -> exception::Result {
     match pid_or_port.to_typed_term().unwrap() {
         TypedTerm::Pid(pid) => {
             if pid == process.pid() {

--- a/lumen_runtime/src/otp/erlang/unlink_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/unlink_1/test.rs
@@ -5,7 +5,7 @@ use proptest::strategy::Strategy;
 use proptest::test_runner::{Config, TestRunner};
 
 use liblumen_alloc::badarg;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 
 use crate::otp::erlang::unlink_1::native;
 use crate::scheduler::{with_process, with_process_arc};
@@ -30,6 +30,6 @@ fn without_pid_or_port_errors_badarg() {
     });
 }
 
-fn link_count(process: &ProcessControlBlock) -> usize {
+fn link_count(process: &Process) -> usize {
     process.linked_pid_set.lock().len()
 }

--- a/lumen_runtime/src/otp/lists/keyfind_3.rs
+++ b/lumen_runtime/src/otp/lists/keyfind_3.rs
@@ -11,14 +11,14 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use crate::otp::lists::get_by_term_one_based_index_key;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     key: Term,
     one_based_index: Term,
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let key = arc_process.stack_pop().unwrap();
@@ -45,7 +45,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(tuple_or_false) => {
             arc_process.return_from_call(tuple_or_false)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/lists/keymember_3.rs
+++ b/lumen_runtime/src/otp/lists/keymember_3.rs
@@ -11,14 +11,14 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use crate::otp::lists::get_by_term_one_based_index_key;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     key: Term,
     one_based_index: Term,
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let key = arc_process.stack_pop().unwrap();
@@ -45,7 +45,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(boolean) => {
             arc_process.return_from_call(boolean)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/lists/member_2.rs
+++ b/lumen_runtime/src/otp/lists/member_2.rs
@@ -11,12 +11,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term, TypedTerm};
 use liblumen_alloc::{badarg, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     element: Term,
     list: Term,
@@ -30,7 +30,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let element = arc_process.stack_pop().unwrap();
@@ -40,7 +40,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(boolean) => {
             arc_process.return_from_call(boolean)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_runtime/src/otp/lists/reverse_1.rs
+++ b/lumen_runtime/src/otp/lists/reverse_1.rs
@@ -11,14 +11,14 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use crate::otp::lists::reverse_2;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     list: Term,
 ) -> Result<(), Alloc> {
@@ -30,7 +30,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let list = arc_process.stack_pop().unwrap();
@@ -39,7 +39,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(reversed) => {
             arc_process.return_from_call(reversed)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -61,6 +61,6 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, list: Term) -> exception::Result {
+fn native(process: &Process, list: Term) -> exception::Result {
     reverse_2::native(process, list, Term::NIL)
 }

--- a/lumen_runtime/src/otp/lists/reverse_2.rs
+++ b/lumen_runtime/src/otp/lists/reverse_2.rs
@@ -11,12 +11,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term, TypedTerm};
 use liblumen_alloc::{badarg, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     list: Term,
     tail: Term,
@@ -30,7 +30,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let list = arc_process.stack_pop().unwrap();
@@ -40,7 +40,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(reversed_with_tail) => {
             arc_process.return_from_call(reversed_with_tail)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -62,7 +62,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-pub(super) fn native(process: &ProcessControlBlock, list: Term, tail: Term) -> exception::Result {
+pub(super) fn native(process: &Process, list: Term, tail: Term) -> exception::Result {
     match list.to_typed_term().unwrap() {
         TypedTerm::Nil => Ok(tail),
         TypedTerm::List(cons) => {

--- a/lumen_runtime/src/otp/maps/get_3.rs
+++ b/lumen_runtime/src/otp/maps/get_3.rs
@@ -12,12 +12,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Boxed, Map, Term};
 use liblumen_alloc::{badmap, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     key: Term,
     map: Term,
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 
 // Crate Public
 
-pub(in crate::otp) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub(in crate::otp) fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let default = arc_process.stack_pop().unwrap();
@@ -44,7 +44,7 @@ pub(in crate::otp) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Resu
         Ok(boolean) => {
             arc_process.return_from_call(boolean)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -68,12 +68,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-pub fn native(
-    process: &ProcessControlBlock,
-    key: Term,
-    map: Term,
-    default: Term,
-) -> exception::Result {
+pub fn native(process: &Process, key: Term, map: Term, default: Term) -> exception::Result {
     let result_map: Result<Boxed<Map>, _> = map.try_into();
 
     match result_map {

--- a/lumen_runtime/src/otp/maps/is_key_2.rs
+++ b/lumen_runtime/src/otp/maps/is_key_2.rs
@@ -12,12 +12,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Boxed, Map, Term};
 use liblumen_alloc::{badmap, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     key: Term,
     map: Term,
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 
 // Crate Public
 
-pub(in crate::otp) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub(in crate::otp) fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let key = arc_process.stack_pop().unwrap();
@@ -41,7 +41,7 @@ pub(in crate::otp) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Resu
         Ok(boolean) => {
             arc_process.return_from_call(boolean)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -65,7 +65,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, key: Term, map: Term) -> exception::Result {
+fn native(process: &Process, key: Term, map: Term) -> exception::Result {
     let result_map: Result<Boxed<Map>, _> = map.try_into();
 
     match result_map {

--- a/lumen_runtime/src/otp/maps/merge_2.rs
+++ b/lumen_runtime/src/otp/maps/merge_2.rs
@@ -14,12 +14,12 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Boxed, Map, Term};
 use liblumen_alloc::{badmap, ModuleFunctionArity};
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     map1: Term,
     map2: Term,
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 
 // Crate Public
 
-pub(in crate::otp) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub(in crate::otp) fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let map1 = arc_process.stack_pop().unwrap();
@@ -43,7 +43,7 @@ pub(in crate::otp) fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Resu
         Ok(map3) => {
             arc_process.return_from_call(map3)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -67,7 +67,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, map1: Term, map2: Term) -> exception::Result {
+fn native(process: &Process, map1: Term, map2: Term) -> exception::Result {
     let result_map1: Result<Boxed<Map>, _> = map1.try_into();
 
     match result_map1 {

--- a/lumen_runtime/src/otp/timer/tc_3.rs
+++ b/lumen_runtime/src/otp/timer/tc_3.rs
@@ -8,14 +8,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use crate::otp::erlang::monotonic_time_0;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     module: Term,
     function: Term,
@@ -41,7 +41,7 @@ pub fn place_frame_with_arguments(
 ///   {time, value}
 /// end
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let module = arc_process.stack_pop().unwrap();
@@ -57,7 +57,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     )?;
     monotonic_time_0::place_frame(arc_process, Placement::Push);
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_runtime/src/otp/timer/tc_3/label_1.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_1.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 use crate::otp::erlang::apply_3;
@@ -21,7 +21,7 @@ use crate::otp::timer::tc_3::label_2;
 /// {time, value}
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     module: Term,
     function: Term,
@@ -44,7 +44,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let before = arc_process.stack_pop().unwrap();
@@ -59,10 +59,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     label_2::place_frame_with_arguments(arc_process, Placement::Replace, before)?;
     apply_3::place_frame_with_arguments(arc_process, Placement::Push, module, function, arguments)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/lumen_runtime/src/otp/timer/tc_3/label_2.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_2.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 use crate::otp::erlang::monotonic_time_0;
@@ -20,7 +20,7 @@ use crate::otp::timer::tc_3::label_3;
 /// {time, value}
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     before: Term,
 ) -> Result<(), Alloc> {
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let value = arc_process.stack_pop().unwrap();
@@ -43,10 +43,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     label_3::place_frame_with_arguments(arc_process, Placement::Replace, before, value)?;
     monotonic_time_0::place_frame(arc_process, Placement::Push);
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/lumen_runtime/src/otp/timer/tc_3/label_3.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_3.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 use crate::otp::erlang::subtract_2;
@@ -19,7 +19,7 @@ use crate::otp::timer::tc_3::label_4;
 /// {time, value}
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     before: Term,
     value: Term,
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let after = arc_process.stack_pop().unwrap();
@@ -45,10 +45,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
 
     label_4::place_frame_with_arguments(arc_process, Placement::Replace, value)?;
     subtract_2::place_frame_with_arguments(arc_process, Placement::Push, after, before)?;
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/lumen_runtime/src/otp/timer/tc_3/label_4.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_4.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
 use crate::otp::erlang::convert_time_unit_3;
@@ -18,7 +18,7 @@ use crate::otp::timer::tc_3::label_5;
 /// {time, value}
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     value: Term,
 ) -> Result<(), Alloc> {
@@ -30,7 +30,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let duration = arc_process.stack_pop().unwrap();
@@ -46,10 +46,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         atom_unchecked("microsecond"),
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/lumen_runtime/src/otp/timer/tc_3/label_5.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_5.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::Term;
 
 /// ```elixir
@@ -14,7 +14,7 @@ use liblumen_alloc::erts::term::Term;
 /// {time, value}
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     value: Term,
 ) -> Result<(), Alloc> {
@@ -26,7 +26,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let time = arc_process.stack_pop().unwrap();
@@ -36,10 +36,10 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
     let time_value = arc_process.tuple_from_slice(&[time, value])?;
     arc_process.return_from_call(time_value)?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
-fn frame(process: &ProcessControlBlock) -> Frame {
+fn frame(process: &Process) -> Frame {
     let module_function_arity = process.current_module_function_arity().unwrap();
 
     Frame::new(module_function_arity, code)

--- a/lumen_runtime/src/process/spawn.rs
+++ b/lumen_runtime/src/process/spawn.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::Code;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{AsTerm, Atom, Term, TypedTerm};
 use liblumen_alloc::CloneToProcess;
 
@@ -17,12 +17,12 @@ use crate::process::spawn::options::Options;
 /// This allows the `apply/3` code to be changed with `apply_3::set_code(code)` to handle new
 /// MFA unique to a given application.
 pub fn apply_3(
-    parent_process: &ProcessControlBlock,
+    parent_process: &Process,
     options: Options,
     module: Atom,
     function: Atom,
     arguments: Term,
-) -> Result<ProcessControlBlock, Alloc> {
+) -> Result<Process, Alloc> {
     let arity = arity(arguments);
 
     let child_process = options.spawn(Some(parent_process), module, function, arity)?;
@@ -48,13 +48,13 @@ pub fn apply_3(
 /// Spawns a process with `arguments` on its stack and `code` run with those arguments instead
 /// of passing through `apply/3`.
 pub fn code(
-    parent_process: Option<&ProcessControlBlock>,
+    parent_process: Option<&Process>,
     options: Options,
     module: Atom,
     function: Atom,
     arguments: Vec<Term>,
     code: Code,
-) -> Result<ProcessControlBlock, Alloc> {
+) -> Result<Process, Alloc> {
     let arity = arguments.len() as u8;
 
     let child_process = options.spawn(parent_process, module, function, arity)?;

--- a/lumen_runtime/src/process/spawn/options.rs
+++ b/lumen_runtime/src/process/spawn/options.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::exception::Exception;
 use liblumen_alloc::erts::process::alloc::{default_heap_size, heap, next_heap_size};
-use liblumen_alloc::erts::process::{Priority, ProcessControlBlock};
+use liblumen_alloc::erts::process::{Priority, Process};
 use liblumen_alloc::erts::term::{Atom, Boxed, Cons, Term, Tuple, TypedTerm};
 use liblumen_alloc::{badarg, ModuleFunctionArity};
 
@@ -57,11 +57,7 @@ pub struct Options {
 }
 
 impl Options {
-    pub fn connect(
-        &self,
-        parent_process: Option<&ProcessControlBlock>,
-        child_process: &ProcessControlBlock,
-    ) {
+    pub fn connect(&self, parent_process: Option<&Process>, child_process: &Process) {
         if self.link {
             parent_process.unwrap().link(child_process)
         }
@@ -77,11 +73,11 @@ impl Options {
     /// placing any frames in the `child_process` returns from this function.
     pub fn spawn(
         &self,
-        parent_process: Option<&ProcessControlBlock>,
+        parent_process: Option<&Process>,
         module: Atom,
         function: Atom,
         arity: u8,
-    ) -> Result<ProcessControlBlock, Alloc> {
+    ) -> Result<Process, Alloc> {
         let priority = self.cascaded_priority(parent_process);
         let module_function_arity = Arc::new(ModuleFunctionArity {
             module,
@@ -90,7 +86,7 @@ impl Options {
         });
         let (heap, heap_size) = self.sized_heap()?;
 
-        let process = ProcessControlBlock::new(
+        let process = Process::new(
             priority,
             parent_process.map(|process| process.pid()),
             Arc::clone(&module_function_arity),
@@ -103,7 +99,7 @@ impl Options {
 
     // Private
 
-    fn cascaded_priority(&self, parent_process: Option<&ProcessControlBlock>) -> Priority {
+    fn cascaded_priority(&self, parent_process: Option<&Process>) -> Priority {
         match self.priority {
             Some(priority) => priority,
             None => match parent_process {

--- a/lumen_runtime/src/run.rs
+++ b/lumen_runtime/src/run.rs
@@ -1,13 +1,13 @@
 use alloc::sync::Arc;
 
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 
 pub mod queues;
 
 /// What to run
 pub enum Run {
     /// Run the process now
-    Now(Arc<ProcessControlBlock>),
+    Now(Arc<Process>),
     /// There was a process in the queue, but it needs to be delayed because it is `Priority::Low`
     /// and hadn't been delayed enough yet.  Ask the `RunQueue` again for another process.
     /// -- https://github.com/erlang/otp/blob/fe2b1323a3866ed0a9712e9d12e1f8f84793ec47/erts/emulator/beam/erl_process.c#L9601-L9606

--- a/lumen_runtime/src/run/queues/delayed.rs
+++ b/lumen_runtime/src/run/queues/delayed.rs
@@ -2,7 +2,7 @@ use alloc::collections::vec_deque::VecDeque;
 use alloc::sync::Arc;
 
 use liblumen_alloc::erts::process::Priority;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 
 use crate::run::Run;
 
@@ -14,7 +14,7 @@ pub struct Delayed(VecDeque<DelayedProcess>);
 
 impl Delayed {
     #[cfg(test)]
-    pub fn contains(&self, value: &Arc<ProcessControlBlock>) -> bool {
+    pub fn contains(&self, value: &Arc<Process>) -> bool {
         self.0
             .iter()
             .any(|delayed_process| &delayed_process.arc_process == value)
@@ -40,7 +40,7 @@ impl Delayed {
         }
     }
 
-    pub fn enqueue(&mut self, arc_process: Arc<ProcessControlBlock>) {
+    pub fn enqueue(&mut self, arc_process: Arc<Process>) {
         let delayed_process = DelayedProcess::new(arc_process);
         self.0.push_back(delayed_process);
     }
@@ -51,11 +51,11 @@ type Delay = u8;
 #[derive(Debug)]
 struct DelayedProcess {
     delay: Delay,
-    arc_process: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 }
 
 impl DelayedProcess {
-    fn new(arc_process: Arc<ProcessControlBlock>) -> DelayedProcess {
+    fn new(arc_process: Arc<Process>) -> DelayedProcess {
         DelayedProcess {
             delay: Self::priority_to_delay(arc_process.priority),
             arc_process,

--- a/lumen_runtime/src/run/queues/immediate.rs
+++ b/lumen_runtime/src/run/queues/immediate.rs
@@ -1,17 +1,17 @@
 use alloc::collections::vec_deque::VecDeque;
 use alloc::sync::Arc;
 
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 
 use crate::run::Run;
 
 /// A run queue where the `Arc<Process>` is run immediately when it is encountered
 #[derive(Debug, Default)]
-pub struct Immediate(VecDeque<Arc<ProcessControlBlock>>);
+pub struct Immediate(VecDeque<Arc<Process>>);
 
 impl Immediate {
     #[cfg(test)]
-    pub fn contains(&self, value: &Arc<ProcessControlBlock>) -> bool {
+    pub fn contains(&self, value: &Arc<Process>) -> bool {
         self.0.contains(value)
     }
 
@@ -26,7 +26,7 @@ impl Immediate {
         }
     }
 
-    pub fn enqueue(&mut self, process: Arc<ProcessControlBlock>) {
+    pub fn enqueue(&mut self, process: Arc<Process>) {
         self.0.push_back(process);
     }
 }

--- a/lumen_runtime/src/scheduler.rs
+++ b/lumen_runtime/src/scheduler.rs
@@ -14,7 +14,7 @@ use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::Code;
 #[cfg(test)]
 use liblumen_alloc::erts::process::Priority;
-use liblumen_alloc::erts::process::{ProcessControlBlock, Status};
+use liblumen_alloc::erts::process::{Process, Status};
 pub use liblumen_alloc::erts::scheduler::{id, ID};
 use liblumen_alloc::erts::term::{reference, Atom, Reference, Term};
 
@@ -28,7 +28,7 @@ pub trait Scheduled {
     fn scheduler(&self) -> Option<Arc<Scheduler>>;
 }
 
-impl Scheduled for ProcessControlBlock {
+impl Scheduled for Process {
     fn scheduler(&self) -> Option<Arc<Scheduler>> {
         self.scheduler_id()
             .and_then(|scheduler_id| Scheduler::from_id(&scheduler_id))
@@ -121,7 +121,7 @@ impl Scheduler {
                     // Without this check, a process.exit() from outside the process during WAITING
                     // will return to the Frame that called `process.wait()`
                     if !arc_process.is_exiting() {
-                        match ProcessControlBlock::run(&arc_process) {
+                        match Process::run(&arc_process) {
                             Ok(()) => (),
                             Err(exception) => unimplemented!(
                                 "{:?} {:?}\n{:?}",
@@ -164,13 +164,13 @@ impl Scheduler {
     }
 
     #[cfg(test)]
-    pub fn is_run_queued(&self, value: &Arc<ProcessControlBlock>) -> bool {
+    pub fn is_run_queued(&self, value: &Arc<Process>) -> bool {
         self.run_queues.read().contains(value)
     }
 
     /// Returns `true` if `arc_process` was run; otherwise, `false`.
     #[must_use]
-    pub fn run_through(&self, arc_process: &Arc<ProcessControlBlock>) -> bool {
+    pub fn run_through(&self, arc_process: &Arc<Process>) -> bool {
         let ordering = Ordering::SeqCst;
         let reductions_before = arc_process.total_reductions.load(ordering);
 
@@ -188,19 +188,16 @@ impl Scheduler {
         }
     }
 
-    pub fn schedule(
-        self: Arc<Scheduler>,
-        process_control_block: ProcessControlBlock,
-    ) -> Arc<ProcessControlBlock> {
+    pub fn schedule(self: Arc<Scheduler>, process: Process) -> Arc<Process> {
         let mut writable_run_queues = self.run_queues.write();
 
-        process_control_block.schedule_with(self.id);
+        process.schedule_with(self.id);
 
-        let arc_process_control_block = Arc::new(process_control_block);
+        let arc_process = Arc::new(process);
 
-        writable_run_queues.enqueue(Arc::clone(&arc_process_control_block));
+        writable_run_queues.enqueue(Arc::clone(&arc_process));
 
-        arc_process_control_block
+        arc_process
     }
 
     /// Spawns a process with arguments for `apply(module, function, arguments)` on its stack.
@@ -208,12 +205,12 @@ impl Scheduler {
     /// This allows the `apply/3` code to be changed with `apply_3::set_code(code)` to handle new
     /// MFA unique to a given application.
     pub fn spawn_apply_3(
-        parent_process: &ProcessControlBlock,
+        parent_process: &Process,
         options: Options,
         module: Atom,
         function: Atom,
         arguments: Term,
-    ) -> Result<Arc<ProcessControlBlock>, Alloc> {
+    ) -> Result<Arc<Process>, Alloc> {
         let process =
             process::spawn::apply_3(parent_process, options, module, function, arguments)?;
         let arc_scheduler = parent_process.scheduler().unwrap();
@@ -227,13 +224,13 @@ impl Scheduler {
     /// Spawns a process with `arguments` on its stack and `code` run with those arguments instead
     /// of passing through `apply/3`.
     pub fn spawn_code(
-        parent_process: &ProcessControlBlock,
+        parent_process: &Process,
         options: Options,
         module: Atom,
         function: Atom,
         arguments: Vec<Term>,
         code: Code,
-    ) -> Result<Arc<ProcessControlBlock>, Alloc> {
+    ) -> Result<Arc<Process>, Alloc> {
         let process = process::spawn::code(
             Some(parent_process),
             options,
@@ -253,7 +250,7 @@ impl Scheduler {
     pub fn spawn_init(
         self: Arc<Scheduler>,
         minimum_heap_size: usize,
-    ) -> Result<Arc<ProcessControlBlock>, Alloc> {
+    ) -> Result<Arc<Process>, Alloc> {
         let process = process::init(minimum_heap_size)?;
         let arc_process = Arc::new(process);
         let scheduler_arc_process = Arc::clone(&arc_process);
@@ -270,7 +267,7 @@ impl Scheduler {
         Ok(arc_process)
     }
 
-    pub fn stop_waiting(&self, process: &ProcessControlBlock) {
+    pub fn stop_waiting(&self, process: &Process) {
         self.run_queues.write().stop_waiting(process);
     }
 
@@ -344,7 +341,7 @@ lazy_static! {
 #[cfg(test)]
 pub fn with_process<F>(f: F)
 where
-    F: FnOnce(&ProcessControlBlock) -> (),
+    F: FnOnce(&Process) -> (),
 {
     f(&process::test(&process::test_init()))
 }
@@ -352,7 +349,7 @@ where
 #[cfg(test)]
 pub fn with_process_arc<F>(f: F)
 where
-    F: FnOnce(Arc<ProcessControlBlock>) -> (),
+    F: FnOnce(Arc<Process>) -> (),
 {
     f(process::test(&process::test_init()))
 }

--- a/lumen_runtime/src/scheduler/test/spawn_apply_3.rs
+++ b/lumen_runtime/src/scheduler/test/spawn_apply_3.rs
@@ -9,13 +9,11 @@ fn different_processes_have_different_pids() {
     let erlang = Atom::try_from_str("erlang").unwrap();
     let exit = Atom::try_from_str("exit").unwrap();
     let normal = atom_unchecked("normal");
-    let parent_arc_process_control_block = process::test_init();
+    let parent_arc_process = process::test_init();
 
-    let first_process_arguments = parent_arc_process_control_block
-        .list_from_slice(&[normal])
-        .unwrap();
+    let first_process_arguments = parent_arc_process.list_from_slice(&[normal]).unwrap();
     let first_process = Scheduler::spawn_apply_3(
-        &parent_arc_process_control_block,
+        &parent_arc_process,
         Default::default(),
         erlang,
         exit,
@@ -23,9 +21,7 @@ fn different_processes_have_different_pids() {
     )
     .unwrap();
 
-    let second_process_arguments = parent_arc_process_control_block
-        .list_from_slice(&[normal])
-        .unwrap();
+    let second_process_arguments = parent_arc_process.list_from_slice(&[normal]).unwrap();
     let second_process = Scheduler::spawn_apply_3(
         &first_process,
         Default::default(),

--- a/lumen_runtime/src/test.rs
+++ b/lumen_runtime/src/test.rs
@@ -10,14 +10,14 @@ pub mod strategy;
 use std::sync::atomic::AtomicUsize;
 
 use liblumen_alloc::erts::message::{self, Message};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
-pub fn has_no_message(process: &ProcessControlBlock) -> bool {
+pub fn has_no_message(process: &Process) -> bool {
     process.mailbox.lock().borrow().len() == 0
 }
 
-pub fn has_message(process: &ProcessControlBlock, data: Term) -> bool {
+pub fn has_message(process: &Process, data: Term) -> bool {
     process.mailbox.lock().borrow().iter().any(|message| {
         &data
             == match message {
@@ -27,7 +27,7 @@ pub fn has_message(process: &ProcessControlBlock, data: Term) -> bool {
     })
 }
 
-pub fn has_heap_message(process: &ProcessControlBlock, data: Term) -> bool {
+pub fn has_heap_message(process: &Process, data: Term) -> bool {
     process
         .mailbox
         .lock()
@@ -41,7 +41,7 @@ pub fn has_heap_message(process: &ProcessControlBlock, data: Term) -> bool {
         })
 }
 
-pub fn has_process_message(process: &ProcessControlBlock, data: Term) -> bool {
+pub fn has_process_message(process: &Process, data: Term) -> bool {
     process
         .mailbox
         .lock()
@@ -55,15 +55,15 @@ pub fn has_process_message(process: &ProcessControlBlock, data: Term) -> bool {
         })
 }
 
-pub fn monitor_count(process: &ProcessControlBlock) -> usize {
+pub fn monitor_count(process: &Process) -> usize {
     process.monitor_by_reference.lock().len()
 }
 
-pub fn monitored_count(process: &ProcessControlBlock) -> usize {
+pub fn monitored_count(process: &Process) -> usize {
     process.monitored_pid_by_reference.lock().len()
 }
 
-pub fn receive_message(process: &ProcessControlBlock) -> Option<Term> {
+pub fn receive_message(process: &Process) -> Option<Term> {
     process
         .mailbox
         .lock()

--- a/lumen_runtime/src/test/loop.rs
+++ b/lumen_runtime/src/test/loop.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::Atom;
 
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 pub fn function() -> Atom {

--- a/lumen_runtime/src/test/strategy.rs
+++ b/lumen_runtime/src/test/strategy.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use proptest::collection::SizeRange;
 use proptest::strategy::{BoxedStrategy, Just, Strategy};
 
-use liblumen_alloc::erts::{ProcessControlBlock, Term};
+use liblumen_alloc::erts::{Process, Term};
 
 use crate::process;
 
@@ -23,7 +23,7 @@ pub fn byte_vec() -> BoxedStrategy<Vec<u8>> {
     byte_vec::with_size_range(RANGE_INCLUSIVE.into())
 }
 
-pub fn process() -> BoxedStrategy<Arc<ProcessControlBlock>> {
+pub fn process() -> BoxedStrategy<Arc<Process>> {
     Just(process::test_init())
         .prop_flat_map(|init_arc_process| {
             // generated in a prop_flat_map instead of prop_map so that a new process is generated
@@ -33,7 +33,7 @@ pub fn process() -> BoxedStrategy<Arc<ProcessControlBlock>> {
         .boxed()
 }
 
-pub fn term(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn term(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     let container_arc_process = arc_process.clone();
 
     term::leaf(RANGE_INCLUSIVE, arc_process)

--- a/lumen_runtime/src/test/strategy/term/binary.rs
+++ b/lumen_runtime/src/test/strategy/term/binary.rs
@@ -5,7 +5,7 @@ use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Just, Strategy};
 
 use liblumen_alloc::erts::term::Term;
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 use crate::test::strategy::size_range;
 use crate::test::strategy::term::binary::sub::{bit_count, bit_offset, byte_count, byte_offset};
@@ -13,10 +13,7 @@ use crate::test::strategy::term::binary::sub::{bit_count, bit_offset, byte_count
 pub mod heap;
 pub mod sub;
 
-pub fn containing_bytes(
-    byte_vec: Vec<u8>,
-    arc_process: Arc<ProcessControlBlock>,
-) -> BoxedStrategy<Term> {
+pub fn containing_bytes(byte_vec: Vec<u8>, arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         Just(arc_process.binary_from_bytes(&byte_vec).unwrap()),
         sub::containing_bytes(byte_vec, arc_process.clone())
@@ -24,11 +21,11 @@ pub fn containing_bytes(
     .boxed()
 }
 
-pub fn heap(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn heap(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     heap::with_size_range(size_range(), arc_process)
 }
 
-pub fn is_utf8(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn is_utf8(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     any::<String>()
         .prop_flat_map(move |string| {
             containing_bytes(string.as_bytes().to_owned(), arc_process.clone())
@@ -36,7 +33,7 @@ pub fn is_utf8(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
         .boxed()
 }
 
-pub fn sub(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn sub(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     sub::with_size_range(
         byte_offset(),
         bit_offset(),

--- a/lumen_runtime/src/test/strategy/term/binary/heap.rs
+++ b/lumen_runtime/src/test/strategy/term/binary/heap.rs
@@ -4,14 +4,11 @@ use proptest::collection::SizeRange;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
 use liblumen_alloc::erts::term::Term;
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 use crate::test::strategy::byte_vec;
 
-pub fn with_size_range(
-    size_range: SizeRange,
-    arc_process: Arc<ProcessControlBlock>,
-) -> BoxedStrategy<Term> {
+pub fn with_size_range(size_range: SizeRange, arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     byte_vec::with_size_range(size_range)
         .prop_map(move |byte_vec| arc_process.binary_from_bytes(&byte_vec).unwrap())
         .boxed()

--- a/lumen_runtime/src/test/strategy/term/binary/sub.rs
+++ b/lumen_runtime/src/test/strategy/term/binary/sub.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use proptest::strategy::{BoxedStrategy, Just, Strategy};
 
 use liblumen_alloc::erts::term::Term;
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 use crate::test::strategy::{self, bits_to_bytes, size_range};
 
@@ -26,10 +26,7 @@ pub fn byte_offset() -> BoxedStrategy<usize> {
     size_range::strategy()
 }
 
-pub fn containing_bytes(
-    byte_vec: Vec<u8>,
-    arc_process: Arc<ProcessControlBlock>,
-) -> BoxedStrategy<Term> {
+pub fn containing_bytes(byte_vec: Vec<u8>, arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (byte_offset(), bit_offset(), Just(byte_vec))
         .prop_flat_map(|(byte_offset, bit_offset, byte_vec)| {
             let original_bit_len = original_bit_len(byte_offset, bit_offset, byte_vec.len(), 0);
@@ -56,7 +53,7 @@ pub fn containing_bytes(
         .boxed()
 }
 
-pub fn is_binary(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn is_binary(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     with_size_range(
         byte_offset(),
         bit_offset(),
@@ -66,7 +63,7 @@ pub fn is_binary(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
     )
 }
 
-pub fn is_not_binary(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn is_not_binary(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     with_size_range(
         byte_offset(),
         bit_offset(),
@@ -80,7 +77,7 @@ fn original_bit_len(byte_offset: usize, bit_offset: u8, byte_count: usize, bit_c
     byte_offset * 8 + bit_offset as usize + byte_count * 8 + bit_count as usize
 }
 
-pub fn with_bit_count(bit_count: u8, arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn with_bit_count(bit_count: u8, arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     with_size_range(
         byte_offset(),
         bit_offset(),
@@ -95,7 +92,7 @@ pub fn with_size_range(
     bit_offset: BoxedStrategy<u8>,
     byte_count: BoxedStrategy<usize>,
     bit_count: BoxedStrategy<u8>,
-    arc_process: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> BoxedStrategy<Term> {
     let original_arc_process = arc_process.clone();
     let subbinary_arc_process = arc_process.clone();

--- a/lumen_runtime/src/test/strategy/term/binary/sub/is_binary.rs
+++ b/lumen_runtime/src/test/strategy/term/binary/sub/is_binary.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use proptest::strategy::{BoxedStrategy, Strategy};
 
-use liblumen_alloc::erts::{ProcessControlBlock, Term};
+use liblumen_alloc::erts::{Process, Term};
 
 use crate::test::strategy::term::binary::sub::{bit_offset, byte_count, byte_offset};
 
-pub fn is_not_empty(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn is_not_empty(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     super::with_size_range(
         byte_offset(),
         bit_offset(),

--- a/lumen_runtime/src/test/strategy/term/function.rs
+++ b/lumen_runtime/src/test/strategy/term/function.rs
@@ -6,7 +6,7 @@ use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
 use liblumen_alloc::erts::term::{Term, TypedTerm};
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 pub fn module() -> BoxedStrategy<Term> {
     super::atom()
@@ -16,13 +16,13 @@ pub fn function() -> BoxedStrategy<Term> {
     super::atom()
 }
 
-pub fn arity(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn arity(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     arity_usize()
         .prop_map(move |u| arc_process.integer(u).unwrap())
         .boxed()
 }
 
-pub fn arity_or_arguments(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn arity_or_arguments(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![arity(arc_process.clone()), arguments(arc_process)].boxed()
 }
 
@@ -30,11 +30,11 @@ pub fn arity_usize() -> BoxedStrategy<usize> {
     (0_usize..=255_usize).boxed()
 }
 
-pub fn arguments(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn arguments(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     super::list::proper(arc_process)
 }
 
-pub fn is_not_arity_or_arguments(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn is_not_arity_or_arguments(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     super::super::term(arc_process)
         .prop_filter("Arity and argument must be neither an arity (>= 0) or arguments (an empty or non-empty proper list)", |term| match term.to_typed_term().unwrap() {
             TypedTerm::Nil => false,

--- a/lumen_runtime/src/test/strategy/term/index.rs
+++ b/lumen_runtime/src/test/strategy/term/index.rs
@@ -4,18 +4,18 @@ use num_bigint::BigInt;
 
 use proptest::strategy::{BoxedStrategy, Strategy};
 
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Term, TypedTerm};
 
 use crate::test::strategy;
 
-pub fn is_one_based(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn is_one_based(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (1_usize..std::usize::MAX)
         .prop_map(move |u| arc_process.integer(u).unwrap())
         .boxed()
 }
 
-pub fn is_not_one_based(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn is_not_one_based(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     strategy::term(arc_process)
         .prop_filter(
             "Index either must not be an integer or must be an integer <= 1",

--- a/lumen_runtime/src/test/strategy/term/integer.rs
+++ b/lumen_runtime/src/test/strategy/term/integer.rs
@@ -4,12 +4,12 @@ use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
 use liblumen_alloc::erts::term::{SmallInteger, Term};
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 pub mod big;
 pub mod small;
 
-pub fn big(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn big(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         big::negative(arc_process.clone()),
         big::positive(arc_process)
@@ -17,7 +17,7 @@ pub fn big(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
     .boxed()
 }
 
-pub fn negative(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn negative(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         big::negative(arc_process.clone()),
         small::negative(arc_process)
@@ -25,7 +25,7 @@ pub fn negative(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
     .boxed()
 }
 
-pub fn non_negative(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn non_negative(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         small::non_negative(arc_process.clone()),
         big::positive(arc_process)
@@ -33,7 +33,7 @@ pub fn non_negative(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term
     .boxed()
 }
 
-pub fn non_positive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn non_positive(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         big::negative(arc_process.clone()),
         small::non_positive(arc_process)
@@ -41,7 +41,7 @@ pub fn non_positive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term
     .boxed()
 }
 
-pub fn positive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn positive(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![
         small::positive(arc_process.clone()),
         big::positive(arc_process)
@@ -49,7 +49,7 @@ pub fn positive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
     .boxed()
 }
 
-pub fn small(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn small(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (SmallInteger::MIN_VALUE..=SmallInteger::MAX_VALUE)
         .prop_map(move |i| arc_process.integer(i).unwrap())
         .boxed()

--- a/lumen_runtime/src/test/strategy/term/integer/big.rs
+++ b/lumen_runtime/src/test/strategy/term/integer/big.rs
@@ -4,7 +4,7 @@ use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
 use liblumen_alloc::erts::term::{SmallInteger, Term};
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 pub fn isize() -> BoxedStrategy<isize> {
     prop_oneof![
@@ -14,13 +14,13 @@ pub fn isize() -> BoxedStrategy<isize> {
     .boxed()
 }
 
-pub fn negative(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn negative(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (std::isize::MIN..(SmallInteger::MIN_VALUE - 1))
         .prop_map(move |i| arc_process.integer(i).unwrap())
         .boxed()
 }
 
-pub fn positive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn positive(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     ((SmallInteger::MAX_VALUE + 1)..std::isize::MAX)
         .prop_map(move |i| arc_process.integer(i).unwrap())
         .boxed()

--- a/lumen_runtime/src/test/strategy/term/integer/small.rs
+++ b/lumen_runtime/src/test/strategy/term/integer/small.rs
@@ -3,31 +3,31 @@ use std::sync::Arc;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
 use liblumen_alloc::erts::term::{SmallInteger, Term};
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 pub fn isize() -> BoxedStrategy<isize> {
     (SmallInteger::MIN_VALUE..=SmallInteger::MAX_VALUE).boxed()
 }
 
-pub fn negative(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn negative(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (SmallInteger::MIN_VALUE..=-1)
         .prop_map(move |i| arc_process.integer(i).unwrap())
         .boxed()
 }
 
-pub fn non_negative(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn non_negative(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (0..=SmallInteger::MAX_VALUE)
         .prop_map(move |i| arc_process.integer(i).unwrap())
         .boxed()
 }
 
-pub fn non_positive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn non_positive(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (SmallInteger::MIN_VALUE..=0)
         .prop_map(move |i| arc_process.integer(i).unwrap())
         .boxed()
 }
 
-pub fn positive(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn positive(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     (1..=SmallInteger::MAX_VALUE)
         .prop_map(move |i| arc_process.integer(i).unwrap())
         .boxed()

--- a/lumen_runtime/src/test/strategy/term/is_binary.rs
+++ b/lumen_runtime/src/test/strategy/term/is_binary.rs
@@ -4,14 +4,14 @@ use std::sync::Arc;
 use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
-use liblumen_alloc::{ProcessControlBlock, Term};
+use liblumen_alloc::{Process, Term};
 
 use super::binary::sub::{bit_offset, byte_offset};
 use super::binary::{heap, sub};
 
 pub fn with_byte_len_range(
     byte_len_range_inclusive: RangeInclusive<usize>,
-    arc_process: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> BoxedStrategy<Term> {
     prop_oneof![
         heap::with_size_range(byte_len_range_inclusive.clone().into(), arc_process.clone()),

--- a/lumen_runtime/src/test/strategy/term/is_bitstring.rs
+++ b/lumen_runtime/src/test/strategy/term/is_bitstring.rs
@@ -4,14 +4,14 @@ use std::sync::Arc;
 use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
-use liblumen_alloc::{ProcessControlBlock, Term};
+use liblumen_alloc::{Process, Term};
 
 use super::binary::sub::{bit_count, bit_offset, byte_offset};
 use super::binary::{heap, sub};
 
 pub fn with_byte_len_range(
     byte_len_range_inclusive: RangeInclusive<usize>,
-    arc_process: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> BoxedStrategy<Term> {
     prop_oneof![
         heap::with_size_range(byte_len_range_inclusive.clone().into(), arc_process.clone()),

--- a/lumen_runtime/src/test/strategy/term/list.rs
+++ b/lumen_runtime/src/test/strategy/term/list.rs
@@ -4,11 +4,11 @@ use proptest::collection::SizeRange;
 use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Just, Strategy};
 
-use liblumen_alloc::{ProcessControlBlock, Term};
+use liblumen_alloc::{Process, Term};
 
 use crate::test::strategy::{self, NON_EMPTY_RANGE_INCLUSIVE};
 
-pub fn improper(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn improper(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     let size_range: SizeRange = NON_EMPTY_RANGE_INCLUSIVE.into();
 
     (
@@ -25,7 +25,7 @@ pub fn improper(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
 pub fn intermediate(
     element: BoxedStrategy<Term>,
     size_range: SizeRange,
-    arc_process: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> BoxedStrategy<Term> {
     proptest::collection::vec(element, size_range)
         .prop_map(move |vec| match vec.len() {
@@ -42,7 +42,7 @@ pub fn intermediate(
         .boxed()
 }
 
-pub fn non_empty_maybe_improper(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn non_empty_maybe_improper(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     let size_range: SizeRange = NON_EMPTY_RANGE_INCLUSIVE.clone().into();
 
     proptest::collection::vec(strategy::term(arc_process.clone()), size_range)
@@ -59,7 +59,7 @@ pub fn non_empty_maybe_improper(arc_process: Arc<ProcessControlBlock>) -> BoxedS
         .boxed()
 }
 
-pub fn non_empty_proper(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn non_empty_proper(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     let size_range: SizeRange = NON_EMPTY_RANGE_INCLUSIVE.clone().into();
 
     (
@@ -70,6 +70,6 @@ pub fn non_empty_proper(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<
         .boxed()
 }
 
-pub fn proper(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn proper(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     prop_oneof![Just(Term::NIL), non_empty_proper(arc_process)].boxed()
 }

--- a/lumen_runtime/src/test/strategy/term/map.rs
+++ b/lumen_runtime/src/test/strategy/term/map.rs
@@ -4,12 +4,12 @@ use proptest::collection::SizeRange;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
 use liblumen_alloc::erts::term::Term;
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 pub fn intermediate(
     key_or_value: BoxedStrategy<Term>,
     size_range: SizeRange,
-    arc_process: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> BoxedStrategy<Term> {
     proptest::collection::hash_map(key_or_value.clone(), key_or_value, size_range)
         .prop_map(move |mut hash_map| {

--- a/lumen_runtime/src/test/strategy/term/pid.rs
+++ b/lumen_runtime/src/test/strategy/term/pid.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use proptest::strategy::{BoxedStrategy, Strategy};
 
 use liblumen_alloc::erts::term::{make_pid, Pid, Term};
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 pub mod external;
 
-pub fn external(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<Term> {
+pub fn external(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
     let external_pid_arc_process = arc_process.clone();
 
     (external::node_id(), number(), serial())

--- a/lumen_runtime/src/test/strategy/term/tuple.rs
+++ b/lumen_runtime/src/test/strategy/term/tuple.rs
@@ -8,21 +8,19 @@ use proptest::strategy::{BoxedStrategy, Just, Strategy};
 
 use liblumen_alloc::erts::process::alloc::heap_alloc::HeapAlloc;
 use liblumen_alloc::erts::term::{Boxed, Term, Tuple};
-use liblumen_alloc::erts::ProcessControlBlock;
+use liblumen_alloc::erts::Process;
 
 pub fn intermediate(
     element: BoxedStrategy<Term>,
     size_range: SizeRange,
-    arc_process: Arc<ProcessControlBlock>,
+    arc_process: Arc<Process>,
 ) -> BoxedStrategy<Term> {
     proptest::collection::vec(element, size_range)
         .prop_map(move |vec| arc_process.tuple_from_slice(&vec).unwrap())
         .boxed()
 }
 
-pub fn with_index(
-    arc_process: Arc<ProcessControlBlock>,
-) -> BoxedStrategy<(Vec<Term>, usize, Term, Term)> {
+pub fn with_index(arc_process: Arc<Process>) -> BoxedStrategy<(Vec<Term>, usize, Term, Term)> {
     (Just(arc_process), 1_usize..=4_usize)
         .prop_flat_map(|(arc_process, len)| {
             (
@@ -44,7 +42,7 @@ pub fn with_index(
         .boxed()
 }
 
-pub fn without_index(arc_process: Arc<ProcessControlBlock>) -> BoxedStrategy<(Term, Term)> {
+pub fn without_index(arc_process: Arc<Process>) -> BoxedStrategy<(Term, Term)> {
     (super::tuple(arc_process.clone()), super::super::term(arc_process.clone()))
         .prop_filter("Index either needs to not be an integer or not be an integer in the index range 1..=len", |(tuple, index)| {
             let index_big_int_result: std::result::Result<BigInt, _> = (*index).try_into();

--- a/lumen_runtime/src/time.rs
+++ b/lumen_runtime/src/time.rs
@@ -6,7 +6,7 @@ use num_traits::Zero;
 use liblumen_alloc::erts::exception::runtime::Exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::term::{atom_unchecked, Term, TypedTerm};
-use liblumen_alloc::{badarg, ProcessControlBlock};
+use liblumen_alloc::{badarg, Process};
 
 pub mod monotonic;
 
@@ -61,9 +61,9 @@ impl Unit {
         }
     }
 
-    pub fn to_term(&self, process_control_block: &ProcessControlBlock) -> Result<Term, Alloc> {
+    pub fn to_term(&self, process: &Process) -> Result<Term, Alloc> {
         match self {
-            Unit::Hertz(hertz) => process_control_block.integer(*hertz),
+            Unit::Hertz(hertz) => process.integer(*hertz),
             Unit::Second => Ok(atom_unchecked("second")),
             Unit::Millisecond => Ok(atom_unchecked("millisecond")),
             Unit::Microsecond => Ok(atom_unchecked("microsecond")),

--- a/lumen_web/src/document/body_1.rs
+++ b/lumen_web/src/document/body_1.rs
@@ -4,7 +4,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -18,7 +18,7 @@ use crate::option_to_ok_tuple_or_error;
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
 ) -> Result<(), Alloc> {
@@ -30,7 +30,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let document = arc_process.stack_pop().unwrap();
@@ -39,7 +39,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(body) => {
             arc_process.return_from_call(body)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -61,7 +61,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, document: Term) -> exception::Result {
+fn native(process: &Process, document: Term) -> exception::Result {
     let document_document = document_from_term(document)?;
 
     option_to_ok_tuple_or_error(process, document_document.body()).map_err(|error| error.into())

--- a/lumen_web/src/document/create_element_2.rs
+++ b/lumen_web/src/document/create_element_2.rs
@@ -5,7 +5,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -19,7 +19,7 @@ use crate::{error, ok_tuple};
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     tag: Term,
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let document = arc_process.stack_pop().unwrap();
@@ -43,7 +43,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_or_error) => {
             arc_process.return_from_call(ok_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -65,7 +65,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, document: Term, tag: Term) -> exception::Result {
+fn native(process: &Process, document: Term, tag: Term) -> exception::Result {
     let document_document = document_from_term(document)?;
     let tag_string: String = tag.try_into()?;
 

--- a/lumen_web/src/document/create_text_node_2.rs
+++ b/lumen_web/src/document/create_text_node_2.rs
@@ -5,7 +5,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -15,7 +15,7 @@ use crate::document::document_from_term;
 /// text = Lumen.Web.Document.create_text_node(document, data)
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     data: Term,
@@ -29,7 +29,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let document = arc_process.stack_pop().unwrap();
@@ -39,7 +39,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_or_error) => {
             arc_process.return_from_call(ok_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -61,7 +61,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, document: Term, data: Term) -> exception::Result {
+fn native(process: &Process, document: Term, data: Term) -> exception::Result {
     let document_document = document_from_term(document)?;
     let data_string: String = data.try_into()?;
 

--- a/lumen_web/src/document/get_element_by_id_2.rs
+++ b/lumen_web/src/document/get_element_by_id_2.rs
@@ -5,7 +5,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -19,7 +19,7 @@ use crate::option_to_ok_tuple_or_error;
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     id: Term,
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let document = arc_process.stack_pop().unwrap();
@@ -43,7 +43,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_tuple_or_error) => {
             arc_process.return_from_call(ok_tuple_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -65,7 +65,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, document: Term, id: Term) -> exception::Result {
+fn native(process: &Process, document: Term, id: Term) -> exception::Result {
     let document_document = document_from_term(document)?;
     let id_string: String = id.try_into()?;
 

--- a/lumen_web/src/document/new_0.rs
+++ b/lumen_web/src/document/new_0.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::Atom;
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -18,20 +18,20 @@ use crate::{error, ok_tuple};
 ///    :error -> ...
 /// end
 /// ```
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     match native(arc_process) {
         Ok(ok_tuple_or_error) => {
             arc_process.return_from_call(ok_tuple_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -53,7 +53,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock) -> exception::Result {
+fn native(process: &Process) -> exception::Result {
     match web_sys::Document::new() {
         Ok(document) => ok_tuple(process, Box::new(document)).map_err(|error| error.into()),
         // Not sure how this can happen

--- a/lumen_web/src/element/class_name_1.rs
+++ b/lumen_web/src/element/class_name_1.rs
@@ -4,7 +4,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -14,7 +14,7 @@ use crate::element;
 /// class_name = Lumen.Web.Element.class_name(element)
 /// ``
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     element: Term,
 ) -> Result<(), Alloc> {
@@ -26,7 +26,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let element = arc_process.stack_pop().unwrap();
@@ -35,7 +35,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok) => {
             arc_process.return_from_call(ok)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -57,7 +57,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, element_term: Term) -> exception::Result {
+fn native(process: &Process, element_term: Term) -> exception::Result {
     let element = element::from_term(element_term)?;
     let class_name_binary = process.binary_from_str(&element.class_name())?;
 

--- a/lumen_web/src/element/remove_1.rs
+++ b/lumen_web/src/element/remove_1.rs
@@ -4,7 +4,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -17,7 +17,7 @@ use crate::{element, ok};
 /// end
 /// ``
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     element: Term,
 ) -> Result<(), Alloc> {
@@ -29,7 +29,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let element = arc_process.stack_pop().unwrap();
@@ -38,7 +38,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok) => {
             arc_process.return_from_call(ok)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_web/src/element/set_attribute_3.rs
+++ b/lumen_web/src/element/set_attribute_3.rs
@@ -5,7 +5,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -18,7 +18,7 @@ use crate::{element, error, ok};
 /// end
 /// ``
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     element: Term,
     attribute: Term,
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let element = arc_process.stack_pop().unwrap();
@@ -45,7 +45,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_or_error) => {
             arc_process.return_from_call(ok_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -67,12 +67,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(
-    process: &ProcessControlBlock,
-    element_term: Term,
-    name: Term,
-    value: Term,
-) -> exception::Result {
+fn native(process: &Process, element_term: Term, name: Term, value: Term) -> exception::Result {
     let element = element::from_term(element_term)?;
 
     let name_string: String = name.try_into()?;

--- a/lumen_web/src/event/target_1.rs
+++ b/lumen_web/src/event/target_1.rs
@@ -4,7 +4,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -16,7 +16,7 @@ use crate::{error, event, ok};
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     event: Term,
 ) -> Result<(), Alloc> {
@@ -28,7 +28,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let event = arc_process.stack_pop().unwrap();
@@ -37,7 +37,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_event_target_or_error) => {
             arc_process.return_from_call(ok_event_target_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -59,7 +59,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, event_term: Term) -> exception::Result {
+fn native(process: &Process, event_term: Term) -> exception::Result {
     let event = event::from_term(event_term)?;
 
     match event.target() {

--- a/lumen_web/src/html_form_element/element_2.rs
+++ b/lumen_web/src/html_form_element/element_2.rs
@@ -9,7 +9,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -22,7 +22,7 @@ use crate::{error, html_form_element, ok};
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     html_form_element: Term,
     name: Term,
@@ -36,7 +36,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let html_form_element = arc_process.stack_pop().unwrap();
@@ -46,7 +46,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_html_input_element_or_error) => {
             arc_process.return_from_call(ok_html_input_element_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -68,11 +68,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(
-    process: &ProcessControlBlock,
-    html_form_element_term: Term,
-    name: Term,
-) -> exception::Result {
+fn native(process: &Process, html_form_element_term: Term, name: Term) -> exception::Result {
     let html_form_element_term = html_form_element::from_term(html_form_element_term)?;
     let name_string: String = name.try_into()?;
 

--- a/lumen_web/src/html_input_element/value_1.rs
+++ b/lumen_web/src/html_input_element/value_1.rs
@@ -4,7 +4,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -14,7 +14,7 @@ use crate::html_input_element;
 /// value_string = Lumen.Web.HTMLInputElement.value(html_input_element)
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     html_input_element: Term,
 ) -> Result<(), Alloc> {
@@ -26,7 +26,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let html_input_element = arc_process.stack_pop().unwrap();
@@ -35,7 +35,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(body) => {
             arc_process.return_from_call(body)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -57,7 +57,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, html_input_element_term: Term) -> exception::Result {
+fn native(process: &Process, html_input_element_term: Term) -> exception::Result {
     let html_input_element = html_input_element::from_term(html_input_element_term)?;
     let value_string = html_input_element.value();
 

--- a/lumen_web/src/lib.rs
+++ b/lumen_web/src/lib.rs
@@ -21,7 +21,7 @@ use web_sys::Window;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::Placement;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 
 use lumen_runtime::scheduler::Scheduler;
@@ -70,7 +70,7 @@ fn ok() -> Term {
     atom_unchecked("ok")
 }
 
-fn ok_tuple(process: &ProcessControlBlock, value: Box<dyn Any>) -> Result<Term, Alloc> {
+fn ok_tuple(process: &Process, value: Box<dyn Any>) -> Result<Term, Alloc> {
     let ok = ok();
     let resource_term = process.resource(value)?;
 
@@ -78,7 +78,7 @@ fn ok_tuple(process: &ProcessControlBlock, value: Box<dyn Any>) -> Result<Term, 
 }
 
 fn option_to_ok_tuple_or_error<T: 'static>(
-    process: &ProcessControlBlock,
+    process: &Process,
     option: Option<T>,
 ) -> Result<Term, Alloc> {
     match option {

--- a/lumen_web/src/math/random_integer_1.rs
+++ b/lumen_web/src/math/random_integer_1.rs
@@ -5,7 +5,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -15,7 +15,7 @@ use liblumen_alloc::erts::ModuleFunctionArity;
 /// random_integer = Lumen.Web.Math.random_integer(exclusive_max)
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     exclusive_max: Term,
 ) -> Result<(), Alloc> {
@@ -27,7 +27,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let exclusive_max = arc_process.stack_pop().unwrap();
@@ -36,7 +36,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(random_integer) => {
             arc_process.return_from_call(random_integer)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -58,7 +58,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, exclusive_max: Term) -> exception::Result {
+fn native(process: &Process, exclusive_max: Term) -> exception::Result {
     let exclusive_max_usize: usize = exclusive_max.try_into()?;
     let exclusive_max_f64 = exclusive_max_usize as f64;
     let random_usize = (js_sys::Math::random() * exclusive_max_f64).trunc() as usize;

--- a/lumen_web/src/node/append_child_2.rs
+++ b/lumen_web/src/node/append_child_2.rs
@@ -5,7 +5,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -32,7 +32,7 @@ use crate::ok;
 /// Lumen.Web.Node.append_child(element_with_id, div)
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     parent: Term,
     child: Term,
@@ -46,7 +46,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let parent = arc_process.stack_pop().unwrap();
@@ -56,7 +56,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok) => {
             arc_process.return_from_call(ok)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_web/src/node/insert_before_3.rs
+++ b/lumen_web/src/node/insert_before_3.rs
@@ -8,7 +8,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -29,7 +29,7 @@ use crate::{error, ok_tuple};
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     parent: Term,
     new_child: Term,
@@ -45,7 +45,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let parent = arc_process.stack_pop().unwrap();
@@ -56,7 +56,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_or_error_tuple) => {
             arc_process.return_from_call(ok_or_error_tuple)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -79,7 +79,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
 }
 
 fn native(
-    process: &ProcessControlBlock,
+    process: &Process,
     parent: Term,
     new_child: Term,
     reference_child: Term,

--- a/lumen_web/src/node/replace_child_3.rs
+++ b/lumen_web/src/node/replace_child_3.rs
@@ -8,7 +8,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -29,7 +29,7 @@ use crate::{error, ok_tuple};
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     parent: Term,
     new_child: Term,
@@ -45,7 +45,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let parent = arc_process.stack_pop().unwrap();
@@ -56,7 +56,7 @@ pub fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_or_error_tuple) => {
             arc_process.return_from_call(ok_or_error_tuple)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -78,12 +78,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(
-    process: &ProcessControlBlock,
-    parent: Term,
-    old_child: Term,
-    new_child: Term,
-) -> exception::Result {
+fn native(process: &Process, parent: Term, old_child: Term, new_child: Term) -> exception::Result {
     let parent_node = node_from_term(parent)?;
     let old_child_node = node_from_term(old_child)?;
     let new_child_node = node_from_term(new_child)?;

--- a/lumen_web/src/window.rs
+++ b/lumen_web/src/window.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::JsCast;
 use web_sys::{Event, EventTarget, Window};
 
 use liblumen_alloc::erts::exception::system::Alloc;
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 
 use lumen_runtime::process::spawn::options::Options;
@@ -25,7 +25,7 @@ pub fn add_event_listener<F>(
     options: Options,
     place_frame_with_arguments: F,
 ) where
-    F: Fn(&ProcessControlBlock, Term) -> Result<(), Alloc> + 'static,
+    F: Fn(&Process, Term) -> Result<(), Alloc> + 'static,
 {
     let f = Rc::new(RefCell::new(None));
     let g = f.clone();

--- a/lumen_web/src/window/add_event_listener_5.rs
+++ b/lumen_web/src/window/add_event_listener_5.rs
@@ -8,7 +8,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, resource, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -24,7 +24,7 @@ use crate::window::add_event_listener;
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     window: Term,
     event: Term,
@@ -42,7 +42,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let window = arc_process.stack_pop().unwrap();
@@ -54,7 +54,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_or_error) => {
             arc_process.return_from_call(ok_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }

--- a/lumen_web/src/window/document_1.rs
+++ b/lumen_web/src/window/document_1.rs
@@ -8,7 +8,7 @@ use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
 use liblumen_alloc::erts::process::code::{self, result_from_exception};
-use liblumen_alloc::erts::process::ProcessControlBlock;
+use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{resource, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -21,7 +21,7 @@ use crate::option_to_ok_tuple_or_error;
 /// end
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     window: Term,
 ) -> Result<(), Alloc> {
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let window = arc_process.stack_pop().unwrap();
@@ -42,7 +42,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         Ok(ok_tuple_or_error) => {
             arc_process.return_from_call(ok_tuple_or_error)?;
 
-            ProcessControlBlock::call_code(arc_process)
+            Process::call_code(arc_process)
         }
         Err(exception) => result_from_exception(arc_process, exception),
     }
@@ -64,7 +64,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
     })
 }
 
-fn native(process: &ProcessControlBlock, window: Term) -> exception::Result {
+fn native(process: &Process, window: Term) -> exception::Result {
     let window_reference: resource::Reference = window.try_into()?;
     let window_window: &Window = window_reference.downcast_ref().ok_or_else(|| badarg!())?;
     let option_document = window_window.document();

--- a/lumen_web/src/window/on_submit_1.rs
+++ b/lumen_web/src/window/on_submit_1.rs
@@ -7,7 +7,7 @@ use web_sys::{Event, HtmlFormElement};
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, resource, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
@@ -23,7 +23,7 @@ use crate::error;
 /// :ok = Lumen.Web.Window.on_submit(event)
 /// ```
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     event: Term,
 ) -> Result<(), Alloc> {
@@ -35,7 +35,7 @@ pub fn place_frame_with_arguments(
 
 // Private
 
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let event = arc_process.stack_pop().unwrap();
@@ -88,7 +88,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         }
     }
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/document/body_1/with_body/label_1.rs
+++ b/lumen_web/tests/web/document/body_1/with_body/label_1.rs
@@ -2,13 +2,13 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_2;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -24,7 +24,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 /// body_tuple = Lumen.Web.Document.body(document)
 /// Lumen.Web.Wait.with_return(body_tuple)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_window = arc_process.stack_pop().unwrap();
@@ -46,7 +46,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         window,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/document/body_1/with_body/label_2.rs
+++ b/lumen_web/tests/web/document/body_1/with_body/label_2.rs
@@ -2,11 +2,11 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -21,7 +21,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 /// body_tuple = Lumen.Web.Document.body(document)
 /// Lumen.Web:.Wait.with_return(body_tuple)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_document = arc_process.stack_pop().unwrap();
@@ -42,7 +42,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         document,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/document/body_1/without_body/label_1.rs
+++ b/lumen_web/tests/web/document/body_1/without_body/label_1.rs
@@ -2,11 +2,11 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -21,7 +21,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 /// body_tuple = Lumen.Web.Document.body(document)
 /// Lumen.Web.Wait.with_return(body_tuple)
 /// ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_document = arc_process.stack_pop().unwrap();
@@ -42,7 +42,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         document,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/element/class_name_1/label_1.rs
+++ b/lumen_web/tests/web/element/class_name_1/label_1.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, resource, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -10,7 +10,7 @@ use web_sys::Window;
 
 use super::label_2;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -27,7 +27,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // class_name = Lumen.Web.Element.class_name(body)
 // Lumen.Web.Wait.with_return(class_name)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_window = arc_process.stack_pop().unwrap();
@@ -50,7 +50,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         window,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/element/class_name_1/label_2.rs
+++ b/lumen_web/tests/web/element/class_name_1/label_2.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, resource, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -10,7 +10,7 @@ use web_sys::Document;
 
 use super::label_3;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -26,7 +26,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // class_name = Lumen.Web.Element.class_name(body)
 // Lumen.Web.Wait.with_return(class_name)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_document = arc_process.stack_pop().unwrap();
@@ -49,7 +49,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         document,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/element/class_name_1/label_3.rs
+++ b/lumen_web/tests/web/element/class_name_1/label_3.rs
@@ -2,11 +2,11 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -21,7 +21,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // class_name = Lumen.Web.Element.class_name(body)
 // Lumen.Web.Wait.with_return(class_name)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_body = arc_process.stack_pop().unwrap();
@@ -38,7 +38,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         body,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/element/remove_1/removes_element/label_1.rs
+++ b/lumen_web/tests/web/element/remove_1/removes_element/label_1.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, resource, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -10,7 +10,7 @@ use web_sys::Window;
 
 use super::label_2;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -29,7 +29,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // :ok = Lumen.Web.Element.remove(child);
 // Lumen.Web.Wait.with_return(body_tuple)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_window = arc_process.stack_pop().unwrap();
@@ -52,7 +52,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         window,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/element/remove_1/removes_element/label_2.rs
+++ b/lumen_web/tests/web/element/remove_1/removes_element/label_2.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, resource, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -10,7 +10,7 @@ use web_sys::Document;
 
 use super::label_3;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -28,7 +28,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // :ok = Lumen.Web.Element.remove(child);
 // Lumen.Web.Wait.with_return(body_tuple)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_document = arc_process.stack_pop().unwrap();
@@ -51,7 +51,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         document,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/element/remove_1/removes_element/label_3.rs
+++ b/lumen_web/tests/web/element/remove_1/removes_element/label_3.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_4;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
 ) -> Result<(), Alloc> {
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 // remove_ok = Lumen.Web.Element.remove(child);
 // Lumen.Web.Wait.with_return(remove_ok)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_body = arc_process.stack_pop().unwrap();
@@ -58,7 +58,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         child_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/element/remove_1/removes_element/label_4.rs
+++ b/lumen_web/tests/web/element/remove_1/removes_element/label_4.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, resource, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -12,7 +12,7 @@ use web_sys::Element;
 use super::label_5;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     body: Term,
 ) -> Result<(), Alloc> {
@@ -35,7 +35,7 @@ pub fn place_frame_with_arguments(
 // remove_ok = Lumen.Web.Element.remove(child);
 // Lumen.Web.Wait.with_return(remove_ok)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_child = arc_process.stack_pop().unwrap();
@@ -63,7 +63,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/element/remove_1/removes_element/label_5.rs
+++ b/lumen_web/tests/web/element/remove_1/removes_element/label_5.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     child: Term,
 ) -> Result<(), Alloc> {
@@ -29,7 +29,7 @@ pub fn place_frame_with_arguments(
 // remove_ok = Lumen.Web.Element.remove(child);
 // Lumen.Web.Wait.with_return(remove_ok)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -44,7 +44,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_1.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_1.rs
@@ -2,13 +2,13 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_2;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -27,7 +27,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, nil)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_document = arc_process.stack_pop().unwrap();
@@ -52,7 +52,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         existing_child_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_2.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_2.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_3;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
 ) -> Result<(), Alloc> {
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, nil)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_existing_child = arc_process.stack_pop().unwrap();
@@ -62,7 +62,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         parent_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_3.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_3.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_4;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     existing_child: Term,
@@ -35,7 +35,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, nil)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_parent = arc_process.stack_pop().unwrap();
@@ -70,7 +70,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         parent,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_4.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_4.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, resource, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
@@ -12,7 +12,7 @@ use web_sys::Element;
 use super::label_5;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     parent: Term,
@@ -38,7 +38,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, nil)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -63,7 +63,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         existing_child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_5.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_5.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_6;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     parent: Term,
@@ -32,7 +32,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, nil)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -54,7 +54,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         new_child_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_6.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_nil_reference_child_appends_new_child/label_6.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     parent: Term,
 ) -> Result<(), Alloc> {
@@ -29,7 +29,7 @@ pub fn place_frame_with_arguments(
 // # returns: {:ok, inserted_child}
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, nil)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_new_child = arc_process.stack_pop().unwrap();
@@ -56,7 +56,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         reference_child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_1.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_1.rs
@@ -2,13 +2,13 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_2;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -27,7 +27,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, reference_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_document = arc_process.stack_pop().unwrap();
@@ -52,7 +52,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         reference_child_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_2.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_2.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_3;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
 ) -> Result<(), Alloc> {
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, reference_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_reference_child = arc_process.stack_pop().unwrap();
@@ -67,7 +67,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         parent_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_3.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_3.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_4;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     reference_child: Term,
@@ -35,7 +35,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, reference_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_parent = arc_process.stack_pop().unwrap();
@@ -71,7 +71,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         parent,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_4.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_4.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_5;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     parent: Term,
@@ -35,7 +35,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, reference_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -65,7 +65,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         reference_child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_5.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_5.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_6;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     parent: Term,
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, reference_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -59,7 +59,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         new_child_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_6.rs
+++ b/lumen_web/tests/web/node/insert_before_3/with_reference_child_inserts_before_reference_child/label_6.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     parent: Term,
     reference_child: Term,
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 // # returns: {:ok, inserted_child}
 // {:ok, inserted_child} = Lumen.Web.insert_before(parent, new_child, reference_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_new_child = arc_process.stack_pop().unwrap();
@@ -60,7 +60,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         reference_child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_is_parent_returns_error_hierarchy_request/label_1.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_is_parent_returns_error_hierarchy_request/label_1.rs
@@ -2,13 +2,13 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_2;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -25,7 +25,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // :ok = Lumen.Web.Node.append_child(parent, old_child)
 // {:error, :hierarchy_request} = Lumen.Web.replace_child(parent, old_child, parent)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_document = arc_process.stack_pop().unwrap();
@@ -50,7 +50,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         old_child_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_is_parent_returns_error_hierarchy_request/label_2.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_is_parent_returns_error_hierarchy_request/label_2.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_3;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
 ) -> Result<(), Alloc> {
@@ -32,7 +32,7 @@ pub fn place_frame_with_arguments(
 // :ok = Lumen.Web.Node.append_child(parent, old_child)
 // {:error, :hierarchy_request} = Lumen.Web.replace_child(parent, old_child, parent)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_old_child = arc_process.stack_pop().unwrap();
@@ -60,7 +60,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         parent_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_is_parent_returns_error_hierarchy_request/label_3.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_is_parent_returns_error_hierarchy_request/label_3.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_4;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     old_child: Term,
 ) -> Result<(), Alloc> {
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 // :ok = Lumen.Web.Node.append_child(parent, old_child)
 // {:error, :hierarchy_request} = Lumen.Web.replace_child(parent, old_child, parent)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_parent = arc_process.stack_pop().unwrap();
@@ -58,7 +58,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         old_child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_is_parent_returns_error_hierarchy_request/label_4.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_is_parent_returns_error_hierarchy_request/label_4.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     parent: Term,
     old_child: Term,
@@ -29,7 +29,7 @@ pub fn place_frame_with_arguments(
 // # returns: {:error, :hierarchy_request}
 // {:error, :hierarchy_request} = Lumen.Web.replace_child(parent, old_child, parent)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -47,7 +47,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         old_child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_1.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_1.rs
@@ -2,13 +2,13 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_2;
 
-pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
+pub fn place_frame(process: &Process, placement: Placement) {
     process.place_frame(frame(), placement);
 }
 
@@ -26,7 +26,7 @@ pub fn place_frame(process: &ProcessControlBlock, placement: Placement) {
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, replaced_child} = Lumen.Web.replace_child(parent, new_child, old_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_parent_document = arc_process.stack_pop().unwrap();
@@ -51,7 +51,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         old_child_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_2.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_2.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_3;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
 ) -> Result<(), Alloc> {
@@ -33,7 +33,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, replaced_child} = Lumen.Web.replace_child(parent, new_child, old_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_old_child = arc_process.stack_pop().unwrap();
@@ -61,7 +61,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         parent_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_3.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_3.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_4;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     old_child: Term,
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, replaced_child} = Lumen.Web.replace_child(parent, new_child, old_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_parent = arc_process.stack_pop().unwrap();
@@ -70,7 +70,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         old_child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_4.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_4.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Term};
 use liblumen_alloc::ModuleFunctionArity;
 
 use super::label_5;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     document: Term,
     parent: Term,
@@ -34,7 +34,7 @@ pub fn place_frame_with_arguments(
 // {:ok, new_child} = Lumen.Web.Document.create_element(document, "ul");
 // {:ok, replaced_child} = Lumen.Web.replace_child(parent, new_child, old_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok = arc_process.stack_pop().unwrap();
@@ -59,7 +59,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         new_child_tag,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {

--- a/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_5.rs
+++ b/lumen_web/tests/web/node/replace_child_3/with_new_child_returns_ok_replaced_child/label_5.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
-use liblumen_alloc::erts::process::{code, ProcessControlBlock};
+use liblumen_alloc::erts::process::{code, Process};
 use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Term, Tuple};
 
 use liblumen_alloc::ModuleFunctionArity;
 
 pub fn place_frame_with_arguments(
-    process: &ProcessControlBlock,
+    process: &Process,
     placement: Placement,
     parent: Term,
     old_child: Term,
@@ -31,7 +31,7 @@ pub fn place_frame_with_arguments(
 // # returns: {:ok, replaced_child}
 // {:ok, replaced_child} = Lumen.Web.replace_child(parent, new_child, old_child)
 // ```
-fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
+fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_new_child = arc_process.stack_pop().unwrap();
@@ -60,7 +60,7 @@ fn code(arc_process: &Arc<ProcessControlBlock>) -> code::Result {
         old_child,
     )?;
 
-    ProcessControlBlock::call_code(arc_process)
+    Process::call_code(arc_process)
 }
 
 fn frame() -> Frame {


### PR DESCRIPTION
Resolves #270

# Changelog
## Enhancements
* Rename `ProcessControlBlock` to `Process` since there is no non-control block code.
  * Rename any `process_control_block` parameter/argument to `process` too.

## Incompatible Changes
* `ProcessControlBlock` -> `Process