### PR TITLE
group_leader/0

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -65,6 +65,7 @@ pub mod get_1;
 pub mod get_keys_0;
 pub mod get_keys_1;
 pub mod get_stacktrace_0;
+pub mod group_leader_0;
 pub mod hd_1;
 pub mod insert_element_3;
 pub mod integer_to_binary_1;

--- a/lumen_runtime/src/otp/erlang/group_leader_0.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_0.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+mod test;
+
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::prelude::*;
+
+use lumen_runtime_macros::native_implemented_function;
+
+#[native_implemented_function(group_leader/0)]
+pub fn native(process: &Process) -> Term {
+    process.group_leader_pid_term()
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_0/test.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_0/test.rs
@@ -1,0 +1,18 @@
+use crate::otp::erlang::group_leader_0::native;
+use crate::otp::erlang::self_0;
+use crate::process;
+
+#[test]
+fn without_parent_returns_self() {
+    let arc_process = process::test_init();
+
+    assert_eq!(native(&arc_process), self_0::native(&arc_process));
+}
+
+#[test]
+fn with_parent_returns_parent_group_leader() {
+    let parent_arc_process = process::test_init();
+    let arc_process = process::test(&parent_arc_process);
+
+    assert_eq!(native(&arc_process), self_0::native(&parent_arc_process));
+}

--- a/lumen_runtime/src/process/spawn/options.rs
+++ b/lumen_runtime/src/process/spawn/options.rs
@@ -94,7 +94,7 @@ impl Options {
 
         let process = Process::new(
             priority,
-            parent_process.map(|process| process.pid()),
+            parent_process,
             Arc::clone(&module_function_arity),
             heap,
             heap_size,


### PR DESCRIPTION
Part of #138

# Changelog
## Enhancements
* `:erlang.group_leader/0`
  The group_leader is init itself or the parent's group_leader when there is a parent.

  Note: This does not change I/O to use the group_leader as there is no such I/O system yet.  It only shows the assigned group leader.