### PR TITLE
spawn_link/1

### DIFF
--- a/liblumen_alloc/src/erts/process.rs
+++ b/liblumen_alloc/src/erts/process.rs
@@ -44,7 +44,7 @@ use self::code::stack::frame::{Frame, Placement};
 pub use self::flags::*;
 pub use self::flags::*;
 pub use self::gc::{GcError, RootSet};
-use self::heap::ProcessHeap;
+pub use self::heap::ProcessHeap;
 pub use self::mailbox::*;
 pub use self::monitor::Monitor;
 pub use self::priority::Priority;
@@ -850,7 +850,7 @@ impl Process {
 
         let code_result = match option_code {
             Some(code) => code(arc_process),
-            None => Ok(arc_process.exit()),
+            None => Ok(arc_process.exit_normal()),
         };
 
         arc_process.stop_running();
@@ -882,9 +882,13 @@ impl Process {
         self.run_reductions.fetch_add(1, Ordering::AcqRel);
     }
 
-    pub fn exit(&self) {
+    pub fn exit(&self, reason: Term) {
         self.reduce();
-        self.exception(exit!(atom_unchecked("normal")));
+        self.exception(exit!(reason));
+    }
+
+    pub fn exit_normal(&self) {
+        self.exit(atom_unchecked("normal"))
     }
 
     pub fn is_exiting(&self) -> bool {

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -144,6 +144,7 @@ pub mod size_1;
 pub mod spawn_1;
 pub mod spawn_3;
 pub mod spawn_apply_3;
+pub mod spawn_link_1;
 pub mod spawn_link_3;
 pub mod spawn_opt_4;
 pub mod split_binary_2;

--- a/lumen_runtime/src/otp/erlang/is_process_alive_1/test/with_pid/with_self.rs
+++ b/lumen_runtime/src/otp/erlang/is_process_alive_1/test/with_pid/with_self.rs
@@ -14,7 +14,7 @@ fn without_exiting_returns_true() {
 #[test]
 fn with_exiting_returns_false() {
     with_process_arc(|arc_process| {
-        arc_process.exit();
+        arc_process.exit_normal();
 
         assert!(arc_process.is_exiting());
         assert_eq!(

--- a/lumen_runtime/src/otp/erlang/is_process_alive_1/test/with_pid/without_self/with_process.rs
+++ b/lumen_runtime/src/otp/erlang/is_process_alive_1/test/with_pid/without_self/with_process.rs
@@ -22,7 +22,7 @@ fn with_exiting_returns_false() {
     with_process_arc(|arc_process| {
         TestRunner::new(Config::with_source_file(file!()))
             .run(&strategy::process(), |other_arc_process| {
-                other_arc_process.exit();
+                other_arc_process.exit_normal();
 
                 prop_assert!(other_arc_process.is_exiting());
                 prop_assert_eq!(

--- a/lumen_runtime/src/otp/erlang/spawn_link_1.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1.rs
@@ -1,0 +1,43 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::Term;
+
+use lumen_runtime_macros::native_implemented_function;
+
+use crate::otp::erlang::apply_2;
+use crate::process::spawn::options::Options;
+use crate::scheduler::Scheduler;
+
+#[native_implemented_function(spawn_link/1)]
+pub fn native(process: &Process, function: Term) -> exception::Result {
+    if function.is_function() {
+        let options = Options {
+            link: true,
+            ..Default::default()
+        };
+        let arguments = &[function, Term::NIL];
+
+        // The :badarity error is raised in the child process and not in the parent process, so the
+        // child process must be running the equivalent of `apply(functon, [])`.
+        let child_arc_process = Scheduler::spawn_code(
+            process,
+            options,
+            apply_2::module(),
+            apply_2::function(),
+            arguments,
+            apply_2::code,
+        )?;
+
+        Ok(child_arc_process.pid_term())
+    } else {
+        Err(badarg!().into())
+    }
+}

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test.rs
@@ -1,0 +1,31 @@
+mod with_function;
+
+use std::convert::TryInto;
+
+use proptest::prop_assert_eq;
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::process::Status;
+use liblumen_alloc::erts::term::{Pid, Term};
+
+use crate::otp::erlang::spawn_link_1::native;
+use crate::registry::pid_to_process;
+use crate::scheduler::with_process_arc;
+use crate::test::strategy;
+
+#[test]
+fn without_function_errors_badarg() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term::is_not_function(arc_process.clone()),
+                |function| {
+                    prop_assert_eq!(native(&arc_process, function), Err(badarg!().into()));
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    });
+}

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function.rs
@@ -6,7 +6,6 @@ use proptest::prop_assert;
 use proptest::strategy::Strategy;
 
 use liblumen_alloc::erts::exception::Exception;
-use liblumen_alloc::erts::term::atom_unchecked;
 use liblumen_alloc::{badarity, exit};
 
 use crate::process;
@@ -61,7 +60,14 @@ fn without_arity_zero_returns_pid_to_parent_and_child_process_exits_badarity_whi
 
                 match *parent_arc_process.status.read() {
                     Status::Exiting(ref exception) => {
-                        prop_assert_eq!(*exception, exit!(atom_unchecked("normal")));
+                        let reason = match badarity!(&parent_arc_process, function, Term::NIL) {
+                            Exception::Runtime(badarity_runtime_exception) => {
+                                (badarity_runtime_exception.reason)
+                            }
+                            _ => unreachable!("parent process out-of-memory"),
+                        };
+
+                        prop_assert_eq!(*exception, exit!(reason));
                     }
                     ref status => {
                         return Err(proptest::test_runner::TestCaseError::fail(format!(

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function.rs
@@ -1,0 +1,78 @@
+mod with_arity_zero;
+
+use super::*;
+
+use proptest::prop_assert;
+use proptest::strategy::Strategy;
+
+use liblumen_alloc::erts::exception::Exception;
+use liblumen_alloc::erts::term::atom_unchecked;
+use liblumen_alloc::{badarity, exit};
+
+use crate::process;
+use crate::scheduler::Scheduler;
+
+#[test]
+fn without_arity_zero_returns_pid_to_parent_and_child_process_exits_badarity_which_exits_linked_parent(
+) {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &(
+                strategy::module_function_arity::module(),
+                strategy::module_function_arity::function(),
+                (1_u8..=255_u8),
+            ),
+            |(module, function, arity)| {
+                let parent_arc_process = process::test_init();
+                let function =
+                    strategy::term::closure(&parent_arc_process, module, function, arity);
+
+                let result = native(&parent_arc_process, function);
+
+                prop_assert!(result.is_ok());
+
+                let child_pid_term = result.unwrap();
+
+                prop_assert!(child_pid_term.is_pid());
+
+                let child_pid: Pid = child_pid_term.try_into().unwrap();
+
+                let child_arc_process = pid_to_process(&child_pid).unwrap();
+
+                let scheduler = Scheduler::current();
+
+                prop_assert!(scheduler.run_once());
+                prop_assert!(scheduler.run_once());
+
+                match *child_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        prop_assert_eq!(
+                            Exception::Runtime(*exception),
+                            badarity!(&child_arc_process, function, Term::NIL)
+                        );
+                    }
+                    ref status => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Child process did not exit.  Status is {:?}",
+                            status
+                        )))
+                    }
+                }
+
+                match *parent_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        prop_assert_eq!(*exception, exit!(atom_unchecked("normal")));
+                    }
+                    ref status => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Parent process did not exit.  Status is {:?}",
+                            status
+                        )))
+                    }
+                }
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero.rs
@@ -1,0 +1,4 @@
+mod with_environment;
+mod without_environment;
+
+use super::*;

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/with_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/with_environment.rs
@@ -1,0 +1,197 @@
+use super::*;
+
+use std::sync::Arc;
+
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::atom_unchecked;
+use liblumen_alloc::erts::ModuleFunctionArity;
+use liblumen_alloc::exit;
+
+#[test]
+fn without_expected_exit_in_child_process_exits_linked_parent_process() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &(
+                strategy::module_function_arity::module(),
+                strategy::module_function_arity::function(),
+            )
+                .prop_map(|(module, function)| {
+                    let arc_process = process::test_init();
+                    let creator = arc_process.pid_term();
+                    let module_function_arity = Arc::new(ModuleFunctionArity {
+                        module,
+                        function,
+                        arity: 0,
+                    });
+                    let code = |arc_process: &Arc<Process>| {
+                        let first = arc_process.stack_pop().unwrap();
+                        let second = arc_process.stack_pop().unwrap();
+                        let reason = arc_process.list_from_slice(&[first, second])?;
+
+                        arc_process.exception(exit!(reason));
+
+                        Ok(())
+                    };
+
+                    (
+                        arc_process.clone(),
+                        arc_process
+                            .closure_with_env_from_slice(
+                                module_function_arity,
+                                code,
+                                creator,
+                                &[atom_unchecked("first"), atom_unchecked("second")],
+                            )
+                            .unwrap(),
+                    )
+                }),
+            |(parent_arc_process, function)| {
+                let result = native(&parent_arc_process, function);
+
+                prop_assert!(result.is_ok());
+
+                let child_pid_term = result.unwrap();
+
+                prop_assert!(child_pid_term.is_pid());
+
+                let child_pid: Pid = child_pid_term.try_into().unwrap();
+
+                let child_arc_process = pid_to_process(&child_pid).unwrap();
+
+                let scheduler = Scheduler::current();
+
+                prop_assert!(scheduler.run_once());
+                prop_assert!(scheduler.run_once());
+
+                match *child_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        prop_assert_eq!(
+                            exception,
+                            &exit!(child_arc_process
+                                .list_from_slice(&[
+                                    atom_unchecked("first"),
+                                    atom_unchecked("second")
+                                ])
+                                .unwrap())
+                        );
+                    }
+                    ref status => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Child process did not exit.  Status is {:?}",
+                            status
+                        )))
+                    }
+                }
+
+                match *parent_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        prop_assert_eq!(exception, &exit!(atom_unchecked("normal")));
+                    }
+                    ref status => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Parent process did not exit.  Status is {:?}",
+                            status
+                        )))
+                    }
+                }
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn with_expected_exit_in_child_process_does_not_exit_linked_parent_process() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &(
+                strategy::module_function_arity::module(),
+                strategy::module_function_arity::function(),
+            )
+                .prop_map(|(module, function)| {
+                    let arc_process = process::test_init();
+                    let creator = arc_process.pid_term();
+                    let module_function_arity = Arc::new(ModuleFunctionArity {
+                        module,
+                        function,
+                        arity: 0,
+                    });
+                    let code = |arc_process: &Arc<Process>| {
+                        let first = arc_process.stack_pop().unwrap();
+                        let second = arc_process.stack_pop().unwrap();
+                        let reason = arc_process.tuple_from_slice(&[first, second])?;
+
+                        arc_process.exception(exit!(reason));
+
+                        Ok(())
+                    };
+
+                    (
+                        arc_process.clone(),
+                        arc_process
+                            .closure_with_env_from_slice(
+                                module_function_arity,
+                                code,
+                                creator,
+                                &[
+                                    atom_unchecked("shutdown"),
+                                    atom_unchecked("shutdown_reason"),
+                                ],
+                            )
+                            .unwrap(),
+                    )
+                }),
+            |(parent_arc_process, function)| {
+                let result = native(&parent_arc_process, function);
+
+                prop_assert!(result.is_ok());
+
+                let child_pid_term = result.unwrap();
+
+                prop_assert!(child_pid_term.is_pid());
+
+                let child_pid: Pid = child_pid_term.try_into().unwrap();
+
+                let child_arc_process = pid_to_process(&child_pid).unwrap();
+
+                let scheduler = Scheduler::current();
+
+                prop_assert!(scheduler.run_once());
+                prop_assert!(scheduler.run_once());
+
+                match *child_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        prop_assert_eq!(
+                            exception,
+                            &exit!(child_arc_process
+                                .tuple_from_slice(&[
+                                    atom_unchecked("shutdown"),
+                                    atom_unchecked("shutdown_reason")
+                                ])
+                                .unwrap())
+                        );
+                    }
+                    ref status => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Child process did not exit.  Status is {:?}",
+                            status
+                        )))
+                    }
+                }
+
+                match *parent_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Parent process exited {:?}",
+                            exception
+                        )))
+                    }
+                    _ => (),
+                }
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/with_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/with_environment.rs
@@ -85,7 +85,15 @@ fn without_expected_exit_in_child_process_exits_linked_parent_process() {
 
                 match *parent_arc_process.status.read() {
                     Status::Exiting(ref exception) => {
-                        prop_assert_eq!(exception, &exit!(atom_unchecked("normal")));
+                        prop_assert_eq!(
+                            exception,
+                            &exit!(child_arc_process
+                                .list_from_slice(&[
+                                    atom_unchecked("first"),
+                                    atom_unchecked("second")
+                                ])
+                                .unwrap())
+                        );
                     }
                     ref status => {
                         return Err(proptest::test_runner::TestCaseError::fail(format!(

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/without_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/without_environment.rs
@@ -1,0 +1,160 @@
+use super::*;
+
+use std::sync::Arc;
+
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::atom_unchecked;
+use liblumen_alloc::erts::ModuleFunctionArity;
+use liblumen_alloc::exit;
+
+#[test]
+fn without_expected_exit_in_child_process_exits_linked_parent_process() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &(
+                strategy::module_function_arity::module(),
+                strategy::module_function_arity::function(),
+            )
+                .prop_map(|(module, function)| {
+                    let arc_process = process::test_init();
+                    let creator = arc_process.pid_term();
+                    let module_function_arity = Arc::new(ModuleFunctionArity {
+                        module,
+                        function,
+                        arity: 0,
+                    });
+                    let code = |arc_process: &Arc<Process>| {
+                        arc_process.exception(exit!(atom_unchecked("not_normal")));
+
+                        Ok(())
+                    };
+
+                    (
+                        arc_process.clone(),
+                        arc_process
+                            .closure_with_env_from_slice(module_function_arity, code, creator, &[])
+                            .unwrap(),
+                    )
+                }),
+            |(parent_arc_process, function)| {
+                let result = native(&parent_arc_process, function);
+
+                prop_assert!(result.is_ok());
+
+                let child_pid_term = result.unwrap();
+
+                prop_assert!(child_pid_term.is_pid());
+
+                let child_pid: Pid = child_pid_term.try_into().unwrap();
+
+                let child_arc_process = pid_to_process(&child_pid).unwrap();
+
+                let scheduler = Scheduler::current();
+
+                prop_assert!(scheduler.run_once());
+                prop_assert!(scheduler.run_once());
+
+                match *child_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        prop_assert_eq!(exception, &exit!(atom_unchecked("not_normal")));
+                    }
+                    ref status => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Child process did not exit.  Status is {:?}",
+                            status
+                        )))
+                    }
+                }
+
+                match *parent_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        prop_assert_eq!(exception, &exit!(atom_unchecked("normal")));
+                    }
+                    ref status => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Parent process did not exit.  Status is {:?}",
+                            status
+                        )))
+                    }
+                }
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn with_expected_exit_in_child_process_does_not_exit_linked_parent_process() {
+    TestRunner::new(Config::with_source_file(file!()))
+        .run(
+            &(
+                strategy::module_function_arity::module(),
+                strategy::module_function_arity::function(),
+            )
+                .prop_map(|(module, function)| {
+                    let arc_process = process::test_init();
+                    let creator = arc_process.pid_term();
+                    let module_function_arity = Arc::new(ModuleFunctionArity {
+                        module,
+                        function,
+                        arity: 0,
+                    });
+                    let code = |arc_process: &Arc<Process>| {
+                        arc_process.return_from_call(atom_unchecked("ok"))?;
+
+                        Ok(())
+                    };
+
+                    (
+                        arc_process.clone(),
+                        arc_process
+                            .closure_with_env_from_slice(module_function_arity, code, creator, &[])
+                            .unwrap(),
+                    )
+                }),
+            |(parent_arc_process, function)| {
+                let result = native(&parent_arc_process, function);
+
+                prop_assert!(result.is_ok());
+
+                let child_pid_term = result.unwrap();
+
+                prop_assert!(child_pid_term.is_pid());
+
+                let child_pid: Pid = child_pid_term.try_into().unwrap();
+
+                let child_arc_process = pid_to_process(&child_pid).unwrap();
+
+                let scheduler = Scheduler::current();
+
+                prop_assert!(scheduler.run_once());
+                prop_assert!(scheduler.run_once());
+
+                match *child_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        prop_assert_eq!(exception, &exit!(atom_unchecked("normal")));
+                    }
+                    ref status => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Child process did not exit.  Status is {:?}",
+                            status
+                        )))
+                    }
+                }
+
+                match *parent_arc_process.status.read() {
+                    Status::Exiting(ref exception) => {
+                        return Err(proptest::test_runner::TestCaseError::fail(format!(
+                            "Parent process exited {:?}",
+                            exception
+                        )))
+                    }
+                    _ => (),
+                }
+
+                Ok(())
+            },
+        )
+        .unwrap();
+}

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/without_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/without_environment.rs
@@ -68,7 +68,7 @@ fn without_expected_exit_in_child_process_exits_linked_parent_process() {
 
                 match *parent_arc_process.status.read() {
                     Status::Exiting(ref exception) => {
-                        prop_assert_eq!(exception, &exit!(atom_unchecked("normal")));
+                        prop_assert_eq!(exception, &exit!(atom_unchecked("not_normal")));
                     }
                     ref status => {
                         return Err(proptest::test_runner::TestCaseError::fail(format!(

--- a/lumen_runtime/src/process.rs
+++ b/lumen_runtime/src/process.rs
@@ -11,10 +11,10 @@ use liblumen_alloc::erts::exception::runtime;
 use liblumen_alloc::erts::exception::system::Alloc;
 use liblumen_alloc::erts::process::alloc::heap_alloc::HeapAlloc;
 use liblumen_alloc::erts::process::code::stack::frame::Frame;
-use liblumen_alloc::erts::process::{self, Process};
+use liblumen_alloc::erts::process::{self, Process, ProcessHeap};
 use liblumen_alloc::erts::term::{atom_unchecked, Atom, Term, Tuple, TypedTerm};
 use liblumen_alloc::erts::ModuleFunctionArity;
-use liblumen_alloc::HeapFragment;
+use liblumen_alloc::{CloneToProcess, HeapFragment};
 
 use crate::code;
 #[cfg(test)]
@@ -85,6 +85,7 @@ pub fn propagate_exit_to_links(process: &Process, exception: &runtime::Exception
         let tag = atom_unchecked("EXIT");
         let from = process.pid_term();
         let reason = exception.reason;
+        let reason_word_size = reason.size_in_words();
         let exit_message_elements: &[Term] = &[tag, from, reason];
         let exit_message_word_size = Tuple::need_in_words_from_elements(exit_message_elements);
 
@@ -94,35 +95,71 @@ pub fn propagate_exit_to_links(process: &Process, exception: &runtime::Exception
                     match linked_pid_arc_process.try_acquire_heap() {
                         Some(ref mut linked_pid_heap) => {
                             if exit_message_word_size <= linked_pid_heap.heap_available() {
-                                let linked_pid_data = linked_pid_heap
-                                    .tuple_from_slice(exit_message_elements)
-                                    .unwrap();
-
-                                linked_pid_arc_process.send_from_self(linked_pid_data);
+                                send_self_exit_message(
+                                    &linked_pid_arc_process,
+                                    linked_pid_heap,
+                                    exit_message_elements,
+                                );
                             } else {
-                                let (heap_fragment_data, heap_fragment) =
-                                    HeapFragment::tuple_from_slice(exit_message_elements).unwrap();
-
-                                linked_pid_arc_process
-                                    .send_heap_message(heap_fragment, heap_fragment_data);
+                                send_heap_exit_message(
+                                    &linked_pid_arc_process,
+                                    exit_message_elements,
+                                );
                             }
                         }
                         None => {
-                            let (heap_fragment_data, heap_fragment) =
-                                HeapFragment::tuple_from_slice(exit_message_elements).unwrap();
-
-                            linked_pid_arc_process
-                                .send_heap_message(heap_fragment, heap_fragment_data);
+                            send_heap_exit_message(&linked_pid_arc_process, exit_message_elements);
                         }
                     }
                 } else {
                     // only tell the linked process to exit.  When it is run by its scheduler, it
                     // will go through propagating its own exit.
-                    linked_pid_arc_process.exit();
+                    match linked_pid_arc_process.try_acquire_heap() {
+                        Some(ref mut linked_pid_heap) => {
+                            if reason_word_size <= linked_pid_heap.heap_available() {
+                                exit_in_heap(&linked_pid_arc_process, linked_pid_heap, reason);
+                            } else {
+                                exit_in_heap_fragment(&linked_pid_arc_process, reason);
+                            }
+                        }
+                        None => {
+                            exit_in_heap_fragment(&linked_pid_arc_process, reason);
+                        }
+                    }
                 }
             }
         }
     }
+}
+
+fn send_self_exit_message(
+    process: &Process,
+    heap: &mut ProcessHeap,
+    exit_message_elements: &[Term],
+) {
+    let data = heap.tuple_from_slice(exit_message_elements).unwrap();
+
+    process.send_from_self(data);
+}
+
+fn send_heap_exit_message(process: &Process, exit_message_elements: &[Term]) {
+    let (heap_fragment_data, heap_fragment) =
+        HeapFragment::tuple_from_slice(exit_message_elements).unwrap();
+
+    process.send_heap_message(heap_fragment, heap_fragment_data);
+}
+
+fn exit_in_heap(process: &Process, heap: &mut ProcessHeap, reason: Term) {
+    let data = reason.clone_to_heap(heap).unwrap();
+
+    process.exit(data);
+}
+
+fn exit_in_heap_fragment(process: &Process, reason: Term) {
+    let (heap_fragment_data, mut heap_fragment) = reason.clone_to_fragment().unwrap();
+
+    process.attach_fragment(unsafe { heap_fragment.as_mut() });
+    process.exit(heap_fragment_data);
 }
 
 pub fn register_in(

--- a/lumen_runtime/src/run/queues.rs
+++ b/lumen_runtime/src/run/queues.rs
@@ -78,7 +78,7 @@ impl Queues {
             }
             PushBack => {
                 if arc_process.code_stack_len() == 0 {
-                    arc_process.exit();
+                    arc_process.exit_normal();
                     Some(arc_process)
                 } else {
                     self.enqueue(arc_process);

--- a/lumen_runtime/src/scheduler/test.rs
+++ b/lumen_runtime/src/scheduler/test.rs
@@ -35,7 +35,7 @@ fn scheduler_does_run_exiting_process() {
         assert!(scheduler.run_through(&arc_process));
         assert!(scheduler.is_run_queued(&arc_process));
 
-        arc_process.exit();
+        arc_process.exit_normal();
 
         assert!(scheduler.is_run_queued(&arc_process));
         assert!(!scheduler.run_through(&arc_process));


### PR DESCRIPTION
Part of #210 

# Changelog
## Enhancements
* `:erlang.spawn_link/1`

## Bug Fixes
* Linked processes exit with the same reason as the original process instead of `:normal`.