### PR TITLE
demonitor/1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ task:
 task:
   name: macOS x86_64
   osx_instance:
-    image: high-sierra-base
+    image: mojave-base
   env:
     PATH: ${HOME}/.cargo/bin:${PATH}
   macos_x86_64_cargo_cache:
@@ -100,7 +100,7 @@ task:
 task:
   name: macOS wasm32
   osx_instance:
-    image: high-sierra-base
+    image: mojave-base
   env:
     PATH: ${HOME}/.cargo/bin:${PATH}
   macos_wasm32_cargo_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,7 @@ task:
   enable_safari_driver_script: sudo safaridriver --enable
   lumen_web_test_script: |
     pushd lumen_web
-    wasm-pack test --headless --chrome --firefox --safari
+    wasm-pack test --headless --chrome --firefox
     popd
   examples_spawn_chain_build_script: |
     pushd examples/spawn-chain
@@ -142,6 +142,6 @@ task:
     popd
   examples_spawn_chain_test_script: |
     pushd examples/spawn-chain
-    wasm-pack test --headless --chrome --firefox --safari
+    wasm-pack test --headless --chrome --firefox
     popd
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -39,6 +39,7 @@ pub mod ceil_1;
 pub mod concatenate_2;
 pub mod convert_time_unit_3;
 pub mod delete_element_2;
+pub mod demonitor_1;
 pub mod demonitor_2;
 pub mod div_2;
 pub mod divide_2;

--- a/lumen_runtime/src/otp/erlang/demonitor_1.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_1.rs
@@ -1,0 +1,23 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use std::convert::TryInto;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::{Boxed, Reference, Term};
+
+use lumen_runtime_macros::native_implemented_function;
+
+use crate::otp::erlang::demonitor_2::demonitor;
+
+#[native_implemented_function(demonitor/1)]
+pub fn native(process: &Process, reference: Term) -> exception::Result {
+    let reference_reference: Boxed<Reference> = reference.try_into()?;
+
+    demonitor(process, &reference_reference, Default::default())
+}

--- a/lumen_runtime/src/otp/erlang/demonitor_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_1/test.rs
@@ -1,0 +1,27 @@
+mod with_reference;
+
+use proptest::prop_assert_eq;
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::term::Term;
+
+use crate::otp::erlang::demonitor_1::native;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_reference_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::is_not_reference(arc_process.clone()),
+                |reference| {
+                    prop_assert_eq!(native(&arc_process, reference), Err(badarg!().into()));
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/demonitor_1/test/with_reference.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_1/test/with_reference.rs
@@ -1,0 +1,22 @@
+mod with_monitor;
+
+use super::*;
+
+use liblumen_alloc::erts::process::code::stack::frame::Placement;
+use liblumen_alloc::erts::term::atom_unchecked;
+
+use crate::otp::erlang::exit_1;
+use crate::otp::erlang::monitor_2;
+use crate::process;
+use crate::process::SchedulerDependentAlloc;
+use crate::scheduler::Scheduler;
+use crate::test::{has_message, monitor_count, monitored_count};
+
+#[test]
+fn without_monitor_returns_true() {
+    with_process_arc(|monitoring_arc_process| {
+        let reference = monitoring_arc_process.next_reference().unwrap();
+
+        assert_eq!(native(&monitoring_arc_process, reference), Ok(true.into()))
+    });
+}

--- a/lumen_runtime/src/otp/erlang/demonitor_1/test/with_reference/with_monitor.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_1/test/with_reference/with_monitor.rs
@@ -1,0 +1,121 @@
+use super::*;
+
+#[test]
+fn returns_true() {
+    with_process_arc(|monitoring_arc_process| {
+        let monitored_arc_process = process::test(&monitoring_arc_process);
+
+        let monitor_reference = monitor_2::native(
+            &monitoring_arc_process,
+            r#type(),
+            monitored_arc_process.pid_term(),
+        )
+        .unwrap();
+
+        let monitored_monitor_count_before = monitor_count(&monitored_arc_process);
+        let monitoring_monitored_count_before = monitored_count(&monitoring_arc_process);
+
+        assert_eq!(
+            native(&monitoring_arc_process, monitor_reference),
+            Ok(true.into())
+        );
+
+        let monitored_monitor_count_after = monitor_count(&monitored_arc_process);
+        let monitoring_monitored_count_after = monitored_count(&monitoring_arc_process);
+
+        assert_eq!(
+            monitored_monitor_count_after,
+            monitored_monitor_count_before - 1
+        );
+        assert_eq!(
+            monitoring_monitored_count_after,
+            monitoring_monitored_count_before - 1
+        );
+    });
+}
+
+#[test]
+fn does_not_flush_existing_message() {
+    with_process_arc(|monitoring_arc_process| {
+        let monitored_arc_process = process::test(&monitoring_arc_process);
+        let monitored_pid_term = monitored_arc_process.pid_term();
+
+        let monitor_reference =
+            monitor_2::native(&monitoring_arc_process, r#type(), monitored_pid_term).unwrap();
+
+        let reason = atom_unchecked("normal");
+        exit_1::place_frame_with_arguments(&monitored_arc_process, Placement::Replace, reason)
+            .unwrap();
+
+        assert!(Scheduler::current().run_through(&monitored_arc_process));
+
+        assert!(monitored_arc_process.is_exiting());
+        assert!(!monitoring_arc_process.is_exiting());
+
+        let tag = atom_unchecked("DOWN");
+
+        assert!(has_message(
+            &monitoring_arc_process,
+            monitoring_arc_process
+                .tuple_from_slice(&[tag, monitor_reference, r#type(), monitored_pid_term, reason])
+                .unwrap()
+        ));
+
+        assert_eq!(
+            native(&monitoring_arc_process, monitor_reference),
+            Ok(true.into())
+        );
+
+        assert!(has_message(
+            &monitoring_arc_process,
+            monitoring_arc_process
+                .tuple_from_slice(&[tag, monitor_reference, r#type(), monitored_pid_term, reason])
+                .unwrap()
+        ));
+    });
+}
+
+#[test]
+fn prevents_future_messages() {
+    with_process_arc(|monitoring_arc_process| {
+        let monitored_arc_process = process::test(&monitoring_arc_process);
+        let monitored_pid_term = monitored_arc_process.pid_term();
+
+        let monitor_reference =
+            monitor_2::native(&monitoring_arc_process, r#type(), monitored_pid_term).unwrap();
+
+        let reason = atom_unchecked("normal");
+        let tag = atom_unchecked("DOWN");
+
+        assert!(!has_message(
+            &monitoring_arc_process,
+            monitoring_arc_process
+                .tuple_from_slice(&[tag, monitor_reference, r#type(), monitored_pid_term, reason])
+                .unwrap()
+        ));
+
+        assert_eq!(
+            native(&monitoring_arc_process, monitor_reference),
+            Ok(true.into())
+        );
+
+        exit_1::place_frame_with_arguments(&monitored_arc_process, Placement::Replace, reason)
+            .unwrap();
+
+        assert!(Scheduler::current().run_through(&monitored_arc_process));
+
+        assert!(monitored_arc_process.is_exiting());
+        assert!(!monitoring_arc_process.is_exiting());
+
+        assert!(!has_message(
+            &monitoring_arc_process,
+            monitoring_arc_process
+                .tuple_from_slice(&[tag, monitor_reference, r#type(), monitored_pid_term, reason])
+                .unwrap()
+        ));
+    });
+}
+
+fn r#type() -> Term {
+    atom_unchecked("process")
+}

--- a/lumen_runtime/src/otp/erlang/demonitor_2.rs
+++ b/lumen_runtime/src/otp/erlang/demonitor_2.rs
@@ -29,7 +29,7 @@ pub fn native(process: &Process, reference: Term, options: Term) -> exception::R
 
 // Private
 
-fn demonitor(
+pub(in crate::otp::erlang) fn demonitor(
     monitoring_process: &Process,
     reference: &Reference,
     Options { flush, info }: Options,


### PR DESCRIPTION
Resolves #169

# Changelog
## Enhancements
* `:erlang.demonitor/1`

## Bug Fixes
* Fix `PartialOrd` for `TypedTerm` when `other` is `List`. I incorrectly put `List` in the unboxed `match` because I was thinking of it as "after map" instead of being a sibling of the `TypedTerm::Box` and in the same arm as `Nil` (empty list) because List is a pointer type itself and not `Box`ed.