### PR TITLE
erase/0

### DIFF
--- a/liblumen_alloc/src/erts/exception/system.rs
+++ b/liblumen_alloc/src/erts/exception/system.rs
@@ -11,7 +11,7 @@ impl From<Alloc> for Exception {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 pub struct Alloc {
     pub file: &'static str,
     pub line: u32,
@@ -21,5 +21,15 @@ pub struct Alloc {
 impl Debug for Alloc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Alloc at {}:{}:{}", self.file, self.line, self.column)
+    }
+}
+
+impl Eq for Alloc {}
+
+impl PartialEq for Alloc {
+    /// `file`, `line`, and `column` don't count for equality as they are for `Debug` only to help
+    /// track down exceptions.
+    fn eq(&self, _other: &Self) -> bool {
+        true
     }
 }

--- a/liblumen_alloc/src/erts/process/priority.rs
+++ b/liblumen_alloc/src/erts/process/priority.rs
@@ -3,7 +3,7 @@ use core::convert::{TryFrom, TryInto};
 use crate::erts::exception::runtime;
 use crate::erts::term::{Atom, Term, TypedTerm};
 
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Priority {
     Low,
     Normal,

--- a/liblumen_alloc/src/erts/term/list.rs
+++ b/liblumen_alloc/src/erts/term/list.rs
@@ -63,6 +63,18 @@ pub struct Cons {
     pub tail: Term,
 }
 impl Cons {
+    /// The number of bytes for the header and immediate terms or box term pointer to elements
+    /// allocated elsewhere.
+    pub fn need_in_bytes_from_len(len: usize) -> usize {
+        mem::size_of::<Cons>() * len
+    }
+
+    /// The number of words for the header and immediate terms or box term pointer to elements
+    /// allocated elsewhere.
+    pub fn need_in_words_from_len(len: usize) -> usize {
+        to_word_size(Self::need_in_bytes_from_len(len))
+    }
+
     /// Create a new cons cell from a head and tail pointer pair
     #[inline]
     pub fn new(head: Term, tail: Term) -> Self {
@@ -235,7 +247,7 @@ impl CloneToProcess for Cons {
             words += element.size_in_words();
         }
 
-        words += to_word_size(elements * mem::size_of::<Cons>());
+        words += Self::need_in_words_from_len(elements);
         words
     }
 }

--- a/liblumen_alloc/src/macros/erts/exception/system.rs
+++ b/liblumen_alloc/src/macros/erts/exception/system.rs
@@ -1,3 +1,4 @@
+#[macro_export]
 macro_rules! alloc {
     () => {
         $crate::erts::exception::system::Alloc {

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -44,6 +44,7 @@ pub mod demonitor_2;
 pub mod div_2;
 pub mod divide_2;
 pub mod element_2;
+pub mod erase_0;
 pub mod error_1;
 pub mod error_2;
 pub mod exit_1;

--- a/lumen_runtime/src/otp/erlang/erase_0.rs
+++ b/lumen_runtime/src/otp/erlang/erase_0.rs
@@ -1,0 +1,16 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+
+use lumen_runtime_macros::native_implemented_function;
+
+#[native_implemented_function(erase/0)]
+pub fn native(process: &Process) -> exception::Result {
+    process.erase().map_err(|alloc| alloc.into())
+}

--- a/lumen_runtime/src/otp/erlang/erase_0/test.rs
+++ b/lumen_runtime/src/otp/erlang/erase_0/test.rs
@@ -1,0 +1,13 @@
+mod with_entries;
+
+use liblumen_alloc::erts::term::Term;
+
+use crate::otp::erlang::erase_0::native;
+use crate::scheduler::with_process;
+
+#[test]
+fn without_entries_returns_empty_list() {
+    with_process(|process| {
+        assert_eq!(native(process), Ok(Term::NIL));
+    });
+}

--- a/lumen_runtime/src/otp/erlang/erase_0/test/with_entries.rs
+++ b/lumen_runtime/src/otp/erlang/erase_0/test/with_entries.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+use std::convert::TryInto;
+
+use liblumen_alloc::erts::process::alloc::heap_alloc::HeapAlloc;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::{atom_unchecked, Boxed, Cons, Tuple};
+
+use crate::process;
+
+#[test]
+fn without_heap_available_does_not_modify_dictionary() {
+    let init_arc_process = process::test_init();
+    let arc_process = crate::test::process(&init_arc_process, Default::default());
+    let key = atom_unchecked("key");
+    let value = atom_unchecked("value");
+
+    arc_process.put(key, value).unwrap();
+
+    fill_heap(&arc_process);
+
+    assert_eq!(arc_process.get(key), value);
+
+    assert_eq!(native(&arc_process), Err(liblumen_alloc::alloc!().into()));
+
+    assert_eq!(arc_process.get(key), value);
+}
+
+#[test]
+fn with_heap_available_erases_dictionary_and_returns_entries_as_list() {
+    let init_arc_process = process::test_init();
+    let arc_process = crate::test::process(&init_arc_process, Default::default());
+    let key = atom_unchecked("key");
+    let value = atom_unchecked("value");
+
+    arc_process.put(key, value).unwrap();
+
+    assert_eq!(arc_process.get(key), value);
+
+    let result = native(&arc_process);
+
+    assert!(result.is_ok());
+
+    let list = result.unwrap();
+
+    assert!(list.is_list());
+
+    let boxed_cons: Boxed<Cons> = list.try_into().unwrap();
+
+    let head = boxed_cons.head;
+
+    assert!(head.is_tuple());
+
+    let head_boxed_tuple: Boxed<Tuple> = head.try_into().unwrap();
+
+    assert_eq!(head_boxed_tuple.len(), 2);
+
+    assert_eq!(head_boxed_tuple[0], key);
+    assert_eq!(head_boxed_tuple[1], value);
+
+    assert_eq!(boxed_cons.tail, Term::NIL);
+
+    assert_eq!(arc_process.get(key), Term::NIL);
+}
+
+fn fill_heap(process: &Process) {
+    {
+        let mut heap = process.acquire_heap();
+
+        while let Ok(_) = heap.cons(atom_unchecked("hd"), atom_unchecked("tl")) {}
+    }
+}

--- a/lumen_runtime/src/process/spawn/options.rs
+++ b/lumen_runtime/src/process/spawn/options.rs
@@ -8,15 +8,14 @@ use liblumen_alloc::erts::process::{Priority, Process};
 use liblumen_alloc::erts::term::{Atom, Boxed, Cons, Term, Tuple, TypedTerm};
 use liblumen_alloc::{badarg, ModuleFunctionArity};
 
-#[allow(dead_code)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct MaxHeapSize {
     size: Option<usize>,
     kill: Option<bool>,
     error_logger: Option<bool>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum MessageQueueData {
     OnHeap,
     OffHeap,
@@ -42,7 +41,7 @@ impl TryFrom<Term> for MessageQueueData {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Options {
     pub link: bool,
     pub monitor: bool,


### PR DESCRIPTION
Part of #142.

# Changelog
## Enhancements
* `Debug for process::spawn::options::Options`
* `Cons::need_in_(bytes|words)_from_len` allow to calculated needed bytes or words to help yielding back to scheduler without partial allocation.
* `:erlang.erase/0`

## Bug Fixes
* Do not check `file`, `line`, or `column` in `Eq for Alloc`.  They are debug fields just like in `runtime::Exception`.
