### PR TITLE
Set windows default toolchain with host triple

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,7 @@ task:
     CIRRUS_SHELL: powershell
     CARGO_HOME: $USERPROFILE\.cargo
     PATH: $PATH;$CARGO_HOME\bin
-  install_rustup_script: "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -URI https://win.rustup.rs -OutFile rustup-init.exe; ./rustup-init.exe -y --default-toolchain nightly"
+  install_rustup_script: "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -URI https://win.rustup.rs -OutFile rustup-init.exe; ./rustup-init.exe -y --default-toolchain nightly-x86_64-pc-windows-msvc"
   build_script: cargo build
   # `*_test_script`s in order of crate dependency graph
   liblumen_arena_test_script: |


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Sometime between https://cirrus-ci.com/task/5758594137456640?command=install_rustup,
which uses `rust version 1.41.0-nightly (19bd93467 2019-12-18)` and https://cirrus-ci.com/task/4657086155194368?command=install_rustup, which ues `rust version 1.42.0-nightly (a9c1c04e9 2019-12-24)`, the default target triple on Windows switched from `x86_64` to `i686`. Switching to `i686` means that the Windows build is 32-bit instead of 64-bit like we expect.  Fix this by setting the default toolchain to `nightly-x86_64-pc-windows-msvc` instead of the shorted `nightly`.