### PR TITLE
macOS x86_64 and wasm32 tasks in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,13 @@
-container:
-  image: kronicdeth/lumen-development:latest
-  cpu: 4
-  memory: 12
-
 check_formatted_task:
+  container:
+    image: kronicdeth/lumen-development:latest
   script: cargo fmt -- --check
 
 x86_64_test_task:
+  container:
+    image: kronicdeth/lumen-development:latest
+    cpu: 4
+    memory: 12
   x86_64_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
@@ -39,6 +40,8 @@ x86_64_test_task:
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 wasm32_test_task:
+  container:
+    image: kronicdeth/lumen-development:latest
   wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,15 +4,7 @@ task:
     image: kronicdeth/lumen-development:latest
   script: cargo fmt -- --check
 
-task:
-  name: Linux x86_64
-  container:
-    image: kronicdeth/lumen-development:latest
-    cpu: 4
-    memory: 12
-  x86_64_cargo_cache:
-    folder: $CARGO_HOME/registry
-    fingerprint_script: cat Cargo.lock
+x86_64_task_template: &x86_64_TASK_TEMPLATE
   build_script: cargo build
   # `*_test_script`s in order of crate dependency graph
   liblumen_arena_test_script: |
@@ -39,6 +31,31 @@ task:
     pushd examples/spawn-chain
     cargo test
     popd
+
+task:
+  name: Linux x86_64
+  container:
+    image: kronicdeth/lumen-development:latest
+    cpu: 4
+    memory: 12
+  linux_x86_64_cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  << : *x86_64_TASK_TEMPLATE
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+task:
+  name: macOS x86_64
+  osx_instance:
+    image: high-sierra-base
+  env:
+    PATH: ${HOME}/.cargo/bin:${PATH}
+  macos_x86_64_cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  install_rustup_script: |
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
+  <<: *x86_64_TASK_TEMPLATE
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 wasm32_task_template: &WASM32_TASK_TEMPLATE
@@ -81,11 +98,10 @@ task:
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 task:
+  name: macOS wasm32
   osx_instance:
     image: high-sierra-base
-  name: macOS wasm32
   env:
-    HOMEBREW_NO_AUTO_UPDATE: 1
     PATH: ${HOME}/.cargo/bin:${PATH}
   macos_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,9 +128,10 @@ task:
     mv geckodriver /usr/local/bin/
     rm geckodriver-v0.24.0-macos.tar.gz
     geckodriver --version
+  enable_safari_driver_script: sudo safaridriver --enable
   lumen_web_test_script: |
     pushd lumen_web
-    wasm-pack test --headless --chrome --firefox
+    wasm-pack test --headless --chrome --firefox --safari
     popd
   examples_spawn_chain_build_script: |
     pushd examples/spawn-chain
@@ -138,7 +139,7 @@ task:
     popd
   examples_spawn_chain_test_script: |
     pushd examples/spawn-chain
-    wasm-pack test --headless --chrome --firefox
+    wasm-pack test --headless --chrome --firefox --safari
     popd
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -95,6 +95,6 @@ task:
   install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly
   install_wasm_bindgen_cli_script: cargo +nightly install wasm-bindgen-cli
   install_wasm_pack_script: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-  install_chrome_driver_script: brew cask instal chromedriver
+  install_chrome_script: brew cask install google-chrome
   << : *WASM32_TASK_TEMPLATE
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,6 +54,15 @@ wasm32_task_template: &WASM32_TASK_TEMPLATE
     pushd examples/spawn-chain
     wasm-pack test --headless --chrome
     popd
+
+task:
+  name: Linux wasm32
+  container:
+    image: kronicdeth/lumen-development:latest
+  linux_wasm32_cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  << : *WASM32_TASK_TEMPLATE
   examples_spawn_chain_package_script: |
     pushd examples/spawn-chain
     pushd www
@@ -70,15 +79,6 @@ wasm32_task_template: &WASM32_TASK_TEMPLATE
   examples_chain_chain_package_artifacts:
     path: "examples/spawn-chain/www/dist/*"
   before_cache_script: rm -rf $CARGO_HOME/registry/index
-
-task:
-  name: Linux wasm32
-  container:
-    image: kronicdeth/lumen-development:latest
-  linux_wasm32_cargo_cache:
-    folder: $CARGO_HOME/registry
-    fingerprint_script: cat Cargo.lock
-  << : *WASM32_TASK_TEMPLATE
 
 task:
   osx_instance:
@@ -105,4 +105,5 @@ task:
      rm chromedriver_mac64.zip
      chromedriver --version
   << : *WASM32_TASK_TEMPLATE
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -95,6 +95,14 @@ task:
   install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly
   install_wasm_bindgen_cli_script: cargo +nightly install wasm-bindgen-cli
   install_wasm_pack_script: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-  install_chrome_script: brew cask install google-chrome
+  install_chrome_script: |
+     brew cask install google-chrome
+     brew cask info google-chrome
+  install_chrome_driver_script: |
+     wget https://chromedriver.storage.googleapis.com/76.0.3809.126/chromedriver_mac64.zip
+     unzip chromedriver_mac64.zip
+     mv chromedriver /usr/local/bin/
+     rm chromedriver_mac64.zip
+     chromedriver --version
   << : *WASM32_TASK_TEMPLATE
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,7 +58,13 @@ task:
   <<: *x86_64_TASK_TEMPLATE
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-wasm32_task_template: &WASM32_TASK_TEMPLATE
+task:
+  name: Linux wasm32
+  container:
+    image: kronicdeth/lumen-development:latest
+  linux_wasm32_cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
   lumen_web_test_script: |
     pushd lumen_web
     wasm-pack test --headless --chrome
@@ -71,15 +77,6 @@ wasm32_task_template: &WASM32_TASK_TEMPLATE
     pushd examples/spawn-chain
     wasm-pack test --headless --chrome
     popd
-
-task:
-  name: Linux wasm32
-  container:
-    image: kronicdeth/lumen-development:latest
-  linux_wasm32_cargo_cache:
-    folder: $CARGO_HOME/registry
-    fingerprint_script: cat Cargo.lock
-  << : *WASM32_TASK_TEMPLATE
   examples_spawn_chain_package_script: |
     pushd examples/spawn-chain
     pushd www
@@ -112,14 +109,36 @@ task:
   install_wasm_bindgen_cli_script: cargo +nightly install wasm-bindgen-cli
   install_wasm_pack_script: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
   install_chrome_script: |
-     brew cask install google-chrome
-     brew cask info google-chrome
+    brew cask install google-chrome
+    brew cask info google-chrome
   install_chrome_driver_script: |
-     wget https://chromedriver.storage.googleapis.com/76.0.3809.126/chromedriver_mac64.zip
-     unzip chromedriver_mac64.zip
-     mv chromedriver /usr/local/bin/
-     rm chromedriver_mac64.zip
-     chromedriver --version
-  << : *WASM32_TASK_TEMPLATE
+    wget https://chromedriver.storage.googleapis.com/76.0.3809.126/chromedriver_mac64.zip
+    unzip chromedriver_mac64.zip
+    mv chromedriver /usr/local/bin/
+    rm chromedriver_mac64.zip
+    chromedriver --version
+  install_firefox_script: |
+    wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/69.0/mac/en-US/Firefox%2069.0.dmg
+    hdiutil attach "Firefox 69.0.dmg"
+    cp -rf /Volumes/Firefox/Firefox.app /Applications
+    hdiutil detach /Volumes/Firefox
+  install_gecko_driver_script: |
+    wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-macos.tar.gz
+    tar xvfz geckodriver-v0.24.0-macos.tar.gz
+    mv geckodriver /usr/local/bin/
+    rm geckodriver-v0.24.0-macos.tar.gz
+    geckodriver --version
+  lumen_web_test_script: |
+    pushd lumen_web
+    wasm-pack test --headless --chrome --firefox
+    popd
+  examples_spawn_chain_build_script: |
+    pushd examples/spawn-chain
+    wasm-pack build
+    popd
+  examples_spawn_chain_test_script: |
+    pushd examples/spawn-chain
+    wasm-pack test --headless --chrome --firefox
+    popd
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -95,5 +95,6 @@ task:
   install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly
   install_wasm_bindgen_cli_script: cargo +nightly install wasm-bindgen-cli
   install_wasm_pack_script: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+  install_chrome_driver_script: brew cask instal chromedriver
   << : *WASM32_TASK_TEMPLATE
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,6 +84,8 @@ task:
   osx_instance:
     image: high-sierra-base
   name: macOS wasm32
+  env:
+    HOMEBREW_NO_AUTO_UPDATE: 1
   macos_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,5 +89,11 @@ task:
   macos_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
+  install_rustup_script: |
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
+    echo 'export PATH=/Users/distiller/project/cargo/bin:$PATH' >> $BASH_ENV
+  install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly
+  install_wasm_bindgen_cli_script: cargo +nightly install wasm-bindgen-cli
+  install_wasm_pack_script: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
   << : *WASM32_TASK_TEMPLATE
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ check_formatted_task:
     image: kronicdeth/lumen-development:latest
   script: cargo fmt -- --check
 
-x86_64_test_task:
+linux_x86_64_test_task:
   container:
     image: kronicdeth/lumen-development:latest
     cpu: 4
@@ -39,12 +39,7 @@ x86_64_test_task:
     popd
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-wasm32_test_task:
-  container:
-    image: kronicdeth/lumen-development:latest
-  wasm32_cargo_cache:
-    folder: $CARGO_HOME/registry
-    fingerprint_script: cat Cargo.lock
+wasm32_task_template: &WASM32_TEST_TASK_TEMPLATE
   lumen_web_test_script: |
     pushd lumen_web
     wasm-pack test --headless --chrome
@@ -73,4 +68,20 @@ wasm32_test_task:
   examples_chain_chain_package_artifacts:
     path: "examples/spawn-chain/www/dist/*"
   before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+linux_wasm32_test_task:
+  container:
+    image: kronicdeth/lumen-development:latest
+  linux_wasm32_cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  << : *WASM32_TEST_TASK_TEMPLATE
+
+macos_x86_64_test_task:
+  osx_instance:
+    image: mojave-xcode-11
+  macos_wasm32_cargo_cache:
+    folder: $CARGO_HOME/registry
+    fingerprint_script: cat Cargo.lock
+  << : *WASM32_TEST_TASK_TEMPLATE
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -86,12 +86,12 @@ task:
   name: macOS wasm32
   env:
     HOMEBREW_NO_AUTO_UPDATE: 1
+    PATH: ${HOME}/.cargo/bin:${PATH}
   macos_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
   install_rustup_script: |
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly
-    echo 'export PATH=/Users/distiller/project/cargo/bin:$PATH' >> $BASH_ENV
   install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly
   install_wasm_bindgen_cli_script: cargo +nightly install wasm-bindgen-cli
   install_wasm_pack_script: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,11 @@
-check_formatted_task:
+task:
+  name: Check Formatted
   container:
     image: kronicdeth/lumen-development:latest
   script: cargo fmt -- --check
 
-linux_x86_64_test_task:
+task:
+  name: Linux x86_64
   container:
     image: kronicdeth/lumen-development:latest
     cpu: 4
@@ -39,7 +41,7 @@ linux_x86_64_test_task:
     popd
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-wasm32_task_template: &WASM32_TEST_TASK_TEMPLATE
+wasm32_task_template: &WASM32_TASK_TEMPLATE
   lumen_web_test_script: |
     pushd lumen_web
     wasm-pack test --headless --chrome
@@ -69,19 +71,21 @@ wasm32_task_template: &WASM32_TEST_TASK_TEMPLATE
     path: "examples/spawn-chain/www/dist/*"
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-linux_wasm32_test_task:
+task:
+  name: Linux wasm32
   container:
     image: kronicdeth/lumen-development:latest
   linux_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
-  << : *WASM32_TEST_TASK_TEMPLATE
+  << : *WASM32_TASK_TEMPLATE
 
-macos_x86_64_test_task:
+task:
   osx_instance:
-    image: mojave-xcode-11
+    image: high-sierra-base
+  name: macOS wasm32
   macos_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
-  << : *WASM32_TEST_TASK_TEMPLATE
+  << : *WASM32_TASK_TEMPLATE
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: Check Formatted
   container:
-    image: kronicdeth/lumen-development:latest
+    image: kronicdeth/lumen-development@sha256:2a6e1b519b1965586ab19be06470a2edcc18fb936f649cbd25a4bdb9911d15ad
   script: cargo fmt -- --check
 
 x86_64_task_template: &x86_64_TASK_TEMPLATE
@@ -35,7 +35,7 @@ x86_64_task_template: &x86_64_TASK_TEMPLATE
 task:
   name: Linux x86_64
   container:
-    image: kronicdeth/lumen-development:latest
+    image: kronicdeth/lumen-development@sha256:2a6e1b519b1965586ab19be06470a2edcc18fb936f649cbd25a4bdb9911d15ad
     cpu: 4
     memory: 12
   linux_x86_64_cargo_cache:
@@ -61,13 +61,16 @@ task:
 task:
   name: Linux wasm32
   container:
-    image: kronicdeth/lumen-development:latest
+    image: kronicdeth/lumen-development@sha256:2a6e1b519b1965586ab19be06470a2edcc18fb936f649cbd25a4bdb9911d15ad
+    memory: 6
   linux_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
+  firefox_version_script: firefox --version
+  gecko_driver_version_script: geckodriver --version
   lumen_web_test_script: |
     pushd lumen_web
-    wasm-pack test --headless --chrome
+    wasm-pack test --headless --chrome --firefox
     popd
   examples_spawn_chain_build_script: |
     pushd examples/spawn-chain
@@ -75,7 +78,7 @@ task:
     popd
   examples_spawn_chain_test_script: |
     pushd examples/spawn-chain
-    wasm-pack test --headless --chrome
+    wasm-pack test --headless --chrome --firefox
     popd
   examples_spawn_chain_package_script: |
     pushd examples/spawn-chain
@@ -142,4 +145,3 @@ task:
     wasm-pack test --headless --chrome --firefox --safari
     popd
   before_cache_script: rm -rf $CARGO_HOME/registry/index
-

--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -11,14 +11,13 @@ RUN cargo +nightly install wasm-bindgen-cli
 
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-# Based on https://github.com/circleci/circleci-images/blob/a0d9b6f495404d680decc2de92798223bf4b1738/shared/images/Dockerfile-browsers.template
-
 # install firefox
-#
-RUN FIREFOX_URL="https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" \
-  && ACTUAL_URL=$(curl -Ls -o /dev/null -w %{url_effective} $FIREFOX_URL) \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar.bz2 $ACTUAL_URL \
-  && tar -xvjf /tmp/firefox.tar.bz2 -C /opt \
+
+ENV FIREFOX_VERSION=69.0
+
+RUN cd /tmp \
+  && wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2 \
+  && tar -xvjf /tmp/firefox-${FIREFOX_VERSION}.tar.bz2 -C /opt \
   && ln -s /opt/firefox/firefox /usr/local/bin/firefox \
   && rm -rf /tmp/firefox.* \
   && apt-get update \
@@ -27,14 +26,12 @@ RUN FIREFOX_URL="https://download.mozilla.org/?product=firefox-latest-ssl&os=lin
 
 # install geckodriver
 
-RUN apt-get update \
-      && apt-get install -y jq
+ENV GECKO_DRIVER_VERSION=0.24.0
 
-RUN export GECKODRIVER_LATEST_RELEASE_URL=$(curl https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".assets[] | select(.name | test(\"linux64\")) | .browser_download_url") \
-     && curl --silent --show-error --location --fail --retry 3 --output /tmp/geckodriver_linux64.tar.gz "$GECKODRIVER_LATEST_RELEASE_URL" \
-     && cd /tmp \
-     && tar xf geckodriver_linux64.tar.gz \
-     && rm -rf geckodriver_linux64.tar.gz \
+RUN cd /tmp \
+     && wget https://github.com/mozilla/geckodriver/releases/download/v${GECKO_DRIVER_VERSION}/geckodriver-v${GECKO_DRIVER_VERSION}-linux64.tar.gz \
+     && tar xf geckodriver-v${GECKO_DRIVER_VERSION}-linux64.tar.gz \
+     && rm -f geckodriver-v${GECKO_DRIVER_VERISON}-linux64.tar.gz \
      && mv geckodriver /usr/local/bin/geckodriver \
      && chmod +x /usr/local/bin/geckodriver \
      && geckodriver --version

--- a/examples/spawn-chain/tests/web.rs
+++ b/examples/spawn-chain/tests/web.rs
@@ -49,11 +49,6 @@ mod run {
         eq_in_the_future(16)
     }
 
-    #[wasm_bindgen_test(async)]
-    fn with_32() -> impl Future<Item = (), Error = JsValue> {
-        eq_in_the_future(32)
-    }
-
     fn eq_in_the_future(n: usize) -> impl Future<Item = (), Error = JsValue> {
         super::eq_in_the_future(run, n)
     }
@@ -89,11 +84,6 @@ mod log_to_console {
         eq_in_the_future(16)
     }
 
-    #[wasm_bindgen_test(async)]
-    fn with_32() -> impl Future<Item = (), Error = JsValue> {
-        eq_in_the_future(32)
-    }
-
     fn eq_in_the_future(n: usize) -> impl Future<Item = (), Error = JsValue> {
         super::eq_in_the_future(log_to_console, n)
     }
@@ -127,11 +117,6 @@ mod log_to_dom {
     #[wasm_bindgen_test(async)]
     fn with_16() -> impl Future<Item = (), Error = JsValue> {
         eq_in_the_future(16)
-    }
-
-    #[wasm_bindgen_test(async)]
-    fn with_32() -> impl Future<Item = (), Error = JsValue> {
-        eq_in_the_future(32)
     }
 
     fn eq_in_the_future(n: usize) -> impl Future<Item = (), Error = JsValue> {


### PR DESCRIPTION
# Changelog
## Enhancements
* macOS builds in Cirrus CI
* Use `name` to make task name more human readable.
* Use YAML references to eliminate duplication between common scripts between different OS/arch tasks.
* Use `@sha256:SHA256` for docker container digest references instead of tags, to ensure builds are replayable in the future.
* Re-enable firefox tests for Linux x86_64 by not using as much memory to work-around shared-memory limits in the Docker container.