### PR TITLE
Update interpreter-in-browser example

### DIFF
--- a/examples/interpreter-in-browser/README.md
+++ b/examples/interpreter-in-browser/README.md
@@ -1,4 +1,8 @@
-# Lumen Spawn Chain Demo
+# Lumen Interpreter in Browser Demo
+
+This demo runs an interpreter in the browser that loads a .erl file and executes it.
+
+To turn your Elixir project into a .erl file that you can use with this, check further down.
 
 ## 🚴 Usage
 
@@ -25,7 +29,7 @@ popd
 
 pushd www
 npm link interpreter-in-browser
-popd 
+popd
 ```
 
 ### Run manually
@@ -37,3 +41,50 @@ cd www
 npm run start
 open http://localhost:8080
 ```
+
+### Get Demo Running on OS X
+
+If you don't already have the Lumen dev environment and just want to play with the demo, do these steps, **_then_** continue to the [link package](#link-package) steps.
+
+Uninstall `rust` installed with Homebrew, so you can use `nightly`.
+
+```
+brew uninstall rust
+```
+
+Install `rustup` to manage your `rust` version.
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+rustup target add wasm32-unknown-unknown --toolchain nightly
+cargo +nightly install wasm-bindgen-cli
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+wasm-pack build
+```
+
+## Compiling from Elixir to Erlang
+
+Install the mix decompile task:
+
+```
+mix archive.install github michalmuskala/decompile
+```
+
+Create a new mix project somewhere:
+
+```
+mix new ex_sample
+```
+
+You can use the `www/ex_sample.ex` file here for an example in your mix project lib folder. It shows some interaction with the DOM through `lumen_web`. Then run:
+
+```
+mix compile
+mix decompile --to-erl ExSample
+grep -v "no_auto_import" "./Elixir.ExSample.erl" > "./ex_sample.erl"
+```
+
+The grep is to remove a line with `no_auto_import` on it that should be removed. This should generate a nice cleaned up Erlang file for you, add it to the interpreter-in-browser example and you have your own code running.
+
+All of this complexity is being worked away piece by piece.

--- a/examples/interpreter-in-browser/README.md
+++ b/examples/interpreter-in-browser/README.md
@@ -81,7 +81,7 @@ You can use the `www/ex_sample.ex` file here for an example in your mix project 
 
 ```
 mix compile
-mix decompile --to-erl ExSample
+mix decompile ExSample --to erl
 grep -v "no_auto_import" "./Elixir.ExSample.erl" > "./ex_sample.erl"
 ```
 

--- a/examples/interpreter-in-browser/www/ex_sample.erl
+++ b/examples/interpreter-in-browser/www/ex_sample.erl
@@ -1,0 +1,38 @@
+-module('Elixir.ExSample').
+
+-export(['__info__'/1, run_me/1]).
+
+-spec '__info__'(attributes | compile | functions |
+		 macros | md5 | module | deprecated) -> any().
+
+'__info__'(module) -> 'Elixir.ExSample';
+'__info__'(functions) -> [{run_me, 1}];
+'__info__'(macros) -> [];
+'__info__'(Key = attributes) ->
+    erlang:get_module_info('Elixir.ExSample', Key);
+'__info__'(Key = compile) ->
+    erlang:get_module_info('Elixir.ExSample', Key);
+'__info__'(Key = md5) ->
+    erlang:get_module_info('Elixir.ExSample', Key);
+'__info__'(deprecated) -> [].
+
+run_me(_arg@1) ->
+    lumen_intrinsics:println(<<"Doing the Lumen web work...">>),
+    {ok, _window@1} = 'Elixir.Lumen.Web.Window':window(),
+    {ok, _document@1} =
+	'Elixir.Lumen.Web.Window':document(_window@1),
+    {ok, _paragraph@1} =
+	'Elixir.Lumen.Web.Document':create_element(_document@1,
+						   <<"p">>),
+    _text@1 =
+	'Elixir.Lumen.Web.Document':create_text_node(_document@1,
+						     <<"This text was created through Elixir "
+						       "in your browser.">>),
+    ok = 'Elixir.Lumen.Web.Node':append_child(_paragraph@1,
+					      _text@1),
+    {ok, _output@1} =
+	'Elixir.Lumen.Web.Document':get_element_by_id(_document@1,
+						      <<"output">>),
+    ok = 'Elixir.Lumen.Web.Node':append_child(_output@1,
+					      _paragraph@1),
+    lumen_intrinsics:println(<<"Done!">>).

--- a/examples/interpreter-in-browser/www/ex_sample.ex
+++ b/examples/interpreter-in-browser/www/ex_sample.ex
@@ -1,0 +1,21 @@
+defmodule ExSample do
+  # NOTE: this file is not automatically compiled to .erl, please check the
+  # README.md file for more information.
+  def run_me(arg) do
+    :lumen_intrinsics.println("Doing the Lumen web work...")
+    {:ok, window} = Lumen.Web.Window.window()
+    {:ok, document} = Lumen.Web.Window.document(window)
+    {:ok, paragraph} = Lumen.Web.Document.create_element(document, "p")
+
+    text =
+      Lumen.Web.Document.create_text_node(
+        document,
+        "This text was created through Elixir in your browser."
+      )
+
+    :ok = Lumen.Web.Node.append_child(paragraph, text)
+    {:ok, output} = Lumen.Web.Document.get_element_by_id(document, "output")
+    :ok = Lumen.Web.Node.append_child(output, paragraph)
+    :lumen_intrinsics.println("Done!")
+  end
+end

--- a/examples/interpreter-in-browser/www/foo.erl
+++ b/examples/interpreter-in-browser/www/foo.erl
@@ -1,6 +1,0 @@
--module(foo).
-
--export([bar/1]).
-
-bar(Arg) ->
-    lumen_intrinsics:println({yay, Arg}).

--- a/examples/interpreter-in-browser/www/index.html
+++ b/examples/interpreter-in-browser/www/index.html
@@ -1,32 +1,37 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Lumen Spawn Chain Demo</title>
-    <style>
-      table {
-        border-collapse: collapse;
-      }
 
-      td, th {
-        border: 1px solid #898989;
-        padding: 8px;
-      }
+<head>
+  <meta charset="utf-8">
+  <title>Lumen Interpreter Demo</title>
+  <style>
+    table {
+      border-collapse: collapse;
+    }
 
-      th {
-        padding-top: 12px;
-        padding-bottom: 12px;
-        text-align: left;
-        background-color: #7331af;
-        color: white;
-      }
+    td,
+    th {
+      border: 1px solid #898989;
+      padding: 8px;
+    }
 
-      tr:nth-child(even) {
-        background-color: #f2f2f2;
-      }
-    </style>
-  </head>
-  <body>
-    <script src="./bootstrap.js"></script>
-  </body>
+    th {
+      padding-top: 12px;
+      padding-bottom: 12px;
+      text-align: left;
+      background-color: #7331af;
+      color: white;
+    }
+
+    tr:nth-child(even) {
+      background-color: #f2f2f2;
+    }
+  </style>
+</head>
+
+<body>
+  <script src="./bootstrap.js"></script>
+  <div id="output"></div>
+</body>
+
 </html>

--- a/examples/interpreter-in-browser/www/index.js
+++ b/examples/interpreter-in-browser/www/index.js
@@ -3,25 +3,22 @@ import * as Interpreter from "interpreter-in-browser";
 window.Interpreter = Interpreter;
 
 function compile_url(url) {
-    return fetch(url, {
-        method: "GET",
-    }).then((response) => {
-        if (!response.ok) {
-            throw "fail";
-        }
-        return response.text()
-            .then((text) => {
-                Interpreter.compile_erlang_module(text);
-                return text;
-            });
+  return fetch(url, {
+    method: "GET"
+  }).then(response => {
+    if (!response.ok) {
+      throw "fail";
+    }
+    return response.text().then(text => {
+      Interpreter.compile_erlang_module(text);
+      return text;
     });
+  });
 }
 
-compile_url("foo.erl")
-    .then(() => {
-        let heap = new Interpreter.JsHeap(1000);
-        let num = heap.integer(12);
-        console.log("spawning...");
-        heap.spawn("foo", "bar", [num], 100000);
-    });
-
+compile_url("ex_sample.erl").then(() => {
+  let heap = new Interpreter.JsHeap(1000);
+  let num = heap.integer(12);
+  console.log("spawning...");
+  heap.spawn("Elixir.ExSample", "run_me", [num], 100000);
+});


### PR DESCRIPTION
Add more detail to the sample .erl file.
Add instructions from spawn-chain for running on OS X.
Add instruction on how to build from an Elixir project to an appropriate .erl
file.