### PR TITLE
group_leader/2

### DIFF
--- a/lumen_runtime/src/otp/erlang.rs
+++ b/lumen_runtime/src/otp/erlang.rs
@@ -66,6 +66,7 @@ pub mod get_keys_0;
 pub mod get_keys_1;
 pub mod get_stacktrace_0;
 pub mod group_leader_0;
+pub mod group_leader_2;
 pub mod hd_1;
 pub mod insert_element_3;
 pub mod integer_to_binary_1;

--- a/lumen_runtime/src/otp/erlang/group_leader_0.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_0.rs
@@ -8,5 +8,5 @@ use lumen_runtime_macros::native_implemented_function;
 
 #[native_implemented_function(group_leader/0)]
 pub fn native(process: &Process) -> Term {
-    process.group_leader_pid_term()
+    process.get_group_leader_pid_term()
 }

--- a/lumen_runtime/src/otp/erlang/group_leader_2.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2.rs
@@ -1,0 +1,52 @@
+// wasm32 proptest cannot be compiled at the same time as non-wasm32 proptest, so disable tests that
+// use proptest completely for wasm32
+//
+// See https://github.com/rust-lang/cargo/issues/4866
+#[cfg(all(not(target_arch = "wasm32"), test))]
+mod test;
+
+use anyhow::*;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::prelude::*;
+
+use lumen_runtime_macros::native_implemented_function;
+
+use crate::registry::pid_to_process;
+
+macro_rules! is_not_alive {
+    ($name:ident) => {
+        is_not_alive(stringify!($name), $name)
+    };
+}
+
+#[native_implemented_function(group_leader/2)]
+pub fn native(process: &Process, group_leader: Term, pid: Term) -> exception::Result<Term> {
+    let group_leader_pid: Pid = term_try_into_local_pid!(group_leader)?;
+
+    if (group_leader_pid == process.pid()) || pid_to_process(&group_leader_pid).is_some() {
+        let pid_pid: Pid = term_try_into_local_pid!(pid)?;
+
+        if process.pid() == pid_pid {
+            process.set_group_leader_pid(group_leader_pid);
+
+            Ok(true.into())
+        } else {
+            match pid_to_process(&pid_pid) {
+                Some(pid_arc_process) => {
+                    pid_arc_process.set_group_leader_pid(group_leader_pid);
+
+                    Ok(true.into())
+                }
+                None => is_not_alive!(pid),
+            }
+        }
+    } else {
+        is_not_alive!(group_leader)
+    }
+}
+
+fn is_not_alive(name: &'static str, value: Term) -> exception::Result<Term> {
+    Err(anyhow!("{} ({}) is not alive", name, value)).map_err(From::from)
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test.rs
@@ -1,0 +1,27 @@
+mod with_group_leader_pid;
+
+use proptest::strategy::Just;
+use proptest::{prop_assert_eq, prop_oneof};
+
+use crate::otp::erlang::group_leader_0;
+use crate::otp::erlang::group_leader_2::native;
+use crate::scheduler::with_process;
+use crate::test::strategy;
+
+#[test]
+fn without_group_leader_pid_returns_badarg() {
+    run!(
+        |arc_process| {
+            (
+                Just(arc_process.clone()),
+                strategy::term::is_not_pid(arc_process),
+                strategy::term::pid::local(),
+            )
+        },
+        |(arc_process, group_leader, pid)| {
+            prop_assert_is_not_local_pid!(native(&arc_process, group_leader, pid), group_leader);
+
+            Ok(())
+        }
+    );
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid.rs
@@ -1,0 +1,23 @@
+mod with_pid_pid;
+
+use super::*;
+
+#[test]
+fn without_pid_pid_returns_badarg() {
+    run!(
+        |arc_process| {
+            (
+                Just(arc_process.clone()),
+                prop_oneof![Just(arc_process.clone()), strategy::process()],
+                strategy::term::is_not_pid(arc_process),
+            )
+        },
+        |(arc_process, group_leader_arc_process, pid)| {
+            let group_leader = group_leader_arc_process.pid_term();
+
+            prop_assert_is_not_local_pid!(native(&arc_process, group_leader, pid), pid);
+
+            Ok(())
+        }
+    );
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid.rs
@@ -1,0 +1,24 @@
+mod with_group_leader_alive;
+
+use super::*;
+
+#[test]
+fn without_group_leader_alive_returns_badarg() {
+    run!(
+        |arc_process| {
+            (
+                Just(arc_process),
+                strategy::term::pid::local(),
+                strategy::term::pid::local(),
+            )
+        },
+        |(arc_process, group_leader, pid)| {
+            prop_assert_badarg!(
+                native(&arc_process, group_leader, pid),
+                format!("group_leader ({}) is not alive", group_leader)
+            );
+
+            Ok(())
+        }
+    );
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+mod with_other_group_leader;
+mod with_self_group_leader;

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_other_group_leader.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_other_group_leader.rs
@@ -1,0 +1,26 @@
+mod with_pid_alive;
+
+use super::*;
+
+#[test]
+fn without_pid_alive_returns_badarg() {
+    run!(
+        |arc_process| {
+            (
+                Just(arc_process.clone()),
+                strategy::process(),
+                strategy::term::pid::local(),
+            )
+        },
+        |(arc_process, group_leader_arc_process, pid)| {
+            let group_leader = group_leader_arc_process.pid_term();
+
+            prop_assert_badarg!(
+                native(&arc_process, group_leader, pid),
+                format!("pid ({}) is not alive", pid)
+            );
+
+            Ok(())
+        }
+    );
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_other_group_leader/with_pid_alive.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_other_group_leader/with_pid_alive.rs
@@ -1,0 +1,24 @@
+mod without_self_pid;
+
+use super::*;
+
+#[test]
+fn with_self_pid_sets_group_leader() {
+    run!(
+        |arc_process| {
+            (
+                Just(arc_process.clone()),
+                strategy::process(),
+                Just(arc_process.pid_term()),
+            )
+        },
+        |(arc_process, group_leader_arc_pid, pid)| {
+            let group_leader = group_leader_arc_pid.pid_term();
+
+            prop_assert_eq!(native(&arc_process, group_leader, pid), Ok(true.into()));
+            prop_assert_eq!(group_leader_0::native(&arc_process), group_leader);
+
+            Ok(())
+        }
+    );
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_other_group_leader/with_pid_alive/without_self_pid.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_other_group_leader/with_pid_alive/without_self_pid.rs
@@ -1,0 +1,42 @@
+use super::*;
+
+#[test]
+fn with_different_group_leader_and_pid_sets_group_leader() {
+    run!(
+        |arc_process| {
+            (
+                Just(arc_process.clone()),
+                strategy::process(),
+                strategy::process(),
+            )
+        },
+        |(arc_process, group_leader_arc_process, pid_arc_process)| {
+            let group_leader = group_leader_arc_process.pid_term();
+            let pid = pid_arc_process.pid_term();
+
+            prop_assert_eq!(native(&arc_process, group_leader, pid), Ok(true.into()));
+            prop_assert_eq!(group_leader_0::native(&pid_arc_process), group_leader);
+
+            Ok(())
+        }
+    );
+}
+
+#[test]
+fn with_same_group_leader_and_pid_sets_group_leader() {
+    run!(
+        |arc_process| { (Just(arc_process.clone()), strategy::process()) },
+        |(arc_process, group_leader_and_pid_arc_process)| {
+            let group_leader = group_leader_and_pid_arc_process.pid_term();
+            let pid = group_leader;
+
+            prop_assert_eq!(native(&arc_process, group_leader, pid), Ok(true.into()));
+            prop_assert_eq!(
+                group_leader_0::native(&group_leader_and_pid_arc_process),
+                group_leader
+            );
+
+            Ok(())
+        }
+    );
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_self_group_leader.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_self_group_leader.rs
@@ -1,0 +1,24 @@
+mod with_pid_alive;
+
+use super::*;
+
+#[test]
+fn without_pid_alive_returns_badarg() {
+    run!(
+        |arc_process| {
+            (
+                Just(arc_process.clone()),
+                Just(arc_process.pid_term()),
+                strategy::term::pid::local(),
+            )
+        },
+        |(arc_process, group_leader, pid)| {
+            prop_assert_badarg!(
+                native(&arc_process, group_leader, pid),
+                format!("pid ({}) is not alive", pid)
+            );
+
+            Ok(())
+        }
+    );
+}

--- a/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_self_group_leader/with_pid_alive.rs
+++ b/lumen_runtime/src/otp/erlang/group_leader_2/test/with_group_leader_pid/with_pid_pid/with_group_leader_alive/with_self_group_leader/with_pid_alive.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+#[test]
+fn with_self_pid_sets_group_leader() {
+    with_process(|process| {
+        let group_leader = process.pid_term();
+        let pid = process.pid_term();
+
+        assert_eq!(native(process, group_leader, pid), Ok(true.into()));
+        assert_eq!(group_leader_0::native(process), group_leader);
+    });
+}
+
+#[test]
+fn without_self_pid_sets_group_leader() {
+    run!(
+        |arc_process| {
+            (
+                Just(arc_process.clone()),
+                Just(arc_process.pid_term()),
+                strategy::process(),
+            )
+        },
+        |(arc_process, group_leader, pid_arc_process)| {
+            let pid = pid_arc_process.pid_term();
+
+            prop_assert_eq!(native(&arc_process, group_leader, pid), Ok(true.into()));
+            prop_assert_eq!(group_leader_0::native(&pid_arc_process), group_leader);
+
+            Ok(())
+        }
+    );
+}


### PR DESCRIPTION
Resolves #138

# Changelog
## Enhancements
* `:erlang.group_leader(group_leader, pid)`
  
    Note: This does not change I/O to use the group_leader as there is no such I/O system yet.