### PR TITLE
Fix npm link name in README

### DIFF
--- a/examples/interpreter-in-browser/README.md
+++ b/examples/interpreter-in-browser/README.md
@@ -24,7 +24,7 @@ npm link
 popd
 
 pushd www
-npm link spawn-chain
+npm link interpreter-in-browser
 popd 
 ```
 


### PR DESCRIPTION
# Changelog
## Bug Fixes
* `interpreter-in-browser`'s README copied `spawn-chain`'s, but did not change the NPM package to link.