### PR TITLE
Fix interpreter-in-browser example README

### DIFF
--- a/examples/interpreter-in-browser/README.md
+++ b/examples/interpreter-in-browser/README.md
@@ -24,7 +24,7 @@ npm link
 popd
 
 pushd www
-npm link spawn-chain
+npm link interpreter-in-browser
 popd 
 ```
 


### PR DESCRIPTION
Following the `interpreter-in-browser` README example setup, I get the following error:

```
ERROR in ./index.js
Module not found: Error: Can't resolve 'interpreter-in-browser' in '/Users/emcasa/dev/rust_playground/lumen/examples/interpreter-in-browser/www'
 @ ./index.js 1:0-54 3:21-32 14:16-49 22:23-41
 @ ./bootstrap.js
```

This change makes the compilation successful, but the page itself of the example is empty (just some apparently working outputs in the console), so I'm not 100% sure about the fix.