### PR TITLE
Protect remap_fallback with cfg

### DIFF
--- a/liblumen_core/src/sys/unix/mmap.rs
+++ b/liblumen_core/src/sys/unix/mmap.rs
@@ -1,4 +1,11 @@
 use core::alloc::{AllocErr, Layout};
+#[cfg(all(
+    not(target_os = "linux"),
+    not(target_os = "emscripten"),
+    not(target_os = "android"),
+    not(target_os = "freebsd"),
+    not(target_os = "netbsd"),
+))]
 use core::cmp;
 use core::intrinsics::unlikely;
 use core::ptr::{self, NonNull};
@@ -264,6 +271,13 @@ unsafe fn remap_internal(
 }
 
 #[inline]
+#[cfg(all(
+    not(target_os = "linux"),
+    not(target_os = "emscripten"),
+    not(target_os = "android"),
+    not(target_os = "freebsd"),
+    not(target_os = "netbsd"),
+))]
 unsafe fn remap_fallback(
     ptr: *mut u8,
     layout: Layout,


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Protect `remap_fallback` with `cfg`.  It is only called by `remap_internal`, which is protected by `cfg`, so it is dead on Linux.