### PR TITLE
Re-enable safari tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,7 @@ task:
   enable_safari_driver_script: sudo safaridriver --enable
   lumen_web_test_script: |
     pushd lumen_web
-    wasm-pack test --headless --chrome --firefox
+    wasm-pack test --headless --chrome --firefox --safari
     popd
   examples_spawn_chain_build_script: |
     pushd examples/spawn-chain
@@ -142,6 +142,6 @@ task:
     popd
   examples_spawn_chain_test_script: |
     pushd examples/spawn-chain
-    wasm-pack test --headless --chrome --firefox
+    wasm-pack test --headless --chrome --firefox --safari
     popd
   before_cache_script: rm -rf $CARGO_HOME/registry/index


### PR DESCRIPTION
# Changelog
## Bug Fixes
* @fkorotkov fixed (https://github.com/cirruslabs/osx-images/issues/14#issuecomment-538139585) the `mojave-base` to "Allow Remote Automation" in Safari.