### PR TITLE
Use try_into.unwrap_or_else instead of is_tuple for ok_n_input check …

### DIFF
--- a/examples/spawn-chain/src/elixir/chain/on_submit_1/label_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/on_submit_1/label_2.rs
@@ -27,12 +27,9 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
     let ok_n_input = arc_process.stack_pop().unwrap();
-    assert!(
-        ok_n_input.is_tuple(),
-        "ok_n_input ({:?}) is not a tuple",
-        ok_n_input
-    );
-    let ok_n_input_tuple: Boxed<Tuple> = ok_n_input.try_into().unwrap();
+    let ok_n_input_tuple: Boxed<Tuple> = ok_n_input
+        .try_into()
+        .unwrap_or_else(|_| panic!("ok_n_input ({:?}) is not a tuple", ok_n_input));
     assert_eq!(ok_n_input_tuple.len(), 2);
     assert_eq!(ok_n_input_tuple[0], Atom::str_to_term("ok"));
     let n_input = ok_n_input_tuple[1];

--- a/liblumen_alloc/src/erts/term/arch/arch_32.rs
+++ b/liblumen_alloc/src/erts/term/arch/arch_32.rs
@@ -607,10 +607,16 @@ impl fmt::Debug for RawTerm {
                 write!(f, "Term({})", value)
             }
             Tag::Box | Tag::Literal => {
-                let ptr = (self.0 & !MASK_PRIMARY) as *const RawTerm;
-                write!(f, "Box({:p})", ptr)
+                let is_literal = self.0 & FLAG_LITERAL == FLAG_LITERAL;
+                let ptr = unsafe { self.decode_box() };
+                let unboxed = unsafe { &*ptr };
+                write!(
+                    f,
+                    "Box({:p}, literal = {}, value={:?})",
+                    ptr, is_literal, unboxed
+                )
             }
-            Tag::Unknown(invalid_tag) => write!(f, "InvalidTerm(tag: {:064b})", invalid_tag),
+            Tag::Unknown(invalid_tag) => write!(f, "InvalidTerm(tag: {:032b})", invalid_tag),
             header => match self.decode_header(header, None) {
                 Ok(term) => write!(f, "Term({:?})", term),
                 Err(_) => write!(f, "InvalidHeader(tag: {:?})", header),

--- a/liblumen_alloc/src/erts/term/arch/arch_64.rs
+++ b/liblumen_alloc/src/erts/term/arch/arch_64.rs
@@ -615,8 +615,14 @@ impl fmt::Debug for RawTerm {
                 write!(f, "Term({})", value)
             }
             Tag::Box | Tag::Literal => {
-                let ptr = (self.0 & !MASK_PRIMARY) as *const RawTerm;
-                write!(f, "Box({:p})", ptr)
+                let is_literal = self.0 & FLAG_LITERAL == FLAG_LITERAL;
+                let ptr = unsafe { self.decode_box() };
+                let unboxed = unsafe { &*ptr };
+                write!(
+                    f,
+                    "Box({:p}, literal={}, value={:?})",
+                    ptr, is_literal, unboxed
+                )
             }
             Tag::Unknown(invalid_tag) => write!(f, "InvalidTerm(tag: {:064b})", invalid_tag),
             header => match self.decode_header(header, None) {

--- a/liblumen_alloc/src/erts/term/arch/arch_x86_64.rs
+++ b/liblumen_alloc/src/erts/term/arch/arch_x86_64.rs
@@ -735,7 +735,7 @@ impl fmt::Debug for RawTerm {
                 let value = unsafe { self.decode_port() };
                 write!(f, "Term({})", value)
             }
-            Tag::Box => {
+            Tag::Box | Tag::Literal => {
                 let is_literal = self.0 & FLAG_LITERAL == FLAG_LITERAL;
                 let ptr = unsafe { self.decode_box() };
                 let unboxed = unsafe { &*ptr };


### PR DESCRIPTION
Fixes #378

# Changelog
## Enhancements
* Use same `Debug` format across architectures.  Only `x86_64` had the `literal` flag and `value` of boxed terms shown previously.  Showing just the box `ptr` was not very useful for `wasm32` debugging.

## Bug Fixes
* Use `try_into.unwrap_or_else` instead of `is_tuple` for `ok_n_input` check because  `is_tuple` in `Encoded` does not check for boxed tuple, but for the tuple header instead.