### PR TITLE
Implement :maps.from_list/1

### DIFF
--- a/liblumen_alloc/src/erts/term/list.rs
+++ b/liblumen_alloc/src/erts/term/list.rs
@@ -96,7 +96,7 @@ impl Cons {
         self.head.is_none()
     }
 
-    /// Returns true if this cons is the head oflumen_runtime/src/otp/erlang.rs:1818:26
+    /// Returns true if this cons is the head of
     ///a proper list.
     pub fn is_proper(&self) -> bool {
         self.into_iter().all(|result| result.is_ok())

--- a/lumen_runtime/src/otp/maps.rs
+++ b/lumen_runtime/src/otp/maps.rs
@@ -1,4 +1,5 @@
 pub mod find_2;
+pub mod from_list_1;
 pub mod get_2;
 pub mod get_3;
 pub mod is_key_2;

--- a/lumen_runtime/src/otp/maps/from_list_1.rs
+++ b/lumen_runtime/src/otp/maps/from_list_1.rs
@@ -1,0 +1,69 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use std::sync::Arc;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::exception::system::Alloc;
+use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
+use liblumen_alloc::erts::process::code::{self, result_from_exception};
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::{Atom, Map, Term};
+use liblumen_alloc::{badarg, ModuleFunctionArity};
+
+pub fn place_frame_with_arguments(
+    process: &Process,
+    placement: Placement,
+    list: Term,
+) -> Result<(), Alloc> {
+    process.stack_push(list)?;
+    process.place_frame(frame(), placement);
+
+    Ok(())
+}
+
+// Crate Public
+
+pub(in crate::otp) fn code(arc_process: &Arc<Process>) -> code::Result {
+    arc_process.reduce();
+
+    let list = arc_process.stack_pop().unwrap();
+
+    match native(arc_process, list) {
+        Ok(map) => {
+            arc_process.return_from_call(map)?;
+
+            Process::call_code(arc_process)
+        }
+        Err(exception) => result_from_exception(arc_process, exception),
+    }
+}
+
+// Private
+
+fn frame() -> Frame {
+    Frame::new(module_function_arity(), code)
+}
+
+fn function() -> Atom {
+    Atom::try_from_str("from_list").unwrap()
+}
+
+fn module_function_arity() -> Arc<ModuleFunctionArity> {
+    Arc::new(ModuleFunctionArity {
+        module: super::module(),
+        function: function(),
+        arity: 1,
+    })
+}
+
+fn native(process: &Process, list: Term) -> exception::Result {
+    match Map::from_list(list) {
+        Some(hash_map) => Ok(process.map_from_hash_map(hash_map)?),
+        None => Err(badarg!().into()),
+    }
+}

--- a/lumen_runtime/src/otp/maps/from_list_1/test.rs
+++ b/lumen_runtime/src/otp/maps/from_list_1/test.rs
@@ -1,0 +1,27 @@
+mod with_list;
+
+use proptest::prop_assert_eq;
+use proptest::strategy::Strategy;
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badarg;
+
+use crate::otp::maps::from_list_1::native;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_list_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(strategy::term::is_not_list(arc_process.clone())),
+                |list| {
+                    prop_assert_eq!(native(&arc_process, list), Err(badarg!().into()));
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/maps/from_list_1/test/with_list.rs
+++ b/lumen_runtime/src/otp/maps/from_list_1/test/with_list.rs
@@ -1,0 +1,91 @@
+use super::*;
+
+use liblumen_alloc::erts::term::atom_unchecked;
+use proptest::strategy::Just;
+
+#[test]
+fn without_proper_list_errors_badarg() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    strategy::term::is_not_proper_list(arc_process.clone()),
+                )
+            }),
+            |(arc_process, list)| {
+                prop_assert_eq!(native(&arc_process, list), Err(badarg!().into()));
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn without_tuple_list_errors_badarg() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    strategy::term::is_not_tuple(arc_process.clone()),
+                )
+            }),
+            |(arc_process, term)| {
+                let list = arc_process.list_from_slice(&[term]).unwrap();
+                prop_assert_eq!(native(&arc_process, list), Err(badarg!().into()));
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn with_two_element_tuple_list_returns_value() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    strategy::term(arc_process.clone()),
+                )
+            }),
+            |(arc_process, key)| {
+                let value = atom_unchecked("value");
+                let tuple = arc_process.tuple_from_slice(&[key, value]).unwrap();
+                let list = arc_process.list_from_slice(&[tuple]).unwrap();
+                let map = arc_process.map_from_slice(&[(key, value)]).unwrap();
+                prop_assert_eq!(native(&arc_process, list), Ok(map));
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn with_duplicate_keys_preserves_last_value() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    strategy::term(arc_process.clone()),
+                )
+            }),
+            |(arc_process, key)| {
+                let value1 = atom_unchecked("value1");
+                let value2 = atom_unchecked("value2");
+                let tuple1 = arc_process.tuple_from_slice(&[key, value1]).unwrap();
+                let tuple2 = arc_process.tuple_from_slice(&[key, value2]).unwrap();
+                let list = arc_process.list_from_slice(&[tuple1, tuple2]).unwrap();
+                let map = arc_process.map_from_slice(&[(key, value2)]).unwrap();
+                prop_assert_eq!(native(&arc_process, list), Ok(map));
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}


### PR DESCRIPTION
This is my attempt at implementing `:maps.from_list/1`. It's quite a bit trickier than the other ones I implemented. I know there's at least one improvement that could be made, to build the map while checking the values. The problem I struggled with, is that there isn't a clear separation to me between what should be in lumen_runtime vs lumen_alloc for this. So, pretty much all of it is in lumen_runtime. The tests are using too much memory, so I'll come back and make the fix for that later.