### PR TITLE
Use full name of toolchain with date and not just nightly

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -146,8 +146,8 @@ task:
     popd
   install_rustup_script: |
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2019-12-19
-  install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly
-  install_wasm_bindgen_cli_script: cargo +nightly install wasm-bindgen-cli
+  install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly-2019-12-19
+  install_wasm_bindgen_cli_script: cargo +nightly-2019-12-19 install wasm-bindgen-cli
   install_wasm_pack_script: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
   update_homebrew_script: |
     brew update


### PR DESCRIPTION
# Changelog
## Bug Fixes
* For macOS wasm32 build user full name of toolchain with date and not just `nightly`.