### PR TITLE
list_to_integer/1

### DIFF
--- a/examples/spawn-chain/src/elixir/io/puts_1.rs
+++ b/examples/spawn-chain/src/elixir/io/puts_1.rs
@@ -1,7 +1,5 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
-use liblumen_alloc::erts::exception::runtime;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::code;
 use liblumen_alloc::erts::process::code::stack::frame::{Frame, Placement};
@@ -10,6 +8,7 @@ use liblumen_alloc::erts::term::Term;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
+use lumen_runtime::binary_to_string::binary_to_string;
 use lumen_runtime::system;
 
 pub fn place_frame_with_arguments(
@@ -30,7 +29,7 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     let elixir_string = arc_process.stack_pop().unwrap();
 
-    match elixir_string.try_into(): Result<String, runtime::Exception> {
+    match binary_to_string(elixir_string) {
         Ok(string) => {
             // NOT A DEBUGGING LOG
             system::io::puts(&string);

--- a/liblumen_alloc/src/erts/term/term.rs
+++ b/liblumen_alloc/src/erts/term/term.rs
@@ -6,8 +6,6 @@ use core::fmt::{self, Debug, Display};
 use core::hash::{Hash, Hasher};
 use core::ptr;
 
-use alloc::string::String;
-
 use crate::borrow::CloneToProcess;
 use crate::erts::exception::runtime;
 use crate::erts::exception::system::Alloc;
@@ -1734,14 +1732,6 @@ impl TryInto<BigInt> for Term {
             Some(big_int) => Ok(big_int),
             None => Err(TypeError),
         }
-    }
-}
-
-impl TryInto<String> for Term {
-    type Error = runtime::Exception;
-
-    fn try_into(self) -> Result<String, Self::Error> {
-        self.to_typed_term().unwrap().try_into()
     }
 }
 

--- a/liblumen_alloc/src/erts/term/typed_term.rs
+++ b/liblumen_alloc/src/erts/term/typed_term.rs
@@ -3,8 +3,6 @@ use core::convert::TryInto;
 use core::fmt::{self, Display};
 use core::hash::{Hash, Hasher};
 
-use alloc::string::String;
-
 use num_bigint::{BigInt, Sign};
 
 use crate::borrow::CloneToProcess;
@@ -955,23 +953,6 @@ impl TryInto<isize> for TypedTerm {
             }
             TypedTerm::Boxed(boxed) => boxed.to_typed_term().unwrap().try_into(),
             _ => Err(TypeError),
-        }
-    }
-}
-
-impl TryInto<String> for TypedTerm {
-    type Error = runtime::Exception;
-
-    fn try_into(self) -> Result<String, Self::Error> {
-        match self {
-            TypedTerm::Boxed(boxed) => boxed.to_typed_term().unwrap().try_into(),
-            TypedTerm::HeapBinary(heap_binary) => heap_binary.try_into(),
-            TypedTerm::SubBinary(subbinary) => subbinary.try_into(),
-            TypedTerm::ProcBin(process_binary) => process_binary.try_into(),
-            TypedTerm::MatchContext(match_context) => match_context.try_into(),
-            TypedTerm::Nil => Ok("".to_string()),
-            TypedTerm::List(boxed_cons) => boxed_cons.try_into(),
-            _ => Err(badarg!()),
         }
     }
 }

--- a/lumen_runtime/src/binary_to_string.rs
+++ b/lumen_runtime/src/binary_to_string.rs
@@ -1,0 +1,18 @@
+use std::convert::TryInto;
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::exception::runtime;
+use liblumen_alloc::erts::term::{Term, TypedTerm};
+
+pub fn binary_to_string(binary: Term) -> Result<String, runtime::Exception> {
+    match binary.to_typed_term().unwrap() {
+        TypedTerm::Boxed(boxed) => match boxed.to_typed_term().unwrap() {
+            TypedTerm::HeapBinary(heap_binary) => heap_binary.try_into(),
+            TypedTerm::SubBinary(subbinary) => subbinary.try_into(),
+            TypedTerm::ProcBin(process_binary) => process_binary.try_into(),
+            TypedTerm::MatchContext(match_context) => match_context.try_into(),
+            _ => Err(badarg!()),
+        },
+        _ => Err(badarg!()),
+    }
+}

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -30,6 +30,7 @@ extern crate lazy_static;
 mod macros;
 
 mod binary;
+pub mod binary_to_string;
 // `pub` or `examples/spawn-chain`
 pub mod code;
 mod config;

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -91,6 +91,7 @@ pub mod list_to_binary_1;
 pub mod list_to_bitstring_1;
 pub mod list_to_existing_atom_1;
 pub mod list_to_pid_1;
+mod list_to_string;
 pub mod list_to_tuple_1;
 pub mod make_ref_0;
 pub mod make_tuple_2;
@@ -132,6 +133,7 @@ pub mod spawn_opt_4;
 pub mod split_binary_2;
 pub mod start_timer_3;
 pub mod start_timer_4;
+mod string_to_integer;
 pub mod subtract_2;
 pub mod subtract_list_2;
 pub mod throw_1;
@@ -148,9 +150,9 @@ use core::convert::TryInto;
 use alloc::sync::Arc;
 
 use liblumen_alloc::badarg;
-use liblumen_alloc::erts::exception::{Exception, Result};
+use liblumen_alloc::erts::exception::Result;
 use liblumen_alloc::erts::process::Process;
-use liblumen_alloc::erts::term::{atom_unchecked, Atom, ImproperList, Term, TypedTerm};
+use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term, TypedTerm};
 
 use crate::registry::pid_to_self_or_process;
 use crate::time::monotonic::{self, Milliseconds};
@@ -246,24 +248,6 @@ fn is_record(term: Term, record_tag: Term, size: Option<Term>) -> Result {
             _ => Ok(false.into()),
         },
         _ => Ok(false.into()),
-    }
-}
-
-fn list_to_string(list: Term) -> std::result::Result<String, Exception> {
-    match list.to_typed_term().unwrap() {
-        TypedTerm::Nil => Ok("".to_owned()),
-        TypedTerm::List(cons) => cons
-            .into_iter()
-            .map(|result| match result {
-                Ok(term) => {
-                    let c: char = term.try_into()?;
-
-                    Ok(c)
-                }
-                Err(ImproperList { .. }) => Err(badarg!().into()),
-            })
-            .collect::<std::result::Result<String, Exception>>(),
-        _ => Err(badarg!().into()),
     }
 }
 

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -90,6 +90,7 @@ pub mod list_to_atom_1;
 pub mod list_to_binary_1;
 pub mod list_to_bitstring_1;
 pub mod list_to_existing_atom_1;
+pub mod list_to_integer_1;
 pub mod list_to_pid_1;
 mod list_to_string;
 pub mod list_to_tuple_1;

--- a/lumen_runtime/src/otp/erlang/binary_to_integer_1.rs
+++ b/lumen_runtime/src/otp/erlang/binary_to_integer_1.rs
@@ -5,23 +5,18 @@
 #[cfg(all(not(target_arch = "wasm32"), test))]
 mod test;
 
-use std::convert::TryInto;
-
-use num_bigint::BigInt;
-
-use liblumen_alloc::badarg;
 use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::Term;
 
 use lumen_runtime_macros::native_implemented_function;
 
+use crate::binary_to_string::binary_to_string;
+use crate::otp::erlang::string_to_integer::string_to_integer;
+
 #[native_implemented_function(binary_to_integer/1)]
 pub fn native(process: &Process, binary: Term) -> exception::Result {
-    let string: String = binary.try_into()?;
+    let string: String = binary_to_string(binary)?;
 
-    match BigInt::parse_bytes(string.as_bytes(), 10) {
-        Some(big_int) => process.integer(big_int).map_err(|error| error.into()),
-        None => Err(badarg!().into()),
-    }
+    string_to_integer(process, &string)
 }

--- a/lumen_runtime/src/otp/erlang/integer_to_binary_1/test/with_integer.rs
+++ b/lumen_runtime/src/otp/erlang/integer_to_binary_1/test/with_integer.rs
@@ -1,7 +1,6 @@
 use super::*;
 
-use std::convert::TryInto;
-
+use crate::binary_to_string::binary_to_string;
 use crate::otp::erlang::binary_to_integer_1;
 
 #[test]
@@ -19,7 +18,7 @@ fn with_small_integer_returns_binary() {
 
                 prop_assert!(term.is_binary());
 
-                let string: String = term.try_into().unwrap();
+                let string: String = binary_to_string(term).unwrap();
 
                 prop_assert_eq!(string, integer_isize.to_string());
 
@@ -44,7 +43,7 @@ fn with_big_integer_returns_binary() {
 
                 prop_assert!(term.is_binary());
 
-                let string: String = term.try_into().unwrap();
+                let string: String = binary_to_string(term).unwrap();
 
                 prop_assert_eq!(string, integer_isize.to_string());
 

--- a/lumen_runtime/src/otp/erlang/integer_to_binary_2/test/with_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/integer_to_binary_2/test/with_integer_integer.rs
@@ -1,9 +1,8 @@
 use super::*;
 
-use std::convert::TryInto;
-
 use proptest::arbitrary::any;
 
+use crate::binary_to_string::binary_to_string;
 use crate::otp::erlang::binary_to_integer_2;
 
 #[test]
@@ -63,7 +62,7 @@ fn with_negative_integer_returns_binary_in_base_with_negative_sign_in_front_of_n
                     let positive_isize = -1 * negative_isize;
                     let positive_integer = arc_process.integer(positive_isize).unwrap();
                     let positive_binary = native(&arc_process, positive_integer, base).unwrap();
-                    let positive_string: String = positive_binary.try_into().unwrap();
+                    let positive_string: String = binary_to_string(positive_binary).unwrap();
                     let expected_negative_string = format!("-{}", positive_string);
                     let expected_negative_binary = arc_process
                         .binary_from_str(&expected_negative_string)

--- a/lumen_runtime/src/otp/erlang/integer_to_list_1/test/with_integer.rs
+++ b/lumen_runtime/src/otp/erlang/integer_to_list_1/test/with_integer.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use std::convert::TryInto;
+use crate::otp::erlang::list_to_string::list_to_string;
 
 #[test]
 fn with_small_integer_returns_list() {
@@ -17,7 +17,7 @@ fn with_small_integer_returns_list() {
 
                 prop_assert!(term.is_list());
 
-                let string: String = term.try_into().unwrap();
+                let string: String = list_to_string(term).unwrap();
 
                 prop_assert_eq!(string, integer_isize.to_string());
 
@@ -42,7 +42,7 @@ fn with_big_integer_returns_list() {
 
                 prop_assert!(term.is_list());
 
-                let string: String = term.try_into().unwrap();
+                let string: String = list_to_string(term).unwrap();
 
                 prop_assert_eq!(string, integer_isize.to_string());
 

--- a/lumen_runtime/src/otp/erlang/integer_to_list_1/test/with_integer.rs
+++ b/lumen_runtime/src/otp/erlang/integer_to_list_1/test/with_integer.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::otp::erlang::list_to_integer_1;
 use crate::otp::erlang::list_to_string::list_to_string;
 
 #[test]
@@ -48,6 +49,28 @@ fn with_big_integer_returns_list() {
 
                 Ok(())
             })
+            .unwrap();
+    });
+}
+
+#[test]
+fn is_dual_of_list_to_integer_1() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::is_integer(arc_process.clone()),
+                |integer| {
+                    let result_list = native(&arc_process, integer);
+
+                    prop_assert!(result_list.is_ok());
+
+                    let list = result_list.unwrap();
+
+                    prop_assert_eq!(list_to_integer_1::native(&arc_process, list), Ok(integer));
+
+                    Ok(())
+                },
+            )
             .unwrap();
     });
 }

--- a/lumen_runtime/src/otp/erlang/integer_to_list_2/test/with_integer_integer.rs
+++ b/lumen_runtime/src/otp/erlang/integer_to_list_2/test/with_integer_integer.rs
@@ -1,7 +1,6 @@
 use super::*;
 
-use std::convert::TryInto;
-
+use crate::otp::erlang::list_to_string::list_to_string;
 use proptest::arbitrary::any;
 use proptest::strategy::{Just, Strategy};
 
@@ -64,7 +63,7 @@ fn with_negative_integer_returns_list_in_base_with_negative_sign_in_front_of_non
                 let positive_isize = -1 * negative_isize;
                 let positive_integer = arc_process.integer(positive_isize).unwrap();
                 let positive_list = native(&arc_process, positive_integer, base).unwrap();
-                let positive_string: String = positive_list.try_into().unwrap();
+                let positive_string: String = list_to_string(positive_list).unwrap();
                 let expected_negative_string = format!("-{}", positive_string);
                 let expected_negative_list = arc_process
                     .charlist_from_str(&expected_negative_string)

--- a/lumen_runtime/src/otp/erlang/list_to_atom_1.rs
+++ b/lumen_runtime/src/otp/erlang/list_to_atom_1.rs
@@ -11,7 +11,7 @@ use liblumen_alloc::erts::term::{AsTerm, Atom, Term};
 
 use lumen_runtime_macros::native_implemented_function;
 
-use crate::otp::erlang::list_to_string;
+use crate::otp::erlang::list_to_string::list_to_string;
 
 #[native_implemented_function(list_to_atom/1)]
 pub fn native(string: Term) -> exception::Result {

--- a/lumen_runtime/src/otp/erlang/list_to_existing_atom_1.rs
+++ b/lumen_runtime/src/otp/erlang/list_to_existing_atom_1.rs
@@ -11,7 +11,7 @@ use liblumen_alloc::erts::term::{AsTerm, Atom, Term};
 
 use lumen_runtime_macros::native_implemented_function;
 
-use crate::otp::erlang::list_to_string;
+use crate::otp::erlang::list_to_string::list_to_string;
 
 #[native_implemented_function(list_to_existing_atom/1)]
 pub fn native(string: Term) -> exception::Result {

--- a/lumen_runtime/src/otp/erlang/list_to_integer_1.rs
+++ b/lumen_runtime/src/otp/erlang/list_to_integer_1.rs
@@ -1,0 +1,22 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::Term;
+
+use lumen_runtime_macros::native_implemented_function;
+
+use crate::otp::erlang::list_to_string::list_to_string;
+use crate::otp::erlang::string_to_integer::string_to_integer;
+
+#[native_implemented_function(list_to_integer/1)]
+pub fn native(process: &Process, list: Term) -> exception::Result {
+    let string: String = list_to_string(list)?;
+
+    string_to_integer(process, &string)
+}

--- a/lumen_runtime/src/otp/erlang/list_to_integer_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/list_to_integer_1/test.rs
@@ -1,0 +1,27 @@
+mod with_list;
+
+use proptest::strategy::Strategy;
+use proptest::test_runner::{Config, TestRunner};
+use proptest::{prop_assert, prop_assert_eq};
+
+use liblumen_alloc::badarg;
+
+use crate::otp::erlang::list_to_integer_1::native;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_binary_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::is_not_binary(arc_process.clone()),
+                |binary| {
+                    prop_assert_eq!(native(&arc_process, binary), Err(badarg!().into()));
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/list_to_integer_1/test/with_list.rs
+++ b/lumen_runtime/src/otp/erlang/list_to_integer_1/test/with_list.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+use std::convert::TryInto;
+
+use liblumen_alloc::erts::term::SmallInteger;
+
+#[test]
+fn with_small_integer_returns_small_integer() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::integer::small::isize().prop_map(|integer| {
+                    (
+                        integer,
+                        arc_process.charlist_from_str(&integer.to_string()).unwrap(),
+                    )
+                }),
+                |(integer, list)| {
+                    let result = native(&arc_process, list);
+
+                    prop_assert!(result.is_ok());
+
+                    let term = result.unwrap();
+
+                    let small_integer_result: core::result::Result<SmallInteger, _> =
+                        term.try_into();
+
+                    prop_assert!(small_integer_result.is_ok());
+
+                    let small_integer = small_integer_result.unwrap();
+                    let small_integer_isize: isize = small_integer.into();
+
+                    prop_assert_eq!(small_integer_isize, integer);
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}
+
+#[test]
+fn with_big_integer_returns_big_integer() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::integer::big::isize().prop_map(|integer| {
+                    (
+                        integer,
+                        arc_process.charlist_from_str(&integer.to_string()).unwrap(),
+                    )
+                }),
+                |(integer, list)| {
+                    let result = native(&arc_process, list);
+
+                    prop_assert!(result.is_ok());
+
+                    let term = result.unwrap();
+
+                    prop_assert!(term.is_bigint());
+                    prop_assert_eq!(term, arc_process.integer(integer).unwrap());
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}
+
+#[test]
+fn with_non_decimal_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::binary::containing_bytes(
+                    "FF".as_bytes().to_owned(),
+                    arc_process.clone(),
+                ),
+                |binary| {
+                    prop_assert_eq!(native(&arc_process, binary), Err(badarg!().into()));
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/list_to_string.rs
+++ b/lumen_runtime/src/otp/erlang/list_to_string.rs
@@ -1,0 +1,23 @@
+use std::convert::TryInto;
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::exception::Exception;
+use liblumen_alloc::erts::term::{Term, TypedTerm};
+
+pub fn list_to_string(list: Term) -> Result<String, Exception> {
+    match list.to_typed_term().unwrap() {
+        TypedTerm::Nil => Ok("".to_owned()),
+        TypedTerm::List(cons) => cons
+            .into_iter()
+            .map(|result| match result {
+                Ok(term) => {
+                    let c: char = term.try_into()?;
+
+                    Ok(c)
+                }
+                Err(_) => Err(badarg!().into()),
+            })
+            .collect::<Result<String, Exception>>(),
+        _ => Err(badarg!().into()),
+    }
+}

--- a/lumen_runtime/src/otp/erlang/string_to_integer.rs
+++ b/lumen_runtime/src/otp/erlang/string_to_integer.rs
@@ -1,0 +1,12 @@
+use num_bigint::BigInt;
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+
+pub fn string_to_integer(process: &Process, string: &str) -> exception::Result {
+    match BigInt::parse_bytes(string.as_bytes(), 10) {
+        Some(big_int) => process.integer(big_int).map_err(|error| error.into()),
+        None => Err(badarg!().into()),
+    }
+}

--- a/lumen_web/src/document/create_element_2.rs
+++ b/lumen_web/src/document/create_element_2.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::exception;
@@ -8,6 +7,8 @@ use liblumen_alloc::erts::process::code::{self, result_from_exception};
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
+
+use lumen_runtime::binary_to_string::binary_to_string;
 
 use crate::document::document_from_term;
 use crate::{error, ok_tuple};
@@ -67,7 +68,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
 
 pub fn native(process: &Process, document: Term, tag: Term) -> exception::Result {
     let document_document = document_from_term(document)?;
-    let tag_string: String = tag.try_into()?;
+    let tag_string: String = binary_to_string(tag)?;
 
     match document_document.create_element(&tag_string) {
         Ok(element) => ok_tuple(process, Box::new(element)),

--- a/lumen_web/src/document/create_text_node_2.rs
+++ b/lumen_web/src/document/create_text_node_2.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::exception;
@@ -10,6 +9,7 @@ use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
 
 use crate::document::document_from_term;
+use lumen_runtime::binary_to_string::binary_to_string;
 
 /// ```elixir
 /// text = Lumen.Web.Document.create_text_node(document, data)
@@ -63,7 +63,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
 
 pub fn native(process: &Process, document: Term, data: Term) -> exception::Result {
     let document_document = document_from_term(document)?;
-    let data_string: String = data.try_into()?;
+    let data_string: String = binary_to_string(data)?;
 
     let text = document_document.create_text_node(&data_string);
     let text_box = Box::new(text);

--- a/lumen_web/src/document/get_element_by_id_2.rs
+++ b/lumen_web/src/document/get_element_by_id_2.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::exception;
@@ -8,6 +7,8 @@ use liblumen_alloc::erts::process::code::{self, result_from_exception};
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
+
+use lumen_runtime::binary_to_string::binary_to_string;
 
 use crate::document::document_from_term;
 use crate::option_to_ok_tuple_or_error;
@@ -67,7 +68,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
 
 pub fn native(process: &Process, document: Term, id: Term) -> exception::Result {
     let document_document = document_from_term(document)?;
-    let id_string: String = id.try_into()?;
+    let id_string: String = binary_to_string(id)?;
 
     option_to_ok_tuple_or_error(process, document_document.get_element_by_id(&id_string))
         .map_err(|error| error.into())

--- a/lumen_web/src/element/set_attribute_3.rs
+++ b/lumen_web/src/element/set_attribute_3.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use liblumen_alloc::erts::exception;
@@ -8,6 +7,8 @@ use liblumen_alloc::erts::process::code::{self, result_from_exception};
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
+
+use lumen_runtime::binary_to_string::binary_to_string;
 
 use crate::{element, error, ok};
 
@@ -70,8 +71,8 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
 pub fn native(process: &Process, element_term: Term, name: Term, value: Term) -> exception::Result {
     let element = element::from_term(element_term)?;
 
-    let name_string: String = name.try_into()?;
-    let value_string: String = value.try_into()?;
+    let name_string: String = binary_to_string(name)?;
+    let value_string: String = binary_to_string(value)?;
 
     match element.set_attribute(&name_string, &value_string) {
         Ok(()) => Ok(ok()),

--- a/lumen_web/src/html_form_element/element_2.rs
+++ b/lumen_web/src/html_form_element/element_2.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use wasm_bindgen::JsCast;
@@ -12,6 +11,8 @@ use liblumen_alloc::erts::process::code::{self, result_from_exception};
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::erts::ModuleFunctionArity;
+
+use lumen_runtime::binary_to_string::binary_to_string;
 
 use crate::{error, html_form_element, ok};
 
@@ -70,7 +71,7 @@ fn module_function_arity() -> Arc<ModuleFunctionArity> {
 
 fn native(process: &Process, html_form_element_term: Term, name: Term) -> exception::Result {
     let html_form_element_term = html_form_element::from_term(html_form_element_term)?;
-    let name_string: String = name.try_into()?;
+    let name_string: String = binary_to_string(name)?;
 
     let object = html_form_element_term.get_with_name(&name_string);
     let result_html_input_element: Result<HtmlInputElement, _> = object.dyn_into();


### PR DESCRIPTION
Part of #143

# Pre-reqs
- [x] #315 
- [x] #316

# Changelog
## Enhancements
* `:erlang.list_to_integer/1`

## Bug Fixes
* Don't implement `TryIto<String>` for `Term` or `TypedTerm`.  The actual use cases need to ensure that the Term or TypedTerm is a binary or list, so use binary_to_string and list_to_string, which check the type too before conversion to string.
