### PR TITLE
Update spawn-chain README with more complete instructions

### DIFF
--- a/examples/spawn-chain/README.md
+++ b/examples/spawn-chain/README.md
@@ -4,7 +4,9 @@
 
 ### 🛠️ Build with `wasm-pack build`
 
-Do this whenever the code in `src` changes.
+[Get Demo Running on OS X](#get-demo-running-on-os-x)
+
+Do this first and whenever the code in `src` changes.
 
 ```
 wasm-pack build
@@ -25,7 +27,7 @@ popd
 
 pushd www
 npm link spawn-chain
-popd 
+popd
 ```
 
 ### Run manually
@@ -36,4 +38,20 @@ This will automatically refresh the page if you rerun `wasm-pack build` above.
 cd www
 npm run start
 open http://localhost:8080
+```
+
+### Get Demo Running on OS X
+
+If you don't already have the Lumen dev environment and just want to play with the demo, do these steps, ***then*** continue to the [link package](#link-package) steps.
+
+
+```
+brew uninstall rust
+brew install rustup
+rustup-init
+source ~/.cargo/env
+rustup install nightly
+cargo install wasm-pack
+wasm-pack build
+rustup run nightly wasm-pack build
 ```

--- a/examples/spawn-chain/README.md
+++ b/examples/spawn-chain/README.md
@@ -44,14 +44,19 @@ open http://localhost:8080
 
 If you don't already have the Lumen dev environment and just want to play with the demo, do these steps, ***then*** continue to the [link package](#link-package) steps.
 
+Uninstall `rust` installed with Homebrew, so you can use `nightly`.
 
 ```
 brew uninstall rust
-brew install rustup
-rustup-init
+```
+
+Install `rustup` to manage your `rust` version.
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.cargo/env
-rustup install nightly
-cargo install wasm-pack
+rustup target add wasm32-unknown-unknown --toolchain nightly
+cargo +nightly install wasm-bindgen-cli
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 wasm-pack build
-rustup run nightly wasm-pack build
 ```


### PR DESCRIPTION
Following the instructions listed on the README presented me with multiple issues.  I am supposing that maybe this is all sorted by setting up the full Lumen dev environment.

- wasm-pack wanted rustup to be present
- rustup does not want another rust (i had brew install rust) present
- nightly build is required to run lumen
- Instructions did not explicitly say to run wasm-pack build first (only when changed) err on side of explicit for probably newbies (like me)  to rust and wasm tooling