### PR TITLE
Fix x86_64 Linux and macOS builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: Check Formatted
   container:
-    image: kronicdeth/lumen-development@sha256:2d6eaba839218d6180f06a102cfb7424b02d177820ca980344174328df0c0fc3
+    image: kronicdeth/lumen-development@sha256:6864ea3a8b1786a3b616b1381a333a803d7a9d173803b9cab64393bfdaf0e397
   script: cargo fmt -- --check
 
 x86_64_task_template: &x86_64_TASK_TEMPLATE
@@ -23,7 +23,7 @@ x86_64_task_template: &x86_64_TASK_TEMPLATE
 task:
   name: Linux x86_64
   container:
-    image: kronicdeth/lumen-development@sha256:2d6eaba839218d6180f06a102cfb7424b02d177820ca980344174328df0c0fc3
+    image: kronicdeth/lumen-development@sha256:6864ea3a8b1786a3b616b1381a333a803d7a9d173803b9cab64393bfdaf0e397
     cpu: 4
     memory: 12
   linux_x86_64_cargo_cache:
@@ -99,7 +99,7 @@ task:
 task:
   name: Linux wasm32
   container:
-    image: kronicdeth/lumen-development@sha256:2d6eaba839218d6180f06a102cfb7424b02d177820ca980344174328df0c0fc3
+    image: kronicdeth/lumen-development@sha256:6864ea3a8b1786a3b616b1381a333a803d7a9d173803b9cab64393bfdaf0e397
     memory: 6
   linux_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: Check Formatted
   container:
-    image: kronicdeth/lumen-development@sha256:6864ea3a8b1786a3b616b1381a333a803d7a9d173803b9cab64393bfdaf0e397
+    image: kronicdeth/lumen-development@sha256:3ec4d9b9ce6721d7ba1175342b92f00759da86e0c860ab9237c90f83939b33ca
   script: cargo fmt -- --check
 
 x86_64_task_template: &x86_64_TASK_TEMPLATE
@@ -23,7 +23,7 @@ x86_64_task_template: &x86_64_TASK_TEMPLATE
 task:
   name: Linux x86_64
   container:
-    image: kronicdeth/lumen-development@sha256:6864ea3a8b1786a3b616b1381a333a803d7a9d173803b9cab64393bfdaf0e397
+    image: kronicdeth/lumen-development@sha256:3ec4d9b9ce6721d7ba1175342b92f00759da86e0c860ab9237c90f83939b33ca
     cpu: 4
     memory: 12
   linux_x86_64_cargo_cache:
@@ -99,7 +99,7 @@ task:
 task:
   name: Linux wasm32
   container:
-    image: kronicdeth/lumen-development@sha256:6864ea3a8b1786a3b616b1381a333a803d7a9d173803b9cab64393bfdaf0e397
+    image: kronicdeth/lumen-development@sha256:3ec4d9b9ce6721d7ba1175342b92f00759da86e0c860ab9237c90f83939b33ca
     memory: 6
   linux_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry

--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -1,13 +1,22 @@
 FROM rust:latest
 
-RUN rustup default nightly
+RUN cd /tmp \
+  && wget https://github.com/lumen/llvm-project/releases/download/lumen-10.0.0-dev_2020-03-04/clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz \
+  && tar -xvzf clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz \
+  && rm -f clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz \
+  && mv clang+llvm-10.0.0-x86_64-linux-gnu /opt/llvm
+
+ENV PATH="/opt/llvm/bin:${PATH}"
+ENV LLVM_SYS_90_PREFIX="/opt/llvm"
+
+RUN rustup default nightly-2019-12-19
 
 RUN rustup component add rustfmt
 
 # Add WASM target
-RUN rustup target add wasm32-unknown-unknown --toolchain nightly
+RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2019-12-19
 
-RUN cargo +nightly install wasm-bindgen-cli
+RUN cargo +nightly-2019-12-19 install wasm-bindgen-cli
 
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 

--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -9,6 +9,9 @@ RUN cd /tmp \
 ENV PATH="/opt/llvm/bin:${PATH}"
 ENV LLVM_SYS_90_PREFIX="/opt/llvm"
 
+RUN apt-get update \
+  && apt-get install -y cmake ninja-build
+
 RUN rustup default nightly-2019-12-19
 
 RUN rustup component add rustfmt

--- a/liblumen_alloc/src/erts/term/encoding.rs
+++ b/liblumen_alloc/src/erts/term/encoding.rs
@@ -484,7 +484,7 @@ pub trait Encoded: Repr + Copy {
     }
     /// Returns `true` if the encoded value is the header of an `ExternalPid`
     fn is_remote_pid(self) -> bool {
-        Self::Encoding::is_local_pid(self.value())
+        Self::Encoding::is_remote_pid(self.value())
     }
     /// Returns `true` if the encoded value is a pointer to an `ExternalPid`
     fn is_boxed_remote_pid(self) -> bool {


### PR DESCRIPTION
# Changelog
## Enhancements
* Install specific version of nightly instead of depending on when the `Dockerfile` is built.  Makes it easier to match `macOS` and `inux` builds.

## Bug Fixes
* Install `lumen/llvm-project` for Linux.
* Install `cmake` and `ninja` for Linux.
* Fix copy & paste error where `Encoded.is_remote_pid` called `Encoding::is_local_pid` instead of `Encoding::is_remote_pid`