### PR TITLE
spawn/1

### DIFF
--- a/examples/spawn-chain/src/elixir/chain/none_1/test.rs
+++ b/examples/spawn-chain/src/elixir/chain/none_1/test.rs
@@ -113,7 +113,7 @@ fn run_through(n: usize) {
         options,
         Atom::try_from_str("Elixir.ChainTest").unwrap(),
         Atom::try_from_str("inspect").unwrap(),
-        vec![],
+        &[],
         inspect_code,
     )
     .unwrap();

--- a/liblumen_alloc/src/erts/term/closure.rs
+++ b/liblumen_alloc/src/erts/term/closure.rs
@@ -22,7 +22,8 @@ pub struct Closure {
     header: Term,
     creator: Term, // pid of creator process, possible to be either Pid or ExternalPid
     module_function_arity: Arc<ModuleFunctionArity>,
-    code: Code, // pointer to function entry
+    /// Pointer to function entry
+    pub code: Code,
     pub env_len: usize,
 }
 

--- a/lumen_runtime/src/future.rs
+++ b/lumen_runtime/src/future.rs
@@ -127,7 +127,7 @@ where
 
 fn spawn_unscheduled(options: Options) -> Result<(Process, Arc<Mutex<Future>>), Alloc> {
     let parent_process = None;
-    let arguments = vec![];
+    let arguments = &[];
     let process = process::spawn::code(
         parent_process,
         options,

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -139,6 +139,7 @@ pub mod send_after_3;
 pub mod send_after_4;
 pub mod setelement_3;
 pub mod size_1;
+pub mod spawn_1;
 pub mod spawn_3;
 pub mod spawn_apply_3;
 pub mod spawn_link_3;

--- a/lumen_runtime/src/otp/erlang/apply_2.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2.rs
@@ -18,22 +18,7 @@ use liblumen_alloc::{badarg, badarity};
 
 use liblumen_alloc::ModuleFunctionArity;
 
-pub fn place_frame_with_arguments(
-    process: &Process,
-    placement: Placement,
-    function: Term,
-    arguments: Term,
-) -> Result<(), Alloc> {
-    process.stack_push(arguments)?;
-    process.stack_push(function)?;
-    process.place_frame(frame(), placement);
-
-    Ok(())
-}
-
-// Private
-
-fn code(arc_process: &Arc<Process>) -> code::Result {
+pub fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let function = arc_process.stack_pop().unwrap();
@@ -93,18 +78,37 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
     }
 }
 
-fn frame() -> Frame {
-    Frame::new(module_function_arity(), code)
-}
-
-fn function() -> Atom {
+pub fn function() -> Atom {
     Atom::try_from_str("apply").unwrap()
 }
 
-fn module_function_arity() -> Arc<ModuleFunctionArity> {
+pub fn module() -> Atom {
+    super::module()
+}
+
+pub fn module_function_arity() -> Arc<ModuleFunctionArity> {
     Arc::new(ModuleFunctionArity {
-        module: super::module(),
+        module: module(),
         function: function(),
         arity: 2,
     })
+}
+
+pub fn place_frame_with_arguments(
+    process: &Process,
+    placement: Placement,
+    function: Term,
+    arguments: Term,
+) -> Result<(), Alloc> {
+    process.stack_push(arguments)?;
+    process.stack_push(function)?;
+    process.place_frame(frame(), placement);
+
+    Ok(())
+}
+
+// Private
+
+fn frame() -> Frame {
+    Frame::new(module_function_arity(), code)
 }

--- a/lumen_runtime/src/otp/erlang/apply_2/test.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2/test.rs
@@ -29,7 +29,6 @@ fn without_function_errors_badarg() {
                     } = run_until_ready(
                         Default::default(),
                         |child_process| {
-                            eprintln!("function = {:?}", function);
                             let child_function = function.clone_to_process(child_process);
                             let child_arguments = Term::NIL;
 

--- a/lumen_runtime/src/otp/erlang/spawn_1.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_1.rs
@@ -1,0 +1,38 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::Term;
+
+use lumen_runtime_macros::native_implemented_function;
+
+use crate::otp::erlang::apply_2;
+use crate::scheduler::Scheduler;
+
+#[native_implemented_function(spawn/1)]
+pub fn native(process: &Process, function: Term) -> exception::Result {
+    if function.is_function() {
+        let arguments = &[function, Term::NIL];
+
+        // The :badarity error is raised in the child process and not in the parent process, so the
+        // child process must be running the equivalent of `apply(functon, [])`.
+        let child_arc_process = Scheduler::spawn_code(
+            process,
+            Default::default(),
+            apply_2::module(),
+            apply_2::function(),
+            arguments,
+            apply_2::code,
+        )?;
+
+        Ok(child_arc_process.pid_term())
+    } else {
+        Err(badarg!().into())
+    }
+}

--- a/lumen_runtime/src/otp/erlang/spawn_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_1/test.rs
@@ -1,0 +1,31 @@
+mod with_function;
+
+use std::convert::TryInto;
+
+use proptest::prop_assert_eq;
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::process::Status;
+use liblumen_alloc::erts::term::{Pid, Term};
+
+use crate::otp::erlang::spawn_1::native;
+use crate::registry::pid_to_process;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_function_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::is_not_function(arc_process.clone()),
+                |function| {
+                    prop_assert_eq!(native(&arc_process, function), Err(badarg!().into()));
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/spawn_1/test/with_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_1/test/with_function.rs
@@ -1,0 +1,65 @@
+mod with_arity_zero;
+
+use super::*;
+
+use proptest::prop_assert;
+use proptest::strategy::Strategy;
+
+use liblumen_alloc::badarity;
+use liblumen_alloc::erts::exception::Exception;
+
+use crate::scheduler::Scheduler;
+
+#[test]
+fn without_arity_zero_returns_pid_to_parent_and_child_process_exits_badarity() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    strategy::module_function_arity::module(),
+                    strategy::module_function_arity::function(),
+                    (1_u8..=255_u8),
+                )
+                    .prop_map(|(module, function, arity)| {
+                        strategy::term::closure(&arc_process, module, function, arity)
+                    }),
+                |function| {
+                    let result = native(&arc_process, function);
+
+                    prop_assert!(result.is_ok());
+
+                    let child_pid_term = result.unwrap();
+
+                    prop_assert!(child_pid_term.is_pid());
+
+                    let child_pid: Pid = child_pid_term.try_into().unwrap();
+
+                    let child_arc_process = pid_to_process(&child_pid).unwrap();
+
+                    let scheduler = Scheduler::current();
+
+                    prop_assert!(scheduler.run_once());
+                    prop_assert!(scheduler.run_once());
+                    prop_assert!(scheduler.run_once());
+
+                    match *child_arc_process.status.read() {
+                        Status::Exiting(ref exception) => {
+                            prop_assert_eq!(
+                                Exception::Runtime(*exception),
+                                badarity!(&child_arc_process, function, Term::NIL)
+                            );
+                        }
+                        ref status => {
+                            return Err(proptest::test_runner::TestCaseError::fail(format!(
+                                "Child process did not exit.  Status is {:?}",
+                                status
+                            )))
+                        }
+                    }
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/spawn_1/test/with_function/with_arity_zero.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_1/test/with_function/with_arity_zero.rs
@@ -1,0 +1,153 @@
+use super::*;
+
+use std::sync::Arc;
+
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::atom_unchecked;
+use liblumen_alloc::erts::ModuleFunctionArity;
+use liblumen_alloc::exit;
+
+#[test]
+fn without_environment_runs_function_in_child_process() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    strategy::module_function_arity::module(),
+                    strategy::module_function_arity::function(),
+                )
+                    .prop_map(|(module, function)| {
+                        let creator = arc_process.pid_term();
+                        let module_function_arity = Arc::new(ModuleFunctionArity {
+                            module,
+                            function,
+                            arity: 0,
+                        });
+                        let code = |arc_process: &Arc<Process>| {
+                            arc_process.return_from_call(atom_unchecked("ok"))?;
+
+                            Ok(())
+                        };
+
+                        arc_process
+                            .closure_with_env_from_slice(module_function_arity, code, creator, &[])
+                            .unwrap()
+                    }),
+                |function| {
+                    let result = native(&arc_process, function);
+
+                    prop_assert!(result.is_ok());
+
+                    let child_pid_term = result.unwrap();
+
+                    prop_assert!(child_pid_term.is_pid());
+
+                    let child_pid: Pid = child_pid_term.try_into().unwrap();
+
+                    let child_arc_process = pid_to_process(&child_pid).unwrap();
+
+                    let scheduler = Scheduler::current();
+
+                    prop_assert!(scheduler.run_once());
+                    prop_assert!(scheduler.run_once());
+                    prop_assert!(scheduler.run_once());
+
+                    match *child_arc_process.status.read() {
+                        Status::Exiting(ref exception) => {
+                            prop_assert_eq!(exception, &exit!(atom_unchecked("normal")));
+                        }
+                        ref status => {
+                            return Err(proptest::test_runner::TestCaseError::fail(format!(
+                                "Child process did not exit.  Status is {:?}",
+                                status
+                            )))
+                        }
+                    }
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}
+
+#[test]
+fn with_environment_runs_function_in_child_process() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &(
+                    strategy::module_function_arity::module(),
+                    strategy::module_function_arity::function(),
+                )
+                    .prop_map(|(module, function)| {
+                        let creator = arc_process.pid_term();
+                        let module_function_arity = Arc::new(ModuleFunctionArity {
+                            module,
+                            function,
+                            arity: 0,
+                        });
+                        let code = |arc_process: &Arc<Process>| {
+                            let first = arc_process.stack_pop().unwrap();
+                            let second = arc_process.stack_pop().unwrap();
+                            let reason = arc_process.list_from_slice(&[first, second])?;
+
+                            arc_process.exception(exit!(reason));
+
+                            Ok(())
+                        };
+
+                        arc_process
+                            .closure_with_env_from_slice(
+                                module_function_arity,
+                                code,
+                                creator,
+                                &[atom_unchecked("first"), atom_unchecked("second")],
+                            )
+                            .unwrap()
+                    }),
+                |function| {
+                    let result = native(&arc_process, function);
+
+                    prop_assert!(result.is_ok());
+
+                    let child_pid_term = result.unwrap();
+
+                    prop_assert!(child_pid_term.is_pid());
+
+                    let child_pid: Pid = child_pid_term.try_into().unwrap();
+
+                    let child_arc_process = pid_to_process(&child_pid).unwrap();
+
+                    let scheduler = Scheduler::current();
+
+                    prop_assert!(scheduler.run_once());
+                    prop_assert!(scheduler.run_once());
+                    prop_assert!(scheduler.run_once());
+
+                    match *child_arc_process.status.read() {
+                        Status::Exiting(ref exception) => {
+                            prop_assert_eq!(
+                                exception,
+                                &exit!(child_arc_process
+                                    .list_from_slice(&[
+                                        atom_unchecked("first"),
+                                        atom_unchecked("second")
+                                    ])
+                                    .unwrap())
+                            );
+                        }
+                        ref status => {
+                            return Err(proptest::test_runner::TestCaseError::fail(format!(
+                                "Child process did not exit.  Status is {:?}",
+                                status
+                            )))
+                        }
+                    }
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/spawn_apply_3.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_apply_3.rs
@@ -19,10 +19,10 @@ pub(in crate::otp::erlang) fn native(
     let function_atom: Atom = function.try_into()?;
 
     if arguments.is_proper_list() {
-        let arc_process =
+        let child_arc_process =
             Scheduler::spawn_apply_3(process, options, module_atom, function_atom, arguments)?;
 
-        Ok(arc_process.pid_term())
+        Ok(child_arc_process.pid_term())
     } else {
         Err(badarg!().into())
     }

--- a/lumen_runtime/src/process.rs
+++ b/lumen_runtime/src/process.rs
@@ -203,7 +203,7 @@ pub fn test(parent_process: &Process) -> Arc<Process> {
     options.min_heap_size = Some(16_000);
     let module = test::r#loop::module();
     let function = test::r#loop::function();
-    let arguments = vec![];
+    let arguments = &[];
     let code = test::r#loop::code;
 
     Scheduler::spawn_code(parent_process, options, module, function, arguments, code).unwrap()

--- a/lumen_runtime/src/process/spawn.rs
+++ b/lumen_runtime/src/process/spawn.rs
@@ -52,7 +52,7 @@ pub fn code(
     options: Options,
     module: Atom,
     function: Atom,
-    arguments: Vec<Term>,
+    arguments: &[Term],
     code: Code,
 ) -> Result<Process, Alloc> {
     let arity = arguments.len() as u8;

--- a/lumen_runtime/src/scheduler.rs
+++ b/lumen_runtime/src/scheduler.rs
@@ -230,7 +230,7 @@ impl Scheduler {
         options: Options,
         module: Atom,
         function: Atom,
-        arguments: Vec<Term>,
+        arguments: &[Term],
         code: Code,
     ) -> Result<Arc<Process>, Alloc> {
         let process = process::spawn::code(

--- a/lumen_runtime/src/test.rs
+++ b/lumen_runtime/src/test.rs
@@ -116,7 +116,7 @@ pub fn monitored_count(process: &Process) -> usize {
 pub fn process(parent_process: &Process, options: Options) -> Arc<Process> {
     let module = r#loop::module();
     let function = r#loop::function();
-    let arguments = vec![];
+    let arguments = &[];
     let code = r#loop::code;
 
     Scheduler::spawn_code(parent_process, options, module, function, arguments, code).unwrap()

--- a/lumen_web/src/wait/with_return_0.rs
+++ b/lumen_web/src/wait/with_return_0.rs
@@ -143,7 +143,7 @@ fn spawn_unscheduled(options: Options) -> Result<(Process, Promise), Alloc> {
         options,
         super::module(),
         function(),
-        vec![],
+        &[],
         code,
     )?;
 


### PR DESCRIPTION
Part of #210 

# Changelog
## Enhancements
* `spawn_code` with `&[Term]` instead of `Vec<Term>` for more flexibility and less allocation.
* Clarify parent process vs child `arc_process` in `spawn_apply_3::native`.
* `:erlang.spawn/1`

## Bug Fixes
* Remove debugging `eprintln`.
