### PR TITLE
function_exported/3

### DIFF
--- a/lumen_runtime/src/code/export.rs
+++ b/lumen_runtime/src/code/export.rs
@@ -11,7 +11,19 @@ use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::{Atom, Term};
 use liblumen_alloc::{Arity, ModuleFunctionArity};
 
-pub fn get(module: &Atom, function: &Atom, arity: u8) -> Option<Code> {
+pub fn contains_key(module: &Atom, function: &Atom, arity: Arity) -> bool {
+    RW_LOCK_CODE_BY_ARITY_BY_FUNCTION_BY_MODULE
+        .read()
+        .get(module)
+        .and_then(|code_by_arity_by_function| {
+            code_by_arity_by_function
+                .get(function)
+                .map(|code_by_arity| code_by_arity.contains_key(&arity))
+        })
+        .unwrap_or(false)
+}
+
+pub fn get(module: &Atom, function: &Atom, arity: Arity) -> Option<Code> {
     RW_LOCK_CODE_BY_ARITY_BY_FUNCTION_BY_MODULE
         .read()
         .get(module)
@@ -22,7 +34,7 @@ pub fn get(module: &Atom, function: &Atom, arity: u8) -> Option<Code> {
         })
 }
 
-pub fn insert(module: Atom, function: Atom, arity: u8, code: Code) {
+pub fn insert(module: Atom, function: Atom, arity: Arity, code: Code) {
     RW_LOCK_CODE_BY_ARITY_BY_FUNCTION_BY_MODULE
         .write()
         .entry(module)

--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -59,6 +59,7 @@ pub mod float_to_list_1;
 pub mod float_to_list_2;
 mod float_to_string;
 pub mod floor_1;
+pub mod function_exported_3;
 pub mod get_0;
 pub mod get_1;
 pub mod get_keys_0;

--- a/lumen_runtime/src/otp/erlang/function_exported_3.rs
+++ b/lumen_runtime/src/otp/erlang/function_exported_3.rs
@@ -1,0 +1,48 @@
+//! ```elixir
+//! @doc """
+//! Returns `true` if the `function/arity` is exported from `module`.
+//! """
+//! @spec function_exported(module :: atom(), function :: atom(), arity :: 0..255)
+//! ```
+//!
+//! Even functions that are defined and called from other modules in Lumen compiled code will not
+//! show up as exported unless their `export` function is called such as
+//!
+//! ```
+//! lumen_runtime::otp::erlang::self_0::export();
+//! ```
+//!
+//! or directly registering the `code` function like
+//!
+//! ```
+//! # use liblumen_alloc::erts::term::Atom;
+//! let module = Atom::try_from_str("erlang").unwrap();
+//! let function = Atom::try_from_str("self").unwrap();
+//! let arity = 0;
+//! let code = lumen_runtime::otp::erlang::self_0::code;
+//!
+//! lumen_runtime::code::export::insert(module, function, arity, code);
+//! ```
+
+#[cfg(test)]
+mod test;
+
+use std::convert::TryInto;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::term::{Atom, Term};
+use liblumen_alloc::Arity;
+
+use lumen_runtime_macros::native_implemented_function;
+
+#[native_implemented_function(function_exported/3)]
+pub fn native(module: Term, function: Term, arity: Term) -> exception::Result {
+    let module_atom: Atom = module.try_into()?;
+    let function_atom: Atom = function.try_into()?;
+    let arity_arity: Arity = arity.try_into()?;
+
+    let exported =
+        crate::code::export::contains_key(&module_atom, &function_atom, arity_arity).into();
+
+    Ok(exported)
+}

--- a/lumen_runtime/src/otp/erlang/function_exported_3/test.rs
+++ b/lumen_runtime/src/otp/erlang/function_exported_3/test.rs
@@ -1,0 +1,23 @@
+use liblumen_alloc::erts::term::atom_unchecked;
+
+use crate::otp::erlang::function_exported_3::native;
+
+#[test]
+fn without_exported_function_returns_false() {
+    let module = atom_unchecked("unexported_module");
+    let function = atom_unchecked("unexported_function");
+    let arity = 0.into();
+
+    assert_eq!(native(module, function, arity), Ok(false.into()));
+}
+
+#[test]
+fn with_exported_function_return_true() {
+    let module = atom_unchecked("erlang");
+    let function = atom_unchecked("self");
+    let arity = 0.into();
+
+    crate::otp::erlang::self_0::export();
+
+    assert_eq!(native(module, function, arity), Ok(true.into()));
+}

--- a/lumen_runtime_macros/src/lib.rs
+++ b/lumen_runtime_macros/src/lib.rs
@@ -287,7 +287,7 @@ impl Signatures {
         };
 
         quote! {
-            pub(crate) fn code(arc_process: &std::sync::Arc<liblumen_alloc::erts::process::Process>) -> liblumen_alloc::erts::process::code::Result {
+            pub fn code(arc_process: &std::sync::Arc<liblumen_alloc::erts::process::Process>) -> liblumen_alloc::erts::process::code::Result {
                 arc_process.reduce();
 
                 #(let #stack_popped_code_argument_ident = arc_process.stack_pop().unwrap();)*


### PR DESCRIPTION
Resolves #173

# Changelog
## Enhancements
* The generated code produced by the compiler must register the function as exported for this work. Calling either the `native_implemented_function` macro's generated `export` function like
  
  ```rust
  lumen_runtime::otp::erlang::self_0::export();
  ```
  
  or by generating the `crate::code::export::insert` calls:
  
  ```rust
  use lumen_alloc::erts::term::Atom;
  
  let module = Atom::try_from_str("erlang").unwrap();
  let function = Atom::try_from_str("self").unwrap();
  let arity = 0;
  let code = crate::otp::erlang::self_0::code;
  
  lumen_runtime::code::export::insert(module, function, arity, code);
  ```
  
  The `lumen_runtime::code::export` lookup is used both for `function_exported/3` and `apply/3`.  Just as the compiler keeps track of which functions need to be exported to get polymorphic `apply/3` calls to work, the compiler must also track which ones need to be exported to get `function_exported/3` to work.