### PR TITLE
apply/2

### DIFF
--- a/liblumen_alloc/src/erts/exception.rs
+++ b/liblumen_alloc/src/erts/exception.rs
@@ -15,7 +15,7 @@ use crate::erts::term::{
     TypeError,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Exception {
     System(system::Exception),
     Runtime(runtime::Exception),

--- a/liblumen_alloc/src/erts/exception/runtime.rs
+++ b/liblumen_alloc/src/erts/exception/runtime.rs
@@ -10,7 +10,7 @@ use crate::erts::term::{
     atom_unchecked, index, BoolError, Term, TryIntoIntegerError, TypeError, TypedTerm,
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Class {
     Error { arguments: Option<Term> },
     Exit,
@@ -35,8 +35,7 @@ impl TryFrom<Term> for Class {
     }
 }
 
-#[derive(Debug)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Copy, Clone, Debug)]
 pub struct Exception {
     pub class: Class,
     pub reason: Term,

--- a/liblumen_alloc/src/erts/exception/system.rs
+++ b/liblumen_alloc/src/erts/exception/system.rs
@@ -1,6 +1,6 @@
 use core::fmt::{self, Debug};
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Exception {
     Alloc(Alloc),
 }

--- a/liblumen_alloc/src/erts/node.rs
+++ b/liblumen_alloc/src/erts/node.rs
@@ -7,4 +7,8 @@ impl Node {
     pub(in crate::erts) fn new(id: usize) -> Self {
         Self { id }
     }
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
 }

--- a/liblumen_alloc/src/erts/term/pid.rs
+++ b/liblumen_alloc/src/erts/term/pid.rs
@@ -148,8 +148,14 @@ impl CloneToProcess for ExternalPid {
 }
 
 impl Display for ExternalPid {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
-        unimplemented!()
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "<{}.{}.{}>",
+            self.node.id(),
+            self.pid.number(),
+            self.pid.serial()
+        )
     }
 }
 

--- a/liblumen_alloc/src/erts/term/typed_term.rs
+++ b/liblumen_alloc/src/erts/term/typed_term.rs
@@ -811,7 +811,7 @@ impl CloneToProcess for TypedTerm {
             &Self::List(ref inner) => inner.clone_to_process(process),
             &Self::Tuple(ref inner) => inner.clone_to_process(process),
             &Self::Map(ref inner) => inner.clone_to_process(process),
-            &Self::Boxed(ref inner) => inner.clone_to_process(process),
+            &Self::Boxed(ref inner) => inner.to_typed_term().unwrap().clone_to_process(process),
             &Self::Literal(inner) => inner,
             &Self::Pid(inner) => unsafe { inner.as_term() },
             &Self::Port(inner) => unsafe { inner.as_term() },

--- a/liblumen_alloc/src/erts/term/typed_term.rs
+++ b/liblumen_alloc/src/erts/term/typed_term.rs
@@ -581,8 +581,7 @@ impl Ord for TypedTerm {
                             | TypedTerm::ExternalPort(_)
                             | TypedTerm::ExternalPid(_)
                             | TypedTerm::Tuple(_)
-                            | TypedTerm::Map(_)
-                            | TypedTerm::List(_) => Greater,
+                            | TypedTerm::Map(_) => Greater,
                             TypedTerm::HeapBinary(other_heap_binary) => {
                                 self_heap_binary.as_ref().cmp(other_heap_binary.as_ref())
                             }
@@ -600,7 +599,10 @@ impl Ord for TypedTerm {
                                 .reverse(),
                             _ => unreachable!(),
                         },
-                        TypedTerm::Atom(_) | TypedTerm::Pid(_) | TypedTerm::Nil => Greater,
+                        TypedTerm::Atom(_)
+                        | TypedTerm::Pid(_)
+                        | TypedTerm::Nil
+                        | TypedTerm::List(_) => Greater,
                         _ => unreachable!(),
                     },
                     TypedTerm::ProcBin(self_process_binary) => match other {
@@ -615,8 +617,7 @@ impl Ord for TypedTerm {
                             | TypedTerm::ExternalPort(_)
                             | TypedTerm::ExternalPid(_)
                             | TypedTerm::Tuple(_)
-                            | TypedTerm::Map(_)
-                            | TypedTerm::List(_) => Greater,
+                            | TypedTerm::Map(_) => Greater,
                             TypedTerm::HeapBinary(other_heap_binary) => {
                                 self_process_binary.partial_cmp(&other_heap_binary).unwrap()
                             }
@@ -633,7 +634,10 @@ impl Ord for TypedTerm {
                                 .reverse(),
                             _ => unreachable!(),
                         },
-                        TypedTerm::Atom(_) | TypedTerm::Pid(_) | TypedTerm::Nil => Greater,
+                        TypedTerm::Atom(_)
+                        | TypedTerm::Pid(_)
+                        | TypedTerm::Nil
+                        | TypedTerm::List(_) => Greater,
                         _ => unreachable!(),
                     },
                     TypedTerm::SubBinary(self_subbinary) => match other {
@@ -648,8 +652,7 @@ impl Ord for TypedTerm {
                             | TypedTerm::ExternalPort(_)
                             | TypedTerm::ExternalPid(_)
                             | TypedTerm::Tuple(_)
-                            | TypedTerm::Map(_)
-                            | TypedTerm::List(_) => Greater,
+                            | TypedTerm::Map(_) => Greater,
                             TypedTerm::HeapBinary(other_heap_binary) => self_subbinary
                                 .partial_cmp(other_heap_binary.as_ref())
                                 .unwrap(),
@@ -665,8 +668,11 @@ impl Ord for TypedTerm {
                                 .reverse(),
                             _ => unreachable!(),
                         },
-                        TypedTerm::Atom(_) | TypedTerm::Pid(_) | TypedTerm::Nil => Greater,
-                        _ => unimplemented!("{:?} == {:?}", self, other),
+                        TypedTerm::Atom(_)
+                        | TypedTerm::Pid(_)
+                        | TypedTerm::Nil
+                        | TypedTerm::List(_) => Greater,
+                        _ => unimplemented!("{:?} == {:?}", self_subbinary, other),
                     },
                     TypedTerm::MatchContext(self_match_context) => match other {
                         _ => unimplemented!(

--- a/liblumen_alloc/src/erts/term/typed_term.rs
+++ b/liblumen_alloc/src/erts/term/typed_term.rs
@@ -666,7 +666,7 @@ impl Ord for TypedTerm {
                             _ => unreachable!(),
                         },
                         TypedTerm::Atom(_) | TypedTerm::Pid(_) | TypedTerm::Nil => Greater,
-                        _ => unreachable!(),
+                        _ => unimplemented!("{:?} == {:?}", self, other),
                     },
                     TypedTerm::MatchContext(self_match_context) => match other {
                         _ => unimplemented!(

--- a/lumen_runtime/src/future.rs
+++ b/lumen_runtime/src/future.rs
@@ -1,0 +1,174 @@
+use std::convert::TryInto;
+use std::sync::Arc;
+
+use liblumen_core::locks::Mutex;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::exception::system::Alloc;
+use liblumen_alloc::erts::process::code;
+use liblumen_alloc::erts::process::{Process, Status};
+use liblumen_alloc::erts::term::{resource, Atom};
+
+use crate::process;
+use crate::process::spawn::options::Options;
+use crate::registry;
+use crate::scheduler::Scheduler;
+use crate::time::monotonic::{time_in_milliseconds, Milliseconds};
+
+pub fn run_until_ready<PlaceFrameWithArguments>(
+    options: Options,
+    place_frame_with_arguments: PlaceFrameWithArguments,
+    timeout: Milliseconds,
+) -> Result<Ready, NotReady>
+where
+    PlaceFrameWithArguments: Fn(&Process) -> Result<(), Alloc>,
+{
+    let Spawned {
+        arc_process,
+        arc_mutex_future,
+    } = spawn(options, place_frame_with_arguments)?;
+    let scheduler = Scheduler::current();
+    let end = time_in_milliseconds() + timeout;
+
+    while time_in_milliseconds() < end {
+        assert!(scheduler.run_once());
+
+        if let Future::Ready(ref ready) = *arc_mutex_future.lock() {
+            return Ok(ready.clone());
+        }
+
+        if let Status::Exiting(ref exception) = *arc_process.status.read() {
+            return Ok(Ready {
+                arc_process: arc_process.clone(),
+                result: Err(exception::Exception::Runtime(exception.clone())),
+            });
+        }
+    }
+
+    Err(NotReady::Timeout { duration: timeout })
+}
+
+pub struct Ready {
+    pub arc_process: Arc<Process>,
+    pub result: exception::Result,
+}
+
+impl Clone for Ready {
+    fn clone(&self) -> Self {
+        Ready {
+            arc_process: self.arc_process.clone(),
+            result: match &self.result {
+                Ok(term) => Ok(*term),
+                Err(exception) => Err(exception.clone()),
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum NotReady {
+    Timeout { duration: Milliseconds },
+    Alloc(Alloc),
+}
+
+impl From<Alloc> for NotReady {
+    fn from(alloc: Alloc) -> Self {
+        NotReady::Alloc(alloc)
+    }
+}
+
+// Private
+
+fn code(arc_process: &Arc<Process>) -> code::Result {
+    let return_term = arc_process.stack_pop().unwrap();
+    let future_term = arc_process.stack_pop().unwrap();
+    assert!(future_term.is_resource_reference());
+
+    let future_resource_reference: resource::Reference = future_term.try_into().unwrap();
+    let future_mutex: &Arc<Mutex<Future>> = future_resource_reference.downcast_ref().unwrap();
+
+    future_mutex.lock().ready(Ready {
+        arc_process: arc_process.clone(),
+        result: Ok(return_term),
+    });
+
+    arc_process.remove_last_frame();
+
+    Process::call_code(arc_process)
+}
+
+fn function() -> Atom {
+    Atom::try_from_str("future").unwrap()
+}
+
+fn module() -> Atom {
+    Atom::try_from_str("Elixir.Lumen").unwrap()
+}
+
+fn spawn<PlaceFrameWithArguments>(
+    options: Options,
+    place_frame_with_arguments: PlaceFrameWithArguments,
+) -> Result<Spawned, Alloc>
+where
+    PlaceFrameWithArguments: Fn(&Process) -> Result<(), Alloc>,
+{
+    let (process, arc_mutex_future) = spawn_unscheduled(options)?;
+
+    place_frame_with_arguments(&process)?;
+
+    let arc_process = Scheduler::current().schedule(process);
+    registry::put_pid_to_process(&arc_process);
+
+    Ok(Spawned {
+        arc_process,
+        arc_mutex_future,
+    })
+}
+
+fn spawn_unscheduled(options: Options) -> Result<(Process, Arc<Mutex<Future>>), Alloc> {
+    let parent_process = None;
+    let arguments = vec![];
+    let process = process::spawn::code(
+        parent_process,
+        options,
+        module(),
+        function(),
+        arguments,
+        code,
+    )?;
+
+    let arc_mutex_future = Arc::new(Mutex::new(Default::default()));
+
+    let future_resource_reference = process.resource(Box::new(arc_mutex_future.clone()))?;
+    process.stack_push(future_resource_reference)?;
+
+    Ok((process, arc_mutex_future))
+}
+
+enum Future {
+    /// Future was spawned
+    Spawned,
+    /// Future's process completed.
+    ///
+    /// If `result`:
+    /// * `Ok(Term)` - the `process` completed and `Term` is the return given to `code`.
+    /// * `Err(exception::Exception)` - the `process` exited with an exception.
+    Ready(Ready),
+}
+
+impl Future {
+    fn ready(&mut self, ready: Ready) {
+        *self = Future::Ready(ready);
+    }
+}
+
+impl Default for Future {
+    fn default() -> Self {
+        Self::Spawned
+    }
+}
+
+struct Spawned {
+    arc_process: Arc<Process>,
+    arc_mutex_future: Arc<Mutex<Future>>,
+}

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -33,6 +33,7 @@ mod binary;
 // `pub` or `examples/spawn-chain`
 pub mod code;
 mod config;
+pub mod future;
 mod logging;
 mod node;
 mod number;

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -5,6 +5,7 @@ pub mod add_2;
 pub mod and_2;
 pub mod andalso_2;
 pub mod append_element_2;
+pub mod apply_2;
 pub mod apply_3;
 pub mod are_equal_after_conversion_2;
 pub mod are_exactly_equal_2;

--- a/lumen_runtime/src/otp/erlang/apply_2.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2.rs
@@ -1,0 +1,110 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use std::convert::TryInto;
+use std::sync::Arc;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::exception::system::Alloc;
+use liblumen_alloc::erts::process::code;
+use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::{Atom, Boxed, Closure, Term, TypedTerm};
+use liblumen_alloc::{badarg, badarity};
+
+use liblumen_alloc::ModuleFunctionArity;
+
+pub fn place_frame_with_arguments(
+    process: &Process,
+    placement: Placement,
+    function: Term,
+    arguments: Term,
+) -> Result<(), Alloc> {
+    process.stack_push(arguments)?;
+    process.stack_push(function)?;
+    process.place_frame(frame(), placement);
+
+    Ok(())
+}
+
+// Private
+
+fn code(arc_process: &Arc<Process>) -> code::Result {
+    arc_process.reduce();
+
+    let function = arc_process.stack_pop().unwrap();
+    let arguments = arc_process.stack_pop().unwrap();
+
+    let function_result_boxed_closure: Result<Boxed<Closure>, _> = function.try_into();
+
+    match function_result_boxed_closure {
+        Ok(function_boxed_closure) => {
+            let mut argument_vec = Vec::new();
+
+            match arguments.to_typed_term().unwrap() {
+                TypedTerm::Nil => (),
+                TypedTerm::List(argument_boxed_cons) => {
+                    for result in argument_boxed_cons.into_iter() {
+                        match result {
+                            Ok(element) => argument_vec.push(element),
+                            Err(_) => {
+                                arc_process.exception(badarg!());
+
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    arc_process.exception(badarg!());
+
+                    return Ok(());
+                }
+            }
+
+            if argument_vec.len() == (function_boxed_closure.arity() as usize) {
+                function_boxed_closure.place_frame_with_arguments(
+                    arc_process,
+                    Placement::Replace,
+                    argument_vec,
+                )?;
+
+                Process::call_code(arc_process)
+            } else {
+                match badarity!(arc_process, function, arguments) {
+                    exception::Exception::Runtime(runtime_exception) => {
+                        arc_process.exception(runtime_exception);
+
+                        Ok(())
+                    }
+                    exception::Exception::System(system_exception) => Err(system_exception),
+                }
+            }
+        }
+        Err(_) => {
+            arc_process.exception(badarg!());
+
+            Ok(())
+        }
+    }
+}
+
+fn frame() -> Frame {
+    Frame::new(module_function_arity(), code)
+}
+
+fn function() -> Atom {
+    Atom::try_from_str("apply").unwrap()
+}
+
+fn module_function_arity() -> Arc<ModuleFunctionArity> {
+    Arc::new(ModuleFunctionArity {
+        module: super::module(),
+        function: function(),
+        arity: 2,
+    })
+}

--- a/lumen_runtime/src/otp/erlang/apply_2/test.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2/test.rs
@@ -1,0 +1,56 @@
+mod with_function;
+
+use std::mem;
+
+use proptest::prop_assert_eq;
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::borrow::clone_to_process::CloneToProcess;
+use liblumen_alloc::erts::process::code::stack::frame::Placement;
+use liblumen_alloc::erts::term::Term;
+
+use crate::future::{run_until_ready, Ready};
+use crate::otp::erlang::apply_2::place_frame_with_arguments;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_function_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::is_not_function(arc_process.clone()),
+                |function| {
+                    let Ready {
+                        arc_process: child_arc_proces,
+                        result,
+                        ..
+                    } = run_until_ready(
+                        Default::default(),
+                        |child_process| {
+                            eprintln!("function = {:?}", function);
+                            let child_function = function.clone_to_process(child_process);
+                            let child_arguments = Term::NIL;
+
+                            place_frame_with_arguments(
+                                child_process,
+                                Placement::Push,
+                                child_function,
+                                child_arguments,
+                            )
+                        },
+                        5_000,
+                    )
+                    .unwrap();
+
+                    prop_assert_eq!(result, Err(badarg!().into()));
+
+                    mem::drop(child_arc_proces);
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/apply_2/test/with_function.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2/test/with_function.rs
@@ -1,0 +1,48 @@
+mod with_empty_list_arguments;
+mod with_non_empty_proper_list_arguments;
+
+use super::*;
+
+use crate::test::strategy::module_function_arity;
+
+#[test]
+fn without_proper_list_arguments_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    strategy::term::is_function(arc_process.clone()),
+                    strategy::term::is_not_proper_list(arc_process.clone()),
+                ),
+                |(function, arguments)| {
+                    let Ready {
+                        arc_process: child_arc_process,
+                        result,
+                        ..
+                    } = run_until_ready(
+                        Default::default(),
+                        |child_process| {
+                            let child_function = function.clone_to_process(child_process);
+                            let child_arguments = arguments.clone_to_process(child_process);
+
+                            place_frame_with_arguments(
+                                child_process,
+                                Placement::Push,
+                                child_function,
+                                child_arguments,
+                            )
+                        },
+                        5_000,
+                    )
+                    .unwrap();
+
+                    prop_assert_eq!(result, Err(badarg!().into()));
+
+                    mem::drop(child_arc_process);
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/apply_2/test/with_function/with_empty_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2/test/with_function/with_empty_list_arguments.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+use std::sync::Arc;
+
+use proptest::strategy::Strategy;
+
+use liblumen_alloc::badarity;
+use liblumen_alloc::erts::process::code::Code;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::atom_unchecked;
+use liblumen_alloc::erts::ModuleFunctionArity;
+
+use crate::test::strategy::term::closure;
+
+#[test]
+fn without_arity_errors_badarity() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    module_function_arity::module(),
+                    module_function_arity::function(),
+                    (1_u8..=255_u8),
+                )
+                    .prop_map(|(module, function, arity)| {
+                        closure(&arc_process.clone(), module, function, arity)
+                    }),
+                |function| {
+                    let Ready {
+                        arc_process: child_arc_process,
+                        result,
+                    } = run_until_ready(
+                        Default::default(),
+                        |child_process| {
+                            let child_function = function.clone_to_process(child_process);
+                            let child_arguments = Term::NIL;
+
+                            place_frame_with_arguments(
+                                child_process,
+                                Placement::Push,
+                                child_function,
+                                child_arguments,
+                            )
+                        },
+                        5_000,
+                    )
+                    .unwrap();
+
+                    prop_assert_eq!(result, Err(badarity!(&arc_process, function, Term::NIL)));
+
+                    mem::drop(child_arc_process);
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}
+
+#[test]
+fn with_arity_returns_function_return() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    module_function_arity::module(),
+                    module_function_arity::function(),
+                )
+                    .prop_map(|(module, function)| {
+                        let creator = arc_process.pid_term();
+                        let module_function_arity = Arc::new(ModuleFunctionArity {
+                            module,
+                            function,
+                            arity: 0,
+                        });
+                        let code: Code = |arc_process: &Arc<Process>| {
+                            arc_process.return_from_call(atom_unchecked("return_from_fn"))?;
+
+                            Process::call_code(arc_process)
+                        };
+
+                        arc_process
+                            .closure_with_env_from_slice(module_function_arity, code, creator, &[])
+                            .unwrap()
+                    }),
+                |function| {
+                    let Ready {
+                        arc_process: child_arc_process,
+                        result,
+                    } = run_until_ready(
+                        Default::default(),
+                        |child_process| {
+                            let child_function = function.clone_to_process(child_process);
+                            let child_arguments = Term::NIL;
+
+                            place_frame_with_arguments(
+                                child_process,
+                                Placement::Push,
+                                child_function,
+                                child_arguments,
+                            )
+                        },
+                        5_000,
+                    )
+                    .unwrap();
+
+                    prop_assert_eq!(result, Ok(atom_unchecked("return_from_fn")));
+
+                    mem::drop(child_arc_process);
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/apply_2/test/with_function/with_non_empty_proper_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2/test/with_function/with_non_empty_proper_list_arguments.rs
@@ -1,0 +1,173 @@
+use super::*;
+
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+
+use proptest::collection::SizeRange;
+use proptest::strategy::{Just, Strategy};
+
+use liblumen_alloc::badarity;
+use liblumen_alloc::erts::process::code::Code;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::ModuleFunctionArity;
+
+use crate::process::spawn::options::Options;
+use crate::test::strategy::term::closure;
+
+#[test]
+fn without_arity_errors_badarg() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process()
+                .prop_flat_map(|arc_process| {
+                    (
+                        Just(arc_process),
+                        module_function_arity::module(),
+                        module_function_arity::function(),
+                        1_u8..=255_u8,
+                    )
+                })
+                .prop_flat_map(|(arc_process, module, function, arity)| {
+                    (
+                        Just(arc_process.clone()),
+                        Just(module),
+                        Just(function),
+                        Just(arity.clone()),
+                        (Just(arc_process), module_function_arity::arity())
+                            .prop_filter(
+                                "Arguments arity cannot match function arity",
+                                move |(_, list_arity)| *list_arity != arity,
+                            )
+                            .prop_flat_map(|(arc_process, list_arity)| {
+                                let range_inclusive: RangeInclusive<usize> =
+                                    (list_arity as usize)..=(list_arity as usize);
+                                let size_range: SizeRange = range_inclusive.into();
+
+                                (
+                                    Just(arc_process.clone()),
+                                    proptest::collection::vec(
+                                        strategy::term(arc_process.clone()),
+                                        size_range,
+                                    ),
+                                )
+                                    .prop_map(
+                                        |(arc_process, vec)| {
+                                            arc_process.list_from_slice(&vec).unwrap()
+                                        },
+                                    )
+                            }),
+                    )
+                })
+                .prop_map(|(arc_process, module, function, arity, arguments)| {
+                    (
+                        arc_process.clone(),
+                        closure(&arc_process.clone(), module, function, arity),
+                        arguments,
+                    )
+                }),
+            |(arc_process, function, arguments)| {
+                let size_in_words = function.size_in_words() + arguments.size_in_words();
+                let options = Options {
+                    min_heap_size: Some(size_in_words),
+                    ..Default::default()
+                };
+
+                let Ready {
+                    arc_process: child_arc_process,
+                    result,
+                } = run_until_ready(
+                    options,
+                    |child_process| {
+                        let child_function = function.clone_to_process(child_process);
+                        let child_arguments = arguments.clone_to_process(child_process);
+
+                        place_frame_with_arguments(
+                            child_process,
+                            Placement::Push,
+                            child_function,
+                            child_arguments,
+                        )
+                    },
+                    5_000,
+                )
+                .unwrap();
+
+                prop_assert_eq!(result, Err(badarity!(&arc_process, function, arguments)));
+
+                mem::drop(child_arc_process);
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn with_arity_returns_function_return() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    module_function_arity::module(),
+                    module_function_arity::function(),
+                    strategy::term(arc_process.clone()),
+                )
+                    .prop_map(|(module, function, argument)| {
+                        let creator = arc_process.pid_term();
+                        let module_function_arity = Arc::new(ModuleFunctionArity {
+                            module,
+                            function,
+                            arity: 1,
+                        });
+                        let code: Code = |arc_process: &Arc<Process>| {
+                            let return_term = arc_process.stack_pop().unwrap();
+                            arc_process.return_from_call(return_term)?;
+
+                            Process::call_code(arc_process)
+                        };
+
+                        (
+                            arc_process
+                                .closure_with_env_from_slice(
+                                    module_function_arity,
+                                    code,
+                                    creator,
+                                    &[],
+                                )
+                                .unwrap(),
+                            argument,
+                        )
+                    }),
+                |(function, argument)| {
+                    let arguments = arc_process.list_from_slice(&[argument]).unwrap();
+
+                    let Ready {
+                        arc_process: child_arc_process,
+                        result,
+                    } = run_until_ready(
+                        Default::default(),
+                        |child_process| {
+                            let child_function = function.clone_to_process(child_process);
+                            let child_arguments = arguments.clone_to_process(child_process);
+
+                            place_frame_with_arguments(
+                                child_process,
+                                Placement::Push,
+                                child_function,
+                                child_arguments,
+                            )
+                        },
+                        5_000,
+                    )
+                    .unwrap();
+
+                    prop_assert_eq!(result, Ok(argument));
+
+                    mem::drop(child_arc_process);
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/test/strategy/term.rs
+++ b/lumen_runtime/src/test/strategy/term.rs
@@ -138,7 +138,7 @@ pub fn is_function_with_arity(arc_process: Arc<Process>, arity: u8) -> BoxedStra
         .boxed()
 }
 
-fn closure(process: &Process, module: Atom, function: Atom, arity: u8) -> Term {
+pub fn closure(process: &Process, module: Atom, function: Atom, arity: u8) -> Term {
     let creator = process.pid_term();
     let module_function_arity = Arc::new(ModuleFunctionArity {
         module,

--- a/lumen_web/src/wait/with_return_0.rs
+++ b/lumen_web/src/wait/with_return_0.rs
@@ -186,7 +186,7 @@ fn tuple_to_js_value(tuple: &Tuple) -> JsValue {
 }
 
 /// The executor for a `js_sys::Promise` that will be resolved by `code` or rejected when the owning
-/// promise exits and the executor is dropped.
+/// process exits and the executor is dropped.
 struct Executor {
     state: State,
 }


### PR DESCRIPTION
Resolves #136

# Changelog
## Enhancements
* `Display` for `ExternalPid`
* `:erlang.apply/2`
* Mark `Exception`s as `Clone` and `Copy`.  The backing process needs to stay alive, but making them `Clone` and `Copy` allows for asserts on them in tests when they are returned cross-process.
* `lumen_runtime::future::run_until_ready`
   Allow a process to be spawned that runs a function being placed in the child process using `place_frame_With_arguments` and return the value to caller.  The current thread's `Scheduler` is run until the child process exits or the `Future` is ready.

   The returned `Ready` keeps both the `exception::Result` alive and the `Arc<Process>` backing any terms in its results.

## Bug Fixes
* Fix typo in docs
* Fix `CloneToProcess` for `TypedTerm::Boxed`.  It did not convert the boxed `Term` to a `TypedTerm` before calling `clone_to_process` again, which violates the checks that only immediates and boxed terms can be `clone_to_process`ed in `CloneToProcess for Term`.
* Fix `PartialOrd` for `TypedTerm` when `other` is `List`. I incorrectly put `List` in the unboxed `match` because I was thinking of it as "after map" instead of being a sibling of the `TypedTerm::Box` and in the same arm as `Nil` (empty list) because List is a pointer type itself and not `Box`ed.