### PR TITLE
Put lumen LLVM on macOS path to ensure wasm32-unknown-unknown target

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ task:
     image: mojave-base
   env:
     LLVM_SYS_90_PREFIX: ${HOME}/clang+llvm-10.0.0-x86_64-apple-darwin19.3.0
-    PATH: ${HOME}/.cargo/bin:${PATH}
+    PATH: ${HOME}/.cargo/bin:${LLVM_SYS_90_PREFIX}/bin:${PATH}
   macos_x86_64_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
@@ -135,7 +135,7 @@ task:
     image: mojave-base
   env:
     LLVM_SYS_90_PREFIX: ${HOME}/clang+llvm-10.0.0-x86_64-apple-darwin19.3.0
-    PATH: ${HOME}/.cargo/bin:${PATH}
+    PATH: ${HOME}/.cargo/bin:${LLVM_SYS_90_PREFIX}/bin:${PATH}
   macos_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock


### PR DESCRIPTION
# Changelog
## Bug FIxes
* Put lumen LLVM on macOS path to ensure `wasm32-unknown-unknown` target. It is not supported by native `/usr/bin/clang` and so instead of `brew install llvm`, just use the LLVM we need to compile EIR anyway.