### PR TITLE
unique_integer/1

### DIFF
--- a/liblumen_alloc/src/erts/scheduler/id.rs
+++ b/liblumen_alloc/src/erts/scheduler/id.rs
@@ -31,6 +31,12 @@ impl Into<u32> for ID {
     }
 }
 
+impl Into<u128> for ID {
+    fn into(self) -> u128 {
+        self.0 as u128
+    }
+}
+
 lazy_static! {
     static ref ID_COUNTER: AtomicU32 = AtomicU32::new(0);
 }

--- a/liblumen_alloc/src/erts/term/integer.rs
+++ b/liblumen_alloc/src/erts/term/integer.rs
@@ -139,6 +139,17 @@ impl From<u64> for Integer {
         }
     }
 }
+impl From<u128> for Integer {
+    fn from(u: u128) -> Integer {
+        let result_isize: Result<isize, _> = u.try_into();
+
+        match result_isize {
+            Err(_) => Integer::Big(u.into()),
+            Ok(i) if SmallInteger::MAX_VALUE < i => Integer::Big(i.into()),
+            Ok(i) => Integer::Small(unsafe { SmallInteger::new_unchecked(i) }),
+        }
+    }
+}
 impl From<usize> for Integer {
     #[inline]
     fn from(n: usize) -> Integer {
@@ -158,6 +169,15 @@ impl From<i32> for Integer {
 impl From<i64> for Integer {
     fn from(n: i64) -> Integer {
         if (SmallInteger::MIN_VALUE as i64) <= n && n <= (SmallInteger::MAX_VALUE as i64) {
+            Integer::Small(unsafe { SmallInteger::new_unchecked(n as isize) })
+        } else {
+            Integer::Big(n.into())
+        }
+    }
+}
+impl From<i128> for Integer {
+    fn from(n: i128) -> Integer {
+        if (SmallInteger::MIN_VALUE as i128) <= n && n <= (SmallInteger::MAX_VALUE as i128) {
             Integer::Small(unsafe { SmallInteger::new_unchecked(n as isize) })
         } else {
             Integer::Big(n.into())

--- a/liblumen_alloc/src/erts/term/integer/big.rs
+++ b/liblumen_alloc/src/erts/term/integer/big.rs
@@ -78,6 +78,11 @@ impl From<u64> for BigInteger {
         Self::new(BigInt::from(n))
     }
 }
+impl From<u128> for BigInteger {
+    fn from(n: u128) -> Self {
+        Self::new(BigInt::from(n))
+    }
+}
 impl From<usize> for BigInteger {
     #[inline]
     fn from(n: usize) -> Self {
@@ -93,6 +98,12 @@ impl From<isize> for BigInteger {
 impl From<i64> for BigInteger {
     #[inline]
     fn from(n: i64) -> Self {
+        Self::new(BigInt::from(n))
+    }
+}
+impl From<i128> for BigInteger {
+    #[inline]
+    fn from(n: i128) -> Self {
         Self::new(BigInt::from(n))
     }
 }

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -170,6 +170,8 @@ pub mod tl_1;
 pub mod trunc_1;
 pub mod tuple_size_1;
 pub mod tuple_to_list_1;
+mod unique_integer;
+pub mod unique_integer_1;
 pub mod universaltime_0;
 pub mod unlink_1;
 pub mod unregister_1;

--- a/lumen_runtime/src/otp/erlang/round_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/round_1/test.rs
@@ -67,22 +67,10 @@ fn with_float_rounds_to_nearest_integer() {
                     let result_big_int: BigInt = result_term.try_into().unwrap();
 
                     prop_assert_eq!(number_big_int, result_big_int);
-                } else if (0.0 < number_f64 && number_fract < 0.5)
-                    || (number_f64 < 0.0 && number_fract < -0.5)
-                {
-                    prop_assert!(
-                        result_term <= number,
-                        "Expected rounded ({:?}) <= number ({:?})",
-                        result_term,
-                        number
-                    );
                 } else {
-                    prop_assert!(
-                        number <= result_term,
-                        "Expected number ({:?}) <= rounded ({:?})",
-                        number,
-                        result_term
-                    );
+                    let result_f64: f64 = result_term.try_into().unwrap();
+
+                    prop_assert!((result_f64 - number_f64).abs() <= 0.5)
                 }
 
                 Ok(())

--- a/lumen_runtime/src/otp/erlang/time_offset_0/test.rs
+++ b/lumen_runtime/src/otp/erlang/time_offset_0/test.rs
@@ -4,7 +4,7 @@ use crate::otp::erlang::system_time_0;
 use crate::otp::erlang::time_offset_0;
 use crate::scheduler::with_process;
 
-const TIME_OFFSET_DELTA_LIMIT: u64 = 5;
+const TIME_OFFSET_DELTA_LIMIT: u64 = 20;
 
 #[test]
 fn approximately_system_time_minus_monotonic_time() {
@@ -18,6 +18,11 @@ fn approximately_system_time_minus_monotonic_time() {
         let time_offset_delta =
             subtract_2::native(process, expected_time_offset, time_offset).unwrap();
 
-        assert!(time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap());
+        assert!(
+            time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap(),
+            "time_offset_delta ({:?}) <= TIME_OFFSET_DELTA_LIMIT ({:?})",
+            time_offset_delta,
+            TIME_OFFSET_DELTA_LIMIT
+        );
     });
 }

--- a/lumen_runtime/src/otp/erlang/time_offset_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/time_offset_1/test.rs
@@ -1,116 +1,56 @@
-use crate::otp::erlang::monotonic_time_1;
-use crate::otp::erlang::subtract_2;
-use crate::otp::erlang::system_time_1;
-use crate::otp::erlang::time_offset_1;
-use crate::scheduler::with_process;
 use liblumen_alloc::erts::term::atom_unchecked;
 
-const TIME_OFFSET_DELTA_LIMIT: u64 = 5;
+use crate::otp::erlang::{monotonic_time_1, subtract_2, system_time_1, time_offset_1};
+use crate::scheduler::with_process;
+
+const TIME_OFFSET_DELTA_LIMIT: u64 = 20;
 
 #[test]
 fn approximately_system_time_minus_monotonic_time_in_seconds() {
-    with_process(|process| {
-        let unit = atom_unchecked("second");
-
-        let monotonic_time = monotonic_time_1::native(process, unit).unwrap();
-        let system_time = system_time_1::native(process, unit).unwrap();
-        let time_offset = time_offset_1::native(process, unit).unwrap();
-        let expected_time_offset =
-            subtract_2::native(process, system_time, monotonic_time).unwrap();
-
-        let time_offset_delta =
-            subtract_2::native(process, expected_time_offset, time_offset).unwrap();
-
-        assert!(time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap());
-    });
+    approximately_system_time_minus_monotonic_time_in_unit("second")
 }
 
 #[test]
 fn approximately_system_time_minus_monotonic_time_in_milliseconds() {
-    with_process(|process| {
-        let unit = atom_unchecked("millisecond");
-
-        let monotonic_time = monotonic_time_1::native(process, unit).unwrap();
-        let system_time = system_time_1::native(process, unit).unwrap();
-        let time_offset = time_offset_1::native(process, unit).unwrap();
-        let expected_time_offset =
-            subtract_2::native(process, system_time, monotonic_time).unwrap();
-
-        let time_offset_delta =
-            subtract_2::native(process, expected_time_offset, time_offset).unwrap();
-
-        assert!(time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap());
-    });
+    approximately_system_time_minus_monotonic_time_in_unit("millisecond")
 }
 
 #[test]
 fn approximately_system_time_minus_monotonic_time_in_microseconds() {
-    with_process(|process| {
-        let unit = atom_unchecked("microsecond");
-
-        let monotonic_time = monotonic_time_1::native(process, unit).unwrap();
-        let system_time = system_time_1::native(process, unit).unwrap();
-        let time_offset = time_offset_1::native(process, unit).unwrap();
-        let expected_time_offset =
-            subtract_2::native(process, system_time, monotonic_time).unwrap();
-
-        let time_offset_delta =
-            subtract_2::native(process, expected_time_offset, time_offset).unwrap();
-
-        assert!(time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap());
-    });
+    approximately_system_time_minus_monotonic_time_in_unit("microsecond")
 }
 
 #[test]
 fn approximately_system_time_minus_monotonic_time_in_nanoseconds() {
-    with_process(|process| {
-        let unit = atom_unchecked("nanosecond");
-
-        let monotonic_time = monotonic_time_1::native(process, unit).unwrap();
-        let system_time = system_time_1::native(process, unit).unwrap();
-        let time_offset = time_offset_1::native(process, unit).unwrap();
-        let expected_time_offset =
-            subtract_2::native(process, system_time, monotonic_time).unwrap();
-
-        let time_offset_delta =
-            subtract_2::native(process, expected_time_offset, time_offset).unwrap();
-
-        assert!(time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap());
-    });
+    approximately_system_time_minus_monotonic_time_in_unit("nanosecond");
 }
 
 #[test]
 fn approximately_system_time_minus_monotonic_time_in_native_time_units() {
-    with_process(|process| {
-        let unit = atom_unchecked("native");
-
-        let monotonic_time = monotonic_time_1::native(process, unit).unwrap();
-        let system_time = system_time_1::native(process, unit).unwrap();
-        let time_offset = time_offset_1::native(process, unit).unwrap();
-        let expected_time_offset =
-            subtract_2::native(process, system_time, monotonic_time).unwrap();
-
-        let time_offset_delta =
-            subtract_2::native(process, expected_time_offset, time_offset).unwrap();
-
-        assert!(time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap());
-    });
+    approximately_system_time_minus_monotonic_time_in_unit("native");
 }
 
 #[test]
 fn approximately_system_time_minus_monotonic_time_in_perf_counter_ticks() {
-    with_process(|process| {
-        let unit = atom_unchecked("perf_counter");
+    approximately_system_time_minus_monotonic_time_in_unit("perf_counter");
+}
 
+fn approximately_system_time_minus_monotonic_time_in_unit(unit_str: &str) {
+    with_process(|process| {
+        let unit = atom_unchecked(unit_str);
         let monotonic_time = monotonic_time_1::native(process, unit).unwrap();
         let system_time = system_time_1::native(process, unit).unwrap();
         let time_offset = time_offset_1::native(process, unit).unwrap();
         let expected_time_offset =
             subtract_2::native(process, system_time, monotonic_time).unwrap();
-
         let time_offset_delta =
             subtract_2::native(process, expected_time_offset, time_offset).unwrap();
 
-        assert!(time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap());
+        assert!(
+            time_offset_delta <= process.integer(TIME_OFFSET_DELTA_LIMIT).unwrap(),
+            "time_offset_delta ({:?}) <= TIME_OFFSET_DELTA_LIMIT ({:?})",
+            time_offset_delta,
+            TIME_OFFSET_DELTA_LIMIT
+        );
     });
 }

--- a/lumen_runtime/src/otp/erlang/unique_integer.rs
+++ b/lumen_runtime/src/otp/erlang/unique_integer.rs
@@ -1,0 +1,132 @@
+use std::convert::TryFrom;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::exception::{self, runtime};
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::{Term, TypedTerm};
+
+use crate::scheduler::Scheduler;
+
+/// There are two types of unique integers both created using the erlang:unique_integer() BIF:
+///
+/// 1. Unique integers created with the monotonic modifier consist of a set of 2⁶⁴ - 1 unique
+///    integers.
+/// 2. Unique integers created without the monotonic modifier consist of a set of 2⁶⁴ - 1 unique
+///    integers per scheduler thread and a set of 2⁶⁴ - 1 unique integers shared by other threads.
+///    That is, the total amount of unique integers without the monotonic modifier is
+///    (NoSchedulers + 1) × (2⁶⁴ - 1).
+///
+/// If a unique integer is created each nanosecond, unique integers will at earliest be reused after
+/// more than 584 years. That is, for the foreseeable future they are unique enough.
+///
+/// - http://erlang.org/doc/efficiency_guide/advanced.html#unique_integers
+pub fn unique_integer(process: &Process, options: Options) -> exception::Result {
+    if options.monotonic {
+        let u = MONOTONIC.fetch_add(1, Ordering::SeqCst);
+
+        // See https://github.com/erlang/otp/blob/769ff22c750d939fdc9cb45fae1e44817ec04307/erts/emulator/beam/erl_bif_unique.c#L669-L697
+        if options.positive {
+            process.integer(u)
+        } else {
+            // When not positive allow for negative and positive even though the counter is unsigned
+            // by subtracting counter value down into signed range.
+            let i = if u < NEGATED_I64_MIN_U64 {
+                (u as i64) + std::i64::MIN
+            } else {
+                (u - NEGATED_I64_MIN_U64) as i64
+            };
+
+            process.integer(i)
+        }
+    } else {
+        // Non-monotonic unique integers are per-scheduler (https://github.com/erlang/otp/blob/769ff22c750d939fdc9cb45fae1e44817ec04307/erts/emulator/beam/erl_bif_unique.c#L572-L584)
+        // Instead of being u64, they are u128 with the first u64 is the scheduler ID
+        let scheduler_id = process.scheduler_id().unwrap();
+        let scheduler_id_u128: u128 = scheduler_id.into();
+
+        let arc_scheduler = Scheduler::from_id(&scheduler_id).unwrap();
+        let scheduler_unique_integer = arc_scheduler.next_unique_integer() as u128;
+
+        let u: u128 = (scheduler_id_u128 << 64) | scheduler_unique_integer;
+
+        if options.positive {
+            process.integer(u)
+        } else {
+            let i = if u < NEGATED_I128_MIN_U128 {
+                (u as i128) + std::i128::MIN
+            } else {
+                (u - NEGATED_I128_MIN_U128) as i128
+            };
+
+            process.integer(i)
+        }
+    }
+    .map_err(|alloc| alloc.into())
+}
+
+pub struct Options {
+    positive: bool,
+    monotonic: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            monotonic: false,
+            positive: false,
+        }
+    }
+}
+
+impl Options {
+    fn put_option_term(&mut self, option: Term) -> Result<&Self, runtime::Exception> {
+        match option.to_typed_term().unwrap() {
+            TypedTerm::Atom(atom) => match atom.name() {
+                "monotonic" => {
+                    self.monotonic = true;
+
+                    Ok(self)
+                }
+                "positive" => {
+                    self.positive = true;
+
+                    Ok(self)
+                }
+                _ => Err(badarg!()),
+            },
+            _ => Err(badarg!()),
+        }
+    }
+}
+
+impl TryFrom<Term> for Options {
+    type Error = runtime::Exception;
+
+    fn try_from(term: Term) -> Result<Self, Self::Error> {
+        let mut options: Options = Default::default();
+        let mut options_term = term;
+
+        loop {
+            match options_term.to_typed_term().unwrap() {
+                TypedTerm::Nil => return Ok(options),
+                TypedTerm::List(cons) => {
+                    options.put_option_term(cons.head)?;
+                    options_term = cons.tail;
+
+                    continue;
+                }
+                _ => return Err(badarg!().into()),
+            }
+        }
+    }
+}
+
+// have to add and then subtract to prevent overflow
+const NEGATED_I64_MIN_U64: u64 = ((-(std::i64::MIN + 1)) - 1) as u64;
+// have to add and then subtract to prevent overflow
+const NEGATED_I128_MIN_U128: u128 = ((-(std::i128::MIN + 1)) - 1) as u128;
+
+lazy_static! {
+    static ref MONOTONIC: AtomicU64 = Default::default();
+}

--- a/lumen_runtime/src/otp/erlang/unique_integer_1.rs
+++ b/lumen_runtime/src/otp/erlang/unique_integer_1.rs
@@ -1,0 +1,23 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use std::convert::TryInto;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::Term;
+
+use lumen_runtime_macros::native_implemented_function;
+
+use crate::otp::erlang::unique_integer::{unique_integer, Options};
+
+#[native_implemented_function(unique_integer/1)]
+pub fn native(process: &Process, options: Term) -> exception::Result {
+    let options_options: Options = options.try_into()?;
+
+    unique_integer(process, options_options)
+}

--- a/lumen_runtime/src/otp/erlang/unique_integer_1/test.rs
+++ b/lumen_runtime/src/otp/erlang/unique_integer_1/test.rs
@@ -1,0 +1,172 @@
+use proptest::prop_assert_eq;
+use proptest::strategy::Strategy;
+use proptest::test_runner::{Config, TestRunner};
+
+use liblumen_alloc::badarg;
+use liblumen_alloc::erts::term::{atom_unchecked, Term, TypedTerm};
+
+use crate::otp::erlang::unique_integer_1::native;
+use crate::scheduler::{with_process, with_process_arc};
+use crate::test::strategy;
+
+#[test]
+fn without_proper_list_of_options_errors_badargs() {
+    with_process_arc(|arc_process| {
+        TestRunner::new(Config::with_source_file(file!()))
+            .run(
+                &strategy::term(arc_process.clone()).prop_filter(
+                    "Cannot be a proper list of valid options",
+                    |term| match term.to_typed_term().unwrap() {
+                        TypedTerm::Nil => false,
+                        TypedTerm::List(cons) => {
+                            let mut filter = true;
+
+                            for result in cons.into_iter() {
+                                match result {
+                                    Ok(element) => match element.to_typed_term().unwrap() {
+                                        TypedTerm::Atom(atom) => match atom.name() {
+                                            "monotonic" | "positive" => {
+                                                filter = false;
+
+                                                break;
+                                            }
+                                            _ => break,
+                                        },
+                                        _ => continue,
+                                    },
+                                    Err(_) => break,
+                                }
+                            }
+
+                            filter
+                        }
+                        _ => true,
+                    },
+                ),
+                |options| {
+                    prop_assert_eq!(native(&arc_process, options), Err(badarg!().into()));
+
+                    Ok(())
+                },
+            )
+            .unwrap();
+    })
+}
+
+#[test]
+fn without_options_returns_non_monotonic_negative_and_positive_integer() {
+    const OPTIONS: Term = Term::NIL;
+
+    with_process(|process| {
+        let result_first_unique_integer = native(process, OPTIONS);
+
+        assert!(result_first_unique_integer.is_ok());
+
+        let first_unique_integer = result_first_unique_integer.unwrap();
+        let zero = process.integer(0).unwrap();
+
+        assert!(first_unique_integer.is_integer());
+        assert!(first_unique_integer <= zero);
+
+        let result_second_unique_integer = native(process, OPTIONS);
+
+        assert!(result_second_unique_integer.is_ok());
+
+        let second_unique_integer = result_second_unique_integer.unwrap();
+
+        assert!(second_unique_integer.is_integer());
+        assert!(second_unique_integer <= zero);
+
+        assert_ne!(first_unique_integer, second_unique_integer);
+    });
+}
+
+#[test]
+fn with_monotonic_returns_monotonic_negative_and_positiver_integer() {
+    with_process(|process| {
+        let options = process
+            .list_from_slice(&[atom_unchecked("monotonic")])
+            .unwrap();
+
+        let result_first_unique_integer = native(process, options);
+
+        assert!(result_first_unique_integer.is_ok());
+
+        let first_unique_integer = result_first_unique_integer.unwrap();
+        let zero = process.integer(0).unwrap();
+
+        assert!(first_unique_integer.is_integer());
+        assert!(first_unique_integer <= zero);
+
+        let result_second_unique_integer = native(process, options);
+
+        assert!(result_second_unique_integer.is_ok());
+
+        let second_unique_integer = result_second_unique_integer.unwrap();
+
+        assert!(second_unique_integer.is_integer());
+        assert!(second_unique_integer <= zero);
+
+        assert!(first_unique_integer < second_unique_integer);
+    });
+}
+
+#[test]
+fn with_monotonic_and_positive_returns_monotonic_positiver_integer() {
+    with_process(|process| {
+        let options = process
+            .list_from_slice(&[atom_unchecked("monotonic"), atom_unchecked("positive")])
+            .unwrap();
+
+        let result_first_unique_integer = native(process, options);
+
+        assert!(result_first_unique_integer.is_ok());
+
+        let first_unique_integer = result_first_unique_integer.unwrap();
+        let zero = process.integer(0).unwrap();
+
+        assert!(first_unique_integer.is_integer());
+        assert!(zero <= first_unique_integer);
+
+        let result_second_unique_integer = native(process, options);
+
+        assert!(result_second_unique_integer.is_ok());
+
+        let second_unique_integer = result_second_unique_integer.unwrap();
+
+        assert!(second_unique_integer.is_integer());
+        assert!(zero <= second_unique_integer);
+
+        assert!(first_unique_integer < second_unique_integer);
+    });
+}
+
+#[test]
+fn with_positive_returns_non_monotonic_and_positive_integer() {
+    with_process(|process| {
+        let options = process
+            .list_from_slice(&[atom_unchecked("positive")])
+            .unwrap();
+
+        let result_first_unique_integer = native(process, options);
+
+        assert!(result_first_unique_integer.is_ok());
+
+        let first_unique_integer = result_first_unique_integer.unwrap();
+        let zero = process.integer(0).unwrap();
+
+        assert!(first_unique_integer.is_integer());
+        assert!(zero <= first_unique_integer);
+
+        let result_second_unique_integer = native(process, options);
+
+        assert!(result_second_unique_integer.is_ok());
+
+        let second_unique_integer = result_second_unique_integer.unwrap();
+
+        assert!(second_unique_integer.is_integer());
+        assert!(zero <= second_unique_integer);
+
+        assert_ne!(first_unique_integer, second_unique_integer);
+    });
+}

--- a/lumen_runtime/src/scheduler.rs
+++ b/lumen_runtime/src/scheduler.rs
@@ -48,6 +48,9 @@ pub struct Scheduler {
     // References are always 64-bits even on 32-bit platforms
     reference_count: AtomicU64,
     run_queues: RwLock<run::queues::Queues>,
+    // Non-monotonic unique integers are scoped to the scheduler ID and then use this per-scheduler
+    // `u64`.
+    unique_integer: AtomicU64,
 }
 
 impl Scheduler {
@@ -76,6 +79,10 @@ impl Scheduler {
 
     pub fn next_reference_number(&self) -> reference::Number {
         self.reference_count.fetch_add(1, Ordering::SeqCst)
+    }
+
+    pub fn next_unique_integer(&self) -> u64 {
+        self.unique_integer.fetch_add(1, Ordering::SeqCst)
     }
 
     /// > 1. Update reduction counters
@@ -293,6 +300,7 @@ impl Scheduler {
             hierarchy: Default::default(),
             reference_count: AtomicU64::new(0),
             run_queues: Default::default(),
+            unique_integer: AtomicU64::new(0),
         }
     }
 


### PR DESCRIPTION
Part of #159

# Changelog
## Enhancements
* `:erlang.unique_integer/1`

## Bug Fixes
* Increase `TIME_OFFSET_DELTA_LIMIT` from `5` to `20`.  [The increase from `2` to `5`](https://github.com/lumen/lumen/pull/353) is [still enough on CI](https://github.com/lumen/lumen/runs/288225774).  Also log what the 2 values are when the assert fails, so that more increases can be tuned experimentally.
* Use `round/1` round <= 0.5 for invariant.  Old logic was incorrect for invariant and so made the `round/1` test flaky.