### PR TITLE
make_tuple/3

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -82,6 +82,7 @@ pub mod list_to_pid_1;
 pub mod list_to_tuple_1;
 pub mod make_ref_0;
 pub mod make_tuple_2;
+pub mod make_tuple_3;
 pub mod map_get_2;
 pub mod map_size_1;
 pub mod max_2;

--- a/lumen_runtime/src/otp/erlang/make_tuple_3.rs
+++ b/lumen_runtime/src/otp/erlang/make_tuple_3.rs
@@ -1,0 +1,63 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use std::convert::TryInto;
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::{Boxed, Term, Tuple, TypedTerm};
+
+use liblumen_alloc::HeapAlloc;
+use lumen_runtime_macros::native_implemented_function;
+
+#[native_implemented_function(make_tuple/3)]
+pub fn native(
+    process: &Process,
+    arity: Term,
+    default_value: Term,
+    init_list: Term,
+) -> exception::Result {
+    // arity by definition is only 0-225, so `u8`, but ...
+    let arity_u8: u8 = arity.try_into()?;
+    // ... everything else uses `usize`, so cast it back up
+    let arity_usize: usize = arity_u8 as usize;
+
+    let mut heap = process.acquire_heap();
+    let tuple = heap.mut_tuple(arity_usize)?;
+
+    for index in 0..arity_usize {
+        tuple
+            .set_element_from_zero_based_usize_index(index, default_value)
+            .unwrap();
+    }
+
+    match init_list.to_typed_term().unwrap() {
+        TypedTerm::Nil => Ok(Term::make_boxed(tuple as *const Tuple)),
+        TypedTerm::List(boxed_cons) => {
+            for result in boxed_cons.into_iter() {
+                match result {
+                    Ok(init) => {
+                        let init_boxed_tuple: Boxed<Tuple> = init.try_into()?;
+
+                        if init_boxed_tuple.len() == 2 {
+                            let index = init_boxed_tuple[0];
+                            let element = init_boxed_tuple[1];
+                            tuple.set_element_from_one_based_term_index(index, element)?;
+                        } else {
+                            return Err(badarg!().into());
+                        }
+                    }
+                    Err(_) => return Err(badarg!().into()),
+                }
+            }
+
+            Ok(Term::make_boxed(tuple as *const Tuple))
+        }
+        _ => Err(badarg!().into()),
+    }
+}

--- a/lumen_runtime/src/otp/erlang/make_tuple_3/test.rs
+++ b/lumen_runtime/src/otp/erlang/make_tuple_3/test.rs
@@ -1,0 +1,38 @@
+mod with_arity;
+
+use std::convert::TryInto;
+
+use proptest::strategy::{Just, Strategy};
+use proptest::test_runner::{Config, TestRunner};
+use proptest::{prop_assert, prop_assert_eq};
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::term::{Boxed, Term, Tuple};
+
+use crate::otp::erlang::make_tuple_3::native;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_arity_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    strategy::term::is_not_arity(arc_process.clone()),
+                    strategy::term(arc_process.clone()),
+                ),
+                |(arity, default_value)| {
+                    let init_list = Term::NIL;
+
+                    prop_assert_eq!(
+                        native(&arc_process, arity, default_value, init_list),
+                        Err(badarg!().into())
+                    );
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity.rs
+++ b/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity.rs
@@ -1,0 +1,66 @@
+mod with_proper_list;
+
+use super::*;
+
+#[test]
+fn without_proper_list_init_list_errors_badarg() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    (0_usize..255_usize),
+                    strategy::term(arc_process.clone()),
+                    strategy::term::is_not_proper_list(arc_process),
+                )
+            }),
+            |(arc_process, arity_usize, default_value, init_list)| {
+                let arity = arc_process.integer(arity_usize).unwrap();
+
+                prop_assert_eq!(
+                    native(&arc_process, arity, default_value, init_list),
+                    Err(badarg!().into())
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn with_empty_list_init_list_returns_tuple_with_arity_copies_of_default_value() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    (0_usize..255_usize),
+                    strategy::term(arc_process),
+                )
+            }),
+            |(arc_process, arity_usize, default_value)| {
+                let arity = arc_process.integer(arity_usize).unwrap();
+                let init_list = Term::NIL;
+
+                let result = native(&arc_process, arity, default_value, init_list);
+
+                prop_assert!(result.is_ok());
+
+                let tuple_term = result.unwrap();
+
+                prop_assert!(tuple_term.is_tuple());
+
+                let boxed_tuple: Boxed<Tuple> = tuple_term.try_into().unwrap();
+
+                prop_assert_eq!(boxed_tuple.len(), arity_usize);
+
+                for element in boxed_tuple.iter() {
+                    prop_assert_eq!(element, default_value);
+                }
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity/with_proper_list.rs
+++ b/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity/with_proper_list.rs
@@ -1,0 +1,35 @@
+mod with_tuples_in_init_list;
+
+use super::*;
+
+#[test]
+fn without_tuple_in_init_list_errors_badarg() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    (0_usize..255_usize),
+                    strategy::term(arc_process.clone()),
+                    (
+                        Just(arc_process.clone()),
+                        strategy::term::is_not_tuple(arc_process.clone()),
+                    )
+                        .prop_map(|(arc_process, element)| {
+                            arc_process.list_from_slice(&[element]).unwrap()
+                        }),
+                )
+            }),
+            |(arc_process, arity_usize, default_value, init_list)| {
+                let arity = arc_process.integer(arity_usize).unwrap();
+
+                prop_assert_eq!(
+                    native(&arc_process, arity, default_value, init_list),
+                    Err(badarg!().into())
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity/with_proper_list/with_tuples_in_init_list.rs
+++ b/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity/with_proper_list/with_tuples_in_init_list.rs
@@ -1,0 +1,44 @@
+mod with_arity_2;
+
+use super::*;
+
+use proptest::prop_oneof;
+
+#[test]
+fn without_arity_2_errors_badarg() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    (1_usize..=3_usize),
+                    strategy::term(arc_process.clone()),
+                    (Just(arc_process.clone()), prop_oneof![Just(1), Just(3)])
+                        .prop_flat_map(|(arc_process, len)| {
+                            (
+                                Just(arc_process.clone()),
+                                strategy::term::tuple::intermediate(
+                                    strategy::term(arc_process.clone()),
+                                    (len..=len).into(),
+                                    arc_process.clone(),
+                                ),
+                            )
+                        })
+                        .prop_map(|(arc_process, element)| {
+                            arc_process.list_from_slice(&[element]).unwrap()
+                        }),
+                )
+            }),
+            |(arc_process, arity_usize, default_value, init_list)| {
+                let arity = arc_process.integer(arity_usize).unwrap();
+
+                prop_assert_eq!(
+                    native(&arc_process, arity, default_value, init_list),
+                    Err(badarg!().into())
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity/with_proper_list/with_tuples_in_init_list/with_arity_2.rs
+++ b/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity/with_proper_list/with_tuples_in_init_list/with_arity_2.rs
@@ -1,0 +1,53 @@
+mod with_positive_index;
+
+use super::*;
+
+#[test]
+fn without_positive_index_errors_badarg_because_indexes_are_one_based() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    (1_usize..3_usize),
+                    strategy::term(arc_process.clone()),
+                    (
+                        Just(arc_process.clone()),
+                        strategy::term(arc_process.clone()),
+                    )
+                        .prop_filter("Index must not be a positive index", |(_, index)| {
+                            !index.is_integer() || index <= &Term::make_smallint(0)
+                        })
+                        .prop_flat_map(|(arc_process, index)| {
+                            (
+                                Just(arc_process.clone()),
+                                Just(index),
+                                strategy::term(arc_process.clone()),
+                            )
+                                .prop_map(
+                                    |(arc_process, index, element)| {
+                                        (
+                                            arc_process.clone(),
+                                            arc_process.list_from_slice(&[index, element]).unwrap(),
+                                        )
+                                    },
+                                )
+                        })
+                        .prop_map(|(arc_process, element)| {
+                            arc_process.list_from_slice(&[element]).unwrap()
+                        }),
+                )
+            }),
+            |(arc_process, arity_usize, default_value, init_list)| {
+                let arity = arc_process.integer(arity_usize).unwrap();
+
+                prop_assert_eq!(
+                    native(&arc_process, arity, default_value, init_list),
+                    Err(badarg!().into())
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity/with_proper_list/with_tuples_in_init_list/with_arity_2/with_positive_index.rs
+++ b/lumen_runtime/src/otp/erlang/make_tuple_3/test/with_arity/with_proper_list/with_tuples_in_init_list/with_arity_2/with_positive_index.rs
@@ -1,0 +1,180 @@
+use super::*;
+
+#[test]
+fn with_positive_index_greater_than_length_errors_badarg() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process().prop_flat_map(|arc_process| {
+                (
+                    Just(arc_process.clone()),
+                    (1_usize..3_usize),
+                    strategy::term(arc_process.clone()),
+                    (1_usize..3_usize),
+                    strategy::term(arc_process),
+                )
+                    .prop_flat_map(
+                        |(arc_process, len, default_value, index_offset, index_element)| {
+                            (
+                                Just(arc_process.clone()),
+                                Just(len),
+                                Just(default_value),
+                                Just(
+                                    arc_process
+                                        .list_from_slice(&[arc_process
+                                            .tuple_from_slice(&[
+                                                arc_process.integer(len + index_offset).unwrap(),
+                                                index_element,
+                                            ])
+                                            .unwrap()])
+                                        .unwrap(),
+                                ),
+                            )
+                        },
+                    )
+            }),
+            |(arc_process, arity_usize, default_value, init_list)| {
+                let arity = arc_process.integer(arity_usize).unwrap();
+
+                prop_assert_eq!(
+                    native(&arc_process, arity, default_value, init_list),
+                    Err(badarg!().into())
+                );
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn with_positive_index_less_than_or_equal_to_length_replaces_default_value_at_index_with_init_list_element(
+) {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process()
+                .prop_flat_map(|arc_process| {
+                    (
+                        Just(arc_process.clone()),
+                        (1_usize..3_usize),
+                        strategy::term(arc_process),
+                    )
+                })
+                .prop_flat_map(|(arc_process, len, default_value)| {
+                    (
+                        Just(arc_process.clone()),
+                        Just(len),
+                        Just(default_value),
+                        0..len,
+                        strategy::term(arc_process),
+                    )
+                }),
+            |(arc_process, arity_usize, default_value, zero_based_index, init_list_element)| {
+                let arity = arc_process.integer(arity_usize).unwrap();
+                let one_based_index = arc_process.integer(zero_based_index + 1).unwrap();
+                let init_list = arc_process
+                    .list_from_slice(&[arc_process
+                        .tuple_from_slice(&[one_based_index, init_list_element])
+                        .unwrap()])
+                    .unwrap();
+
+                let result = native(&arc_process, arity, default_value, init_list);
+
+                prop_assert!(result.is_ok());
+
+                let tuple_term = result.unwrap();
+
+                prop_assert!(tuple_term.is_tuple());
+
+                let boxed_tuple: Boxed<Tuple> = tuple_term.try_into().unwrap();
+
+                prop_assert_eq!(boxed_tuple.len(), arity_usize);
+
+                for (index, element) in boxed_tuple.iter().enumerate() {
+                    if index == zero_based_index {
+                        prop_assert_eq!(element, init_list_element);
+                    } else {
+                        prop_assert_eq!(element, default_value);
+                    }
+                }
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+// > If a position occurs more than once in the list, the term corresponding to the last occurrence
+// > is used.
+// - http://erlang.org/doc/man/erlang.html#make_tuple-3
+#[test]
+fn with_multiple_values_at_same_index_then_last_value_is_used() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &strategy::process()
+                .prop_flat_map(|arc_process| {
+                    (
+                        Just(arc_process.clone()),
+                        (1_usize..3_usize),
+                        strategy::term(arc_process),
+                    )
+                })
+                .prop_flat_map(|(arc_process, len, default_value)| {
+                    (
+                        Just(arc_process.clone()),
+                        Just(len),
+                        Just(default_value),
+                        0..len,
+                        strategy::term(arc_process.clone()),
+                        strategy::term(arc_process),
+                    )
+                }),
+            |(
+                arc_process,
+                arity_usize,
+                default_value,
+                init_list_zero_based_index,
+                init_list_ignored_element,
+                init_list_used_element,
+            )| {
+                let arity = arc_process.integer(arity_usize).unwrap();
+                let init_list_one_base_index =
+                    arc_process.integer(init_list_zero_based_index + 1).unwrap();
+                let init_list = arc_process
+                    .list_from_slice(&[
+                        arc_process
+                            .tuple_from_slice(&[
+                                init_list_one_base_index,
+                                init_list_ignored_element,
+                            ])
+                            .unwrap(),
+                        arc_process
+                            .tuple_from_slice(&[init_list_one_base_index, init_list_used_element])
+                            .unwrap(),
+                    ])
+                    .unwrap();
+
+                let result = native(&arc_process, arity, default_value, init_list);
+
+                prop_assert!(result.is_ok());
+
+                let tuple_term = result.unwrap();
+
+                prop_assert!(tuple_term.is_tuple());
+
+                let boxed_tuple: Boxed<Tuple> = tuple_term.try_into().unwrap();
+
+                prop_assert_eq!(boxed_tuple.len(), arity_usize);
+
+                for (index, element) in boxed_tuple.iter().enumerate() {
+                    if index == init_list_zero_based_index {
+                        prop_assert_eq!(element, init_list_used_element);
+                    } else {
+                        prop_assert_eq!(element, default_value);
+                    }
+                }
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}


### PR DESCRIPTION
Resolves #154

# Pre-requisites
- [x] #303  

# Changelog
## Enhancements
* Extract `HeapAlloc::mut_tuple` - The common parts of setting up a Tuple Term in HeapAlloc, before any of the elements are written.
* `:erlang.make_tuple/3`