### PR TITLE
Fix wasm32 builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,7 @@ task:
 task:
   name: macOS x86_64
   osx_instance:
-    image: mojave-base
+    image: catalina-base
   env:
     LLVM_SYS_90_PREFIX: ${HOME}/clang+llvm-10.0.0-x86_64-apple-darwin19.3.0
     PATH: ${HOME}/.cargo/bin:${PATH}
@@ -132,7 +132,7 @@ task:
 task:
   name: macOS wasm32
   osx_instance:
-    image: mojave-base
+    image: catalina-base
   env:
     LLVM_SYS_90_PREFIX: ${HOME}/clang+llvm-10.0.0-x86_64-apple-darwin19.3.0
     PATH: ${HOME}/.cargo/bin:${PATH}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -155,7 +155,7 @@ task:
     brew cask install google-chrome
     brew cask info google-chrome
   install_chrome_driver_script: |
-    wget https://chromedriver.storage.googleapis.com/78.0.3904.70/chromedriver_mac64.zip
+    wget https://chromedriver.storage.googleapis.com/80.0.3987.106/chromedriver_mac64.zip
     unzip chromedriver_mac64.zip
     mv chromedriver /usr/local/bin/
     rm chromedriver_mac64.zip

--- a/liblumen_alloc/src/erts/apply.rs
+++ b/liblumen_alloc/src/erts/apply.rs
@@ -8,9 +8,13 @@ use once_cell::sync::OnceCell;
 
 use liblumen_arena::DroplessArena;
 use liblumen_core::symbols::FunctionSymbol;
-use liblumen_core::sys::dynamic_call::{self, DynamicCallee};
+#[cfg(all(unix, target_arch = "x86_64"))]
+use liblumen_core::sys::dynamic_call;
+use liblumen_core::sys::dynamic_call::DynamicCallee;
 
-use crate::erts::term::prelude::{Atom, Encoded, Term};
+use crate::erts::term::prelude::Atom;
+#[cfg(all(unix, target_arch = "x86_64"))]
+use crate::erts::term::prelude::{Encoded, Term};
 use crate::erts::ModuleFunctionArity;
 
 /// Dynamically invokes the function mapped to the given symbol.

--- a/liblumen_core/src/alloc/mmap.rs
+++ b/liblumen_core/src/alloc/mmap.rs
@@ -38,7 +38,13 @@ pub unsafe fn map_stack(pages: usize) -> Result<NonNull<u8>, AllocErr> {
 #[cfg(not(has_mmap))]
 #[inline]
 pub unsafe fn map_stack(pages: usize) -> Result<NonNull<u8>, AllocErr> {
-    sys_alloc::alloc(pages)
+    let page_size = crate::sys::sysconf::pagesize();
+    let (layout, _offset) = Layout::from_size_align(page_size, page_size)
+        .unwrap()
+        .repeat(pages)
+        .unwrap();
+
+    sys_alloc::alloc(layout)
 }
 
 /// Remaps a mapping given a pointer to the mapping, the layout which created it, and the new size

--- a/liblumen_core/src/symbols.rs
+++ b/liblumen_core/src/symbols.rs
@@ -1,6 +1,8 @@
 use core::ffi::c_void;
+#[cfg(all(unix, target_arch = "x86_64"))]
 use core::mem;
 
+#[cfg(all(unix, target_arch = "x86_64"))]
 use crate::sys::dynamic_call::{self, DynamicCallee};
 
 /// This struct represents the serialized form of a symbol table entry

--- a/liblumen_term/build.rs
+++ b/liblumen_term/build.rs
@@ -8,6 +8,10 @@ use std::path::{Path, PathBuf};
 const ENV_LLVM_PREFIX: &'static str = "LLVM_SYS_90_PREFIX";
 
 fn main() {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "wasm32" {
+        return;
+    }
+
     // Emit custom cfg types:
     //     cargo:rustc-cfg=has_foo
     // Can then be used as `#[cfg(has_foo)]` when emitted

--- a/liblumen_term/src/lib.rs
+++ b/liblumen_term/src/lib.rs
@@ -1,9 +1,11 @@
 #![feature(arbitrary_enum_discriminant)]
 
 mod encoding;
+#[cfg(not(target_arch = "wasm32"))]
 mod ffi;
 mod tag;
 
 pub use self::encoding::*;
+#[cfg(not(target_arch = "wasm32"))]
 pub use self::ffi::{TermKind, Type};
 pub use self::tag::Tag;

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -43,7 +43,7 @@ mod binary;
 pub mod binary_to_string;
 // `pub` or `examples/spawn-chain`
 pub mod code;
-#[cfg(not(test))]
+#[cfg(not(any(test, target_arch = "wasm32")))]
 mod config;
 mod context;
 mod distribution;

--- a/lumen_runtime/src/logging.rs
+++ b/lumen_runtime/src/logging.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
 use colored::*;
-#[cfg(not(test))]
+#[cfg(not(any(test, target_arch = "wasm32")))]
 use log::SetLoggerError;
 use log::{Level, Log, Metadata, Record};
 
@@ -12,7 +12,7 @@ pub struct Logger {
 }
 
 impl Logger {
-    #[cfg(not(test))]
+    #[cfg(not(any(test, target_arch = "wasm32")))]
     pub fn init(level: Level) -> Result<(), SetLoggerError> {
         log::set_max_level(level.to_level_filter());
         Ok(())


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Don't do `cmake` build for `liblumen_term` on `wasm32` to fix.
* Conditionally disable parts not used on `wasm32` to fix `dead_code` warnings.
* Fix type passed to fallback `map_stack` `sys_alloc::alloc`.  It was `usize` `pages`, but it needs to be a `Layout`, so use `crate::sys::sysconf::pagesize` to create a layout of with N `pages` of `pagesize` aligned to `pagesize`.