### PR TITLE
Implement :maps.keys/1

### DIFF
--- a/liblumen_alloc/src/erts/term/map.rs
+++ b/liblumen_alloc/src/erts/term/map.rs
@@ -47,6 +47,10 @@ impl Map {
         self.value.contains_key(&key)
     }
 
+    pub fn keys(&self) -> Vec<Term> {
+        self.value.keys().into_iter().copied().collect()
+    }
+
     pub fn len(&self) -> usize {
         self.value.len()
     }

--- a/lumen_runtime/src/otp/maps.rs
+++ b/lumen_runtime/src/otp/maps.rs
@@ -1,5 +1,6 @@
 pub mod get_3;
 pub mod is_key_2;
+pub mod keys_1;
 pub mod merge_2;
 
 use liblumen_alloc::erts::term::Atom;

--- a/lumen_runtime/src/otp/maps/keys_1.rs
+++ b/lumen_runtime/src/otp/maps/keys_1.rs
@@ -1,0 +1,78 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use std::convert::TryInto;
+use std::sync::Arc;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::exception::system::Alloc;
+use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
+use liblumen_alloc::erts::process::code::{self, result_from_exception};
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::{Atom, Boxed, Map, Term};
+use liblumen_alloc::{badmap, ModuleFunctionArity};
+
+pub fn place_frame_with_arguments(
+    process: &Process,
+    placement: Placement,
+    map: Term,
+) -> Result<(), Alloc> {
+    process.stack_push(map)?;
+    process.place_frame(frame(), placement);
+
+    Ok(())
+}
+
+// Crate Public
+
+pub(in crate::otp) fn code(arc_process: &Arc<Process>) -> code::Result {
+    arc_process.reduce();
+
+    let map = arc_process.stack_pop().unwrap();
+
+    match native(arc_process, map) {
+        Ok(keys) => {
+            arc_process.return_from_call(keys)?;
+
+            Process::call_code(arc_process)
+        }
+        Err(exception) => result_from_exception(arc_process, exception),
+    }
+}
+
+// Private
+
+fn frame() -> Frame {
+    Frame::new(module_function_arity(), code)
+}
+
+fn function() -> Atom {
+    Atom::try_from_str("keys").unwrap()
+}
+
+fn module_function_arity() -> Arc<ModuleFunctionArity> {
+    Arc::new(ModuleFunctionArity {
+        module: super::module(),
+        function: function(),
+        arity: 1,
+    })
+}
+
+fn native(process: &Process, map: Term) -> exception::Result {
+    let result_map: Result<Boxed<Map>, _> = map.try_into();
+
+    match result_map {
+        Ok(map) => {
+            let keys = map.keys();
+            let list = process.list_from_slice(&keys)?;
+
+            Ok(list)
+        }
+
+        Err(_) => Err(badmap!(process, map)),
+    }
+}

--- a/lumen_runtime/src/otp/maps/keys_1/test.rs
+++ b/lumen_runtime/src/otp/maps/keys_1/test.rs
@@ -1,0 +1,30 @@
+mod with_map;
+
+use proptest::prop_assert_eq;
+use proptest::strategy::Strategy;
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badmap;
+
+use crate::otp::maps::keys_1::native;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_map_errors_badmap() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(strategy::term::is_not_map(arc_process.clone())),
+                |non_map| {
+                    prop_assert_eq!(
+                        native(&arc_process, non_map),
+                        Err(badmap!(&arc_process, non_map))
+                    );
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/maps/keys_1/test/with_map.rs
+++ b/lumen_runtime/src/otp/maps/keys_1/test/with_map.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+use liblumen_alloc::erts::term::atom_unchecked;
+use liblumen_alloc::Term;
+
+#[test]
+fn returns_empty_list_of_keys() {
+    with_process_arc(|arc_process| {
+        let empty_map = arc_process.map_from_slice(&[]).unwrap();
+
+        assert_eq!(native(&arc_process, empty_map), Ok(Term::NIL));
+    });
+}
+
+#[test]
+fn returns_list_of_keys() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(strategy::term(arc_process.clone())).prop_map(|key| {
+                    let value = atom_unchecked("value");
+
+                    (
+                        arc_process.list_from_slice(&[key]).unwrap(),
+                        arc_process.map_from_slice(&[(key, value)]).unwrap(),
+                    )
+                }),
+                |(keys, map)| {
+                    prop_assert_eq!(native(&arc_process, map), Ok(keys));
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}


### PR DESCRIPTION
This resolves https://github.com/lumen/lumen/issues/249

I'm not entirely sure if I've done this right, but my (admittedly weak) property tests pass. I haven't coded Rust before, so it's likely that this isn't very idiomatic. I'm happy to receive any feedback, no matter how nitpicky it is :)

I also wasn't sure whether I was supposed to register this BIF in `liblumen_eir_interpreter`. Doing so would require making the `native` function public in the BIF, which seems to go against how most of the other BIFs are implemented, so I held off on that for now. Let me know if you want me to do that, and I'm happy to make that change!