### PR TITLE
Ensure native functions are re-entrant by peeking arguments from stack instead of popping stack immediately

### DIFF
--- a/examples/spawn-chain/src/elixir/chain/create_processes_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/create_processes_2.rs
@@ -51,8 +51,8 @@ pub fn export() {
 const ARITY: Arity = 2;
 
 fn code(arc_process: &Arc<Process>) -> code::Result {
-    let n = arc_process.stack_pop().unwrap();
-    let output = arc_process.stack_pop().unwrap();
+    let n = arc_process.stack_peek(1).unwrap();
+    let output = arc_process.stack_peek(2).unwrap();
 
     // ```elixir
     // 1..n
@@ -64,8 +64,12 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
 
     arc_process.reduce();
 
+    const STACK_USED: usize = 2;
+
     match result {
         Ok(range) => {
+            arc_process.stack_popn(STACK_USED);
+
             //  # label 1
             //  # pushed stack: (output)
             //  # returned from call: last
@@ -96,7 +100,7 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
 
             Process::call_code(arc_process)
         }
-        Err(exception) => result_from_exception(arc_process, exception),
+        Err(exception) => result_from_exception(arc_process, STACK_USED, exception),
     }
 }
 

--- a/examples/spawn-chain/src/elixir/chain/create_processes_2/label_3.rs
+++ b/examples/spawn-chain/src/elixir/chain/create_processes_2/label_3.rs
@@ -26,12 +26,12 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let ok = arc_process.stack_pop().unwrap();
+    let ok = arc_process.stack_peek(1).unwrap();
     assert_eq!(ok, Atom::str_to_term("ok"));
-    let final_answer = arc_process.stack_pop().unwrap();
+    let final_answer = arc_process.stack_peek(2).unwrap();
     assert!(final_answer.is_integer());
 
-    arc_process.return_from_call(final_answer).unwrap();
+    arc_process.return_from_call(2, final_answer).unwrap();
 
     Process::call_code(arc_process)
 }

--- a/examples/spawn-chain/src/elixir/chain/none_1/test.rs
+++ b/examples/spawn-chain/src/elixir/chain/none_1/test.rs
@@ -95,10 +95,10 @@ fn with_65536() {
 }
 
 fn inspect_code(arc_process: &Arc<Process>) -> code::Result {
-    let time_value = arc_process.stack_pop().unwrap();
+    let time_value = arc_process.stack_peek(1).unwrap();
 
     lumen_runtime::system::io::puts(&format!("{}", time_value));
-    arc_process.remove_last_frame();
+    arc_process.remove_last_frame(1);
 
     Process::call_code(arc_process)
 }

--- a/examples/spawn-chain/src/elixir/chain/none_output_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/none_output_1.rs
@@ -18,9 +18,9 @@ const ARITY: u8 = 1;
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let _text = arc_process.stack_pop().unwrap();
+    let _text = arc_process.stack_peek(1).unwrap();
 
-    Process::return_from_call(arc_process, Atom::str_to_term("ok"))?;
+    Process::return_from_call(arc_process, 1, Atom::str_to_term("ok"))?;
 
     Process::call_code(arc_process)
 }

--- a/examples/spawn-chain/src/elixir/chain/run_2/label_2.rs
+++ b/examples/spawn-chain/src/elixir/chain/run_2/label_2.rs
@@ -30,11 +30,11 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let ok = arc_process.stack_pop().unwrap();
+    let ok = arc_process.stack_peek(1).unwrap();
     assert_eq!(ok, Atom::str_to_term("ok"));
-    let time_value = arc_process.stack_pop().unwrap();
+    let time_value = arc_process.stack_peek(2).unwrap();
 
-    arc_process.return_from_call(time_value).unwrap();
+    arc_process.return_from_call(2, time_value).unwrap();
 
     Process::call_code(arc_process)
 }

--- a/examples/spawn-chain/src/elixir/enum/reduce_range_inc_4/label_1.rs
+++ b/examples/spawn-chain/src/elixir/enum/reduce_range_inc_4/label_1.rs
@@ -38,17 +38,21 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let new_first = arc_process.stack_pop().unwrap();
+    let new_first = arc_process.stack_peek(1).unwrap();
     assert!(new_first.is_integer());
-    let first = arc_process.stack_pop().unwrap();
+    let first = arc_process.stack_peek(2).unwrap();
     assert!(first.is_integer());
-    let last = arc_process.stack_pop().unwrap();
+    let last = arc_process.stack_peek(3).unwrap();
     assert!(last.is_integer());
-    let acc = arc_process.stack_pop().unwrap();
-    let reducer = arc_process.stack_pop().unwrap();
+    let acc = arc_process.stack_peek(4).unwrap();
+    let reducer = arc_process.stack_peek(5).unwrap();
+
+    const STACK_USED: usize = 5;
 
     match reducer.decode().unwrap() {
         TypedTerm::Closure(closure) => {
+            arc_process.stack_popn(STACK_USED);
+
             label_2::place_frame_with_arguments(
                 arc_process,
                 Placement::Replace,
@@ -70,6 +74,7 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
 
                 result_from_exception(
                     arc_process,
+                    STACK_USED,
                     badarity(
                         arc_process,
                         reducer,
@@ -81,6 +86,7 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
         }
         _ => result_from_exception(
             arc_process,
+            STACK_USED,
             badfun(arc_process, reducer, anyhow!("reducer").into()),
         ),
     }

--- a/examples/spawn-chain/src/elixir/io/puts_1.rs
+++ b/examples/spawn-chain/src/elixir/io/puts_1.rs
@@ -30,7 +30,9 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let elixir_string = arc_process.stack_pop().unwrap();
+    let elixir_string = arc_process.stack_peek(1).unwrap();
+
+    const STACK_USED: usize = 1;
 
     match binary_to_string(elixir_string) {
         Ok(string) => {
@@ -38,12 +40,13 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
             system::io::puts(&string);
 
             let ok = Atom::str_to_term("ok");
-            arc_process.return_from_call(ok)?;
+            arc_process.return_from_call(STACK_USED, ok)?;
 
             Process::call_code(arc_process)
         }
         Err(exception) => match exception {
             Exception::Runtime(runtime_exception) => {
+                arc_process.stack_popn(STACK_USED);
                 arc_process.exception(runtime_exception);
 
                 Ok(())

--- a/liblumen_alloc/src/erts/process/code.rs
+++ b/liblumen_alloc/src/erts/process/code.rs
@@ -18,13 +18,15 @@ impl Debug for DebuggableCode {
     }
 }
 
-pub fn result_from_exception<P>(process: P, exception: Exception) -> Result
+pub fn result_from_exception<P>(process: P, stack_used: usize, exception: Exception) -> Result
 where
     P: AsRef<Process>,
 {
     match exception {
         Exception::Runtime(err) => {
-            process.as_ref().exception(err);
+            let process_ref = process.as_ref();
+            process_ref.stack_popn(stack_used);
+            process_ref.exception(err);
 
             Ok(())
         }

--- a/liblumen_alloc/src/erts/process/gc/young_heap.rs
+++ b/liblumen_alloc/src/erts/process/gc/young_heap.rs
@@ -491,7 +491,13 @@ impl StackPrimitives for YoungHeap {
 
     #[inline]
     fn stack_popn(&mut self, n: usize) {
-        assert!(n > 0 && n <= self.stack_size);
+        assert!(n > 0);
+        assert!(
+            n <= self.stack_size,
+            "Trying to pop {} terms from stack that only has {} terms",
+            n,
+            self.stack_size
+        );
         if self.stack_size - n == 0 {
             // Freeing the whole stack
             self.stack_start = self.stack_end;

--- a/liblumen_eir_interpreter/src/call_result.rs
+++ b/liblumen_eir_interpreter/src/call_result.rs
@@ -190,7 +190,7 @@ fn return_ok(arc_process: &Arc<Process>) -> code::Result {
         })
         .unwrap();
 
-    Ok(arc_process.return_from_call(argument_vec[0])?)
+    Ok(arc_process.return_from_call(0, argument_vec[0])?)
 }
 
 fn return_throw(arc_process: &Arc<Process>) -> code::Result {
@@ -241,5 +241,5 @@ fn return_throw(arc_process: &Arc<Process>) -> code::Result {
         anyhow!("explicit throw from Erlang").into(),
     );
 
-    code::result_from_exception(arc_process, exc.into())
+    code::result_from_exception(arc_process, 0, exc.into())
 }

--- a/liblumen_eir_interpreter/src/code.rs
+++ b/liblumen_eir_interpreter/src/code.rs
@@ -21,7 +21,7 @@ fn module() -> Atom {
 
 pub fn return_clean(arc_process: &Arc<Process>) -> code::Result {
     let argument_list = arc_process.stack_pop().unwrap();
-    arc_process.return_from_call(argument_list)?;
+    arc_process.return_from_call(0, argument_list)?;
     Process::call_code(arc_process)
 }
 
@@ -51,7 +51,7 @@ pub fn return_ok(arc_process: &Arc<Process>) -> code::Result {
     }
     assert!(argument_vec.len() == 1);
 
-    Ok(arc_process.return_from_call(argument_vec[0])?)
+    Ok(arc_process.return_from_call(0, argument_vec[0])?)
 }
 
 pub fn return_ok_closure(process: &Process) -> exception::Result<Term> {
@@ -89,7 +89,7 @@ pub fn return_throw(arc_process: &Arc<Process>) -> code::Result {
         stacktrace,
         anyhow!("explicit raise from Erlang").into(),
     );
-    code::result_from_exception(arc_process, exception.into())
+    code::result_from_exception(arc_process, 0, exception.into())
 }
 
 pub fn return_throw_closure(process: &Process) -> exception::Result<Term> {

--- a/lumen_runtime/proptest-regressions/otp/erlang/apply_2/test/with_function/with_empty_list_arguments.txt
+++ b/lumen_runtime/proptest-regressions/otp/erlang/apply_2/test/with_function/with_empty_list_arguments.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 92f9e26bcd21e86529e4bf571942f4395e00042c6be406eaf2d06ba7c081ec3e # shrinks to Box(0x1185aade0, literal=false, value=Term(Boxed<liblumen_alloc::erts::term::closure::Closure>(Closure { header: Header<liblumen_alloc::erts::term::closure::Closure>(0b101100000000000000000000000000000000000000000000000), module: :"", definition: Export { function: :"" }, arity: 0, code: Some(4588673728), env_len: 0, env: [] } at 0x1185aade0)))

--- a/lumen_runtime/proptest-regressions/otp/erlang/apply_2/test/with_function/with_non_empty_proper_list_arguments.txt
+++ b/lumen_runtime/proptest-regressions/otp/erlang/apply_2/test/with_function/with_non_empty_proper_list_arguments.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 01fcdd96afb2d39d7b760f8d9c6754ba5ec7699347edee3e3354c69ebd8de2cd # shrinks to (Pid(4899), Box(0x11f338410, literal=false, value=Term(Boxed<liblumen_alloc::erts::term::closure::Closure>(Closure { header: Header<liblumen_alloc::erts::term::closure::Closure>(0b101100000000000000000000000000000000000000000000000), module: :"", definition: Export { function: :"" }, arity: 1, code: Some(4588735856), env_len: 0, env: [] } at 0x11f338410))), Box(0x11f3383e8, literal=false, value=Term(Boxed<liblumen_alloc::erts::term::integer::big::BigInteger>(BigInteger { header: Header<liblumen_alloc::erts::term::integer::big::BigInteger>(0b100000000000000000000000000000000000000000000000100), value: -70368744177667 (101111111111111111111111111111111111111111111101) } at 0x11f3383e8))))

--- a/lumen_runtime/src/future.rs
+++ b/lumen_runtime/src/future.rs
@@ -89,8 +89,8 @@ impl From<Exception> for NotReady {
 // Private
 
 fn code(arc_process: &Arc<Process>) -> code::Result {
-    let return_term = arc_process.stack_pop().unwrap();
-    let future_term = arc_process.stack_pop().unwrap();
+    let return_term = arc_process.stack_peek(1).unwrap();
+    let future_term = arc_process.stack_peek(2).unwrap();
 
     let future_resource_box: Boxed<Resource> = future_term.try_into().unwrap();
     let future_resource: Resource = future_resource_box.into();
@@ -101,7 +101,7 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
         result: Ok(return_term),
     });
 
-    arc_process.remove_last_frame();
+    arc_process.remove_last_frame(2);
 
     Process::call_code(arc_process)
 }

--- a/lumen_runtime/src/otp/erlang/apply_2/test/with_function/with_empty_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2/test/with_function/with_empty_list_arguments.rs
@@ -64,7 +64,7 @@ fn with_arity_returns_function_return() {
                 .prop_map(|(arc_process, module, function)| {
                     let arity = 0;
                     let code: Code = |arc_process: &Arc<Process>| {
-                        arc_process.return_from_call(Atom::str_to_term("return_from_fn"))?;
+                        arc_process.return_from_call(0, Atom::str_to_term("return_from_fn"))?;
 
                         Process::call_code(arc_process)
                     };

--- a/lumen_runtime/src/otp/erlang/apply_2/test/with_function/with_non_empty_proper_list_arguments.rs
+++ b/lumen_runtime/src/otp/erlang/apply_2/test/with_function/with_non_empty_proper_list_arguments.rs
@@ -70,8 +70,8 @@ fn with_arity_returns_function_return() {
                     let arity = 1;
 
                     let code: Code = |arc_process: &Arc<Process>| {
-                        let return_term = arc_process.stack_pop().unwrap();
-                        arc_process.return_from_call(return_term)?;
+                        let return_term = arc_process.stack_peek(1).unwrap();
+                        arc_process.return_from_call(1, return_term)?;
 
                         Process::call_code(arc_process)
                     };

--- a/lumen_runtime/src/otp/erlang/spawn_1/test/with_function/with_arity_zero.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_1/test/with_function/with_arity_zero.rs
@@ -20,7 +20,7 @@ fn without_environment_runs_function_in_child_process() {
                 .prop_map(|(arc_process, module, function)| {
                     let arity = 0;
                     let code = |arc_process: &Arc<Process>| {
-                        arc_process.return_from_call(Atom::str_to_term("ok"))?;
+                        arc_process.return_from_call(0, Atom::str_to_term("ok"))?;
 
                         Ok(())
                     };

--- a/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/without_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_link_1/test/with_function/with_arity_zero/without_environment.rs
@@ -99,7 +99,7 @@ fn with_expected_exit_in_child_process_does_not_exit_linked_parent_process() {
                     let arc_process = process::test_init();
                     let arity = 0;
                     let code = |arc_process: &Arc<Process>| {
-                        arc_process.return_from_call(Atom::str_to_term("ok"))?;
+                        arc_process.return_from_call(0, Atom::str_to_term("ok"))?;
 
                         Ok(())
                     };

--- a/lumen_runtime/src/otp/erlang/spawn_monitor_1/test/with_function/with_arity_zero/without_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_monitor_1/test/with_function/with_arity_zero/without_environment.rs
@@ -117,7 +117,7 @@ fn with_expected_exit_in_child_process_sends_exit_message_to_parent() {
                     let arc_process = process::test_init();
                     let arity = 0;
                     let code = |arc_process: &Arc<Process>| {
-                        arc_process.return_from_call(Atom::str_to_term("ok"))?;
+                        arc_process.return_from_call(0, Atom::str_to_term("ok"))?;
 
                         Ok(())
                     };

--- a/lumen_runtime/src/otp/erlang/spawn_opt_2/test/with_function/with_empty_list_options/with_arity_zero.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_2/test/with_function/with_empty_list_options/with_arity_zero.rs
@@ -18,7 +18,7 @@ fn without_environment_runs_function_in_child_process() {
                 .prop_map(|(arc_process, module, function)| {
                     let arity = 0;
                     let code = |arc_process: &Arc<Process>| {
-                        arc_process.return_from_call(Atom::str_to_term("ok"))?;
+                        arc_process.return_from_call(0, Atom::str_to_term("ok"))?;
 
                         Ok(())
                     };

--- a/lumen_runtime/src/otp/erlang/spawn_opt_2/test/with_function/with_link_and_monitor_in_options_list/with_arity_zero/without_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_2/test/with_function/with_link_and_monitor_in_options_list/with_arity_zero/without_environment.rs
@@ -134,7 +134,7 @@ fn with_expected_exit_in_child_process_sends_exit_message_to_parent() {
                     let arc_process = process::test_init();
                     let arity = 0;
                     let code = |arc_process: &Arc<Process>| {
-                        arc_process.return_from_call(Atom::str_to_term("ok"))?;
+                        arc_process.return_from_call(0, Atom::str_to_term("ok"))?;
 
                         Ok(())
                     };

--- a/lumen_runtime/src/otp/erlang/spawn_opt_2/test/with_function/with_link_in_options_list/with_arity_zero/without_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_2/test/with_function/with_link_in_options_list/with_arity_zero/without_environment.rs
@@ -99,7 +99,7 @@ fn with_expected_exit_in_child_process_does_not_exit_linked_parent_process() {
                     let arc_process = process::test_init();
                     let arity = 0;
                     let code = |arc_process: &Arc<Process>| {
-                        arc_process.return_from_call(Atom::str_to_term("ok"))?;
+                        arc_process.return_from_call(0, Atom::str_to_term("ok"))?;
 
                         Ok(())
                     };

--- a/lumen_runtime/src/otp/erlang/spawn_opt_2/test/with_function/with_monitor_in_options_list/with_arity_zero/without_environment.rs
+++ b/lumen_runtime/src/otp/erlang/spawn_opt_2/test/with_function/with_monitor_in_options_list/with_arity_zero/without_environment.rs
@@ -117,7 +117,7 @@ fn with_expected_exit_in_child_process_sends_exit_message_to_parent() {
                     let arc_process = process::test_init();
                     let arity = 0;
                     let code = |arc_process: &Arc<Process>| {
-                        arc_process.return_from_call(Atom::str_to_term("ok"))?;
+                        arc_process.return_from_call(0, Atom::str_to_term("ok"))?;
 
                         Ok(())
                     };

--- a/lumen_runtime/src/otp/erlang/timestamp_0/test.rs
+++ b/lumen_runtime/src/otp/erlang/timestamp_0/test.rs
@@ -3,7 +3,7 @@ use crate::scheduler::with_process;
 use liblumen_alloc::erts::term::prelude::*;
 use std::convert::TryInto;
 
-const DELTA_LIMIT_MICROSECONDS: u64 = 5;
+const DELTA_LIMIT_MICROSECONDS: u64 = 5_000;
 
 #[test]
 fn returns_a_three_element_tuple() {

--- a/lumen_runtime/src/otp/timer/tc_3.rs
+++ b/lumen_runtime/src/otp/timer/tc_3.rs
@@ -44,9 +44,11 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let module = arc_process.stack_pop().unwrap();
-    let function = arc_process.stack_pop().unwrap();
-    let arguments = arc_process.stack_pop().unwrap();
+    let module = arc_process.stack_peek(1).unwrap();
+    let function = arc_process.stack_peek(2).unwrap();
+    let arguments = arc_process.stack_peek(3).unwrap();
+
+    arc_process.stack_popn(3);
 
     label_1::place_frame_with_arguments(
         arc_process,
@@ -54,8 +56,9 @@ fn code(arc_process: &Arc<Process>) -> code::Result {
         module,
         function,
         arguments,
-    )?;
-    monotonic_time_0::place_frame_with_arguments(arc_process, Placement::Push)?;
+    )
+    .unwrap();
+    monotonic_time_0::place_frame_with_arguments(arc_process, Placement::Push).unwrap();
 
     Process::call_code(arc_process)
 }

--- a/lumen_runtime/src/otp/timer/tc_3/label_1.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_1.rs
@@ -46,14 +46,16 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let before = arc_process.stack_pop().unwrap();
+    let before = arc_process.stack_peek(1).unwrap();
     assert!(before.is_integer());
-    let module = arc_process.stack_pop().unwrap();
+    let module = arc_process.stack_peek(2).unwrap();
     assert!(module.is_atom(), "module ({:?}) is not an atom", module);
-    let function = arc_process.stack_pop().unwrap();
+    let function = arc_process.stack_peek(3).unwrap();
     assert!(function.is_atom());
-    let arguments = arc_process.stack_pop().unwrap();
+    let arguments = arc_process.stack_peek(4).unwrap();
     assert!(arguments.is_list());
+
+    arc_process.stack_popn(4);
 
     label_2::place_frame_with_arguments(arc_process, Placement::Replace, before)?;
     apply_3::place_frame_with_arguments(arc_process, Placement::Push, module, function, arguments)?;

--- a/lumen_runtime/src/otp/timer/tc_3/label_3.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_3.rs
@@ -37,11 +37,13 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let after = arc_process.stack_pop().unwrap();
+    let after = arc_process.stack_peek(1).unwrap();
     assert!(after.is_integer());
-    let before = arc_process.stack_pop().unwrap();
+    let before = arc_process.stack_peek(2).unwrap();
     assert!(before.is_integer());
-    let value = arc_process.stack_pop().unwrap();
+    let value = arc_process.stack_peek(3).unwrap();
+
+    arc_process.stack_popn(3);
 
     label_4::place_frame_with_arguments(arc_process, Placement::Replace, value)?;
     subtract_2::place_frame_with_arguments(arc_process, Placement::Push, after, before)?;

--- a/lumen_runtime/src/otp/timer/tc_3/label_4.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_4.rs
@@ -33,9 +33,11 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let duration = arc_process.stack_pop().unwrap();
+    let duration = arc_process.stack_peek(1).unwrap();
     assert!(duration.is_integer());
-    let value = arc_process.stack_pop().unwrap();
+    let value = arc_process.stack_peek(2).unwrap();
+
+    arc_process.stack_popn(2);
 
     label_5::place_frame_with_arguments(arc_process, Placement::Replace, value)?;
     convert_time_unit_3::place_frame_with_arguments(

--- a/lumen_runtime/src/otp/timer/tc_3/label_5.rs
+++ b/lumen_runtime/src/otp/timer/tc_3/label_5.rs
@@ -29,12 +29,12 @@ pub fn place_frame_with_arguments(
 fn code(arc_process: &Arc<Process>) -> code::Result {
     arc_process.reduce();
 
-    let time = arc_process.stack_pop().unwrap();
+    let time = arc_process.stack_peek(1).unwrap();
     assert!(time.is_integer());
-    let value = arc_process.stack_pop().unwrap();
+    let value = arc_process.stack_peek(2).unwrap();
 
     let time_value = arc_process.tuple_from_slice(&[time, value])?;
-    arc_process.return_from_call(time_value)?;
+    arc_process.return_from_call(2, time_value)?;
 
     Process::call_code(arc_process)
 }

--- a/lumen_web/src/wait/with_return_0.rs
+++ b/lumen_web/src/wait/with_return_0.rs
@@ -59,15 +59,15 @@ fn bytes_to_js_value(bytes: &[u8]) -> JsValue {
 }
 
 fn code(arc_process: &Arc<Process>) -> code::Result {
-    let return_term = arc_process.stack_pop().unwrap();
-    let executor_term = arc_process.stack_pop().unwrap();
+    let return_term = arc_process.stack_peek(1).unwrap();
+    let executor_term = arc_process.stack_peek(2).unwrap();
 
     let executor_resource_boxed: Boxed<Resource> = executor_term.try_into().unwrap();
     let executor_resource: Resource = executor_resource_boxed.into();
     let executor_mutex: &Mutex<Executor> = executor_resource.downcast_ref().unwrap();
     executor_mutex.lock().resolve(return_term);
 
-    arc_process.remove_last_frame();
+    arc_process.remove_last_frame(2);
 
     Process::call_code(arc_process)
 }


### PR DESCRIPTION
Fixes #380

# Changelog
## Enhancements
* Split `stack_popn` `assert`s for improved error messages.

## Bug Fixes
* Ensure native functions are re-entrant by peeking arguments from stack instead of popping stack immediately.

  Details:

  1. When getting the arguments, peek at the stack instead of popping it.
  2. Do any allocations that may fail with `Err(Alloc)` using `?`.
  3. After all failable allocations, but before pushing anything to the stack, pop all arguments.
  4. After the old arguments have been popped, `unwrap` all `Result`s, so that the function will `panic` instead of return an `Err(Alloc)` and be re-entered with an incomplete stack.

  Step (4) can include additional allocations, such as when pushing arguments for new frames.  A future improvement is to reserve stack space for those new frames before popping the old arguments.
* Increase `timestamp/0` test delta to 5ms instead of 5µs.  Hopefully fixes flakiness of the test @bryanjos.