### PR TITLE
Update to nightly-2020-03-10

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: Check Formatted
   container:
-    image: kronicdeth/lumen-development@sha256:273edaaffb45165e6f23d75990cdbfcc677ae47d1a41553f62852630d46d4b40
+    image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
   script: cargo fmt -- --check
 
 x86_64_task_template: &x86_64_TASK_TEMPLATE
@@ -23,7 +23,7 @@ x86_64_task_template: &x86_64_TASK_TEMPLATE
 task:
   name: Linux x86_64 libraries
   container:
-    image: kronicdeth/lumen-development@sha256:273edaaffb45165e6f23d75990cdbfcc677ae47d1a41553f62852630d46d4b40
+    image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
     cpu: 4
     memory: 12
   linux_x86_64_cargo_cache:
@@ -35,7 +35,7 @@ task:
 task:
   name: Linux x86_64 compiler
   container:
-    image: kronicdeth/lumen-development@sha256:273edaaffb45165e6f23d75990cdbfcc677ae47d1a41553f62852630d46d4b40
+    image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
   linux_x86_64_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock
@@ -61,7 +61,7 @@ task:
     tar xvfz clang+llvm-10.0.0-x86_64-apple-darwin19.3.0.tar.gz
     popd
   install_rustup_script: |
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2019-12-19
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2020-03-10
   <<: *x86_64_TASK_TEMPLATE
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
@@ -81,7 +81,7 @@ task:
     tar xvfz clang+llvm-10.0.0-x86_64-apple-darwin19.3.0.tar.gz
     popd
   install_rustup_script: |
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2019-12-19
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2020-03-10
   install_jq_script: |
     brew install jq
   install_ninja_script: |
@@ -139,7 +139,7 @@ task:
 task:
   name: Linux wasm32
   container:
-    image: kronicdeth/lumen-development@sha256:273edaaffb45165e6f23d75990cdbfcc677ae47d1a41553f62852630d46d4b40
+    image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
     memory: 6
   linux_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry
@@ -185,9 +185,9 @@ task:
     tar xvfz clang+llvm-10.0.0-x86_64-apple-darwin19.3.0.tar.gz
     popd
   install_rustup_script: |
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2019-12-19
-  install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly-2019-12-19
-  install_wasm_bindgen_cli_script: cargo +nightly-2019-12-19 install wasm-bindgen-cli
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=nightly-2020-03-10
+  install_wasm32_target_script: rustup target add wasm32-unknown-unknown --toolchain nightly-2020-03-10
+  install_wasm_bindgen_cli_script: cargo +nightly-2020-03-10 install wasm-bindgen-cli
   install_wasm_pack_script: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
   update_homebrew_script: |
     brew update

--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -12,14 +12,14 @@ ENV LLVM_SYS_90_PREFIX="/opt/llvm"
 RUN apt-get update \
   && apt-get install -y cmake jq libc++-dev libc++abi-dev libunwind-dev ninja-build rsync
 
-RUN rustup default nightly-2019-12-19
+RUN rustup default nightly-2020-03-10
 
 RUN rustup component add rustfmt
 
 # Add WASM target
-RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2019-12-19
+RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2020-03-10
 
-RUN cargo +nightly-2019-12-19 install wasm-bindgen-cli
+RUN cargo +nightly-2020-03-10 install wasm-bindgen-cli
 
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,7 @@ dependencies = [
  "libeir_ir 0.1.0 (git+https://github.com/bitwalker/eir?branch=bitwalker/lumen-changes)",
  "libeir_passes 0.1.0 (git+https://github.com/bitwalker/eir?branch=bitwalker/lumen-changes)",
  "libeir_syntax_erl 0.1.0 (git+https://github.com/bitwalker/eir?branch=bitwalker/lumen-changes)",
+ "libeir_util_parse 0.1.0 (git+https://github.com/bitwalker/eir?branch=bitwalker/lumen-changes)",
  "liblumen_alloc 0.1.0",
  "lumen_runtime 0.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "dlmalloc"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/lumen/dlmalloc-rs.git?branch=nightly-2020-03-10#fc8d2b734abfd69adcbaef0b95523a646510151f"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1090,7 +1090,7 @@ name = "liblumen_core"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlmalloc 0.1.3 (git+https://github.com/lumen/dlmalloc-rs.git?branch=nightly-2020-03-10)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "liblumen_core_macros 0.1.0",
@@ -2738,7 +2738,7 @@ dependencies = [
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-"checksum dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f283302e035e61c23f2b86b3093e8c6273a4c3125742d6087e96ade001ca5e63"
+"checksum dlmalloc 0.1.3 (git+https://github.com/lumen/dlmalloc-rs.git?branch=nightly-2020-03-10)" = "<none>"
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 "checksum docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ libeir_intern = { git = "https://github.com/bitwalker/eir.git", branch = "bitwal
 libeir_lowerutils = { git = "https://github.com/bitwalker/eir.git", branch = "bitwalker/lumen-changes" }
 libeir_passes = { git = "https://github.com/bitwalker/eir.git", branch = "bitwalker/lumen-changes" }
 libeir_util_datastructures = { git = "https://github.com/bitwalker/eir.git", branch = "bitwalker/lumen-changes" }
+libeir_util_parse = { git = "https://github.com/bitwalker/eir.git", branch = "bitwalker/lumen-changes" }
 #libeir_diagnostics = { path = "../eir/libeir_diagnostics" }
 #libeir_frontend = { path = "../eir/libeir_frontend" }
 #libeir_syntax_erl = { path = "../eir/libeir_syntax_erl" }

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ In order to build Lumen, or make changes to it, you'll need the following instal
 
 First, you will need to install [rustup](https://rustup.rs/). Follow the instructions at that link.
 
-Once you have installed `rustup`, you will need to install the nightly version of Rust, this is
-currently required due to our dependency on `wasm-bindgen` when targeting WebAssembly:
+Once you have installed `rustup`, you will need to install the nightly version of Rust from 2020-03-10. A nightly
+version is currently required due to our dependency on `wasm-bindgen` when targeting WebAssembly and `AllocRef` for
+memory allocation:
 
-    rustup default nightly # install nightly toolchain
+    rustup default nightly-2020-03-10 # install nightly toolchain from 2020-03-10 to match CI
 
 You may also want to install the following tools for editor support (`rustfmt` will be required on
 all pull requests!):
@@ -35,11 +36,11 @@ all pull requests!):
 
 Next, you will need to install the `wasm32` targets for the toolchain:
 
-    rustup target add wasm32-unknown-unknown --toolchain nightly
+    rustup target add wasm32-unknown-unknown --toolchain nightly-2020-03-10
 
 You will also need to install the `wasm-bindgen** command-line tools:
 
-    cargo +nightly install wasm-bindgen-cli
+    cargo +nightly-2020-03-10 install wasm-bindgen-cli
 
 Finally we will need `wasm-pack`. It is needed to build the examples and get up and running. Follow their installation instructions from [the wasm-pack repository](https://github.com/rustwasm/wasm-pack).
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ Finally we will need `wasm-pack`. It is needed to build the examples and get up 
 
 #### LLVM
 
+##### Using prebuilt tarballs
+
+LLVM takes a long time to compile (~2 hours) and a lot of space (~29G), so if you can, we recommend using the prebuilt tarballs.
+
+###### Linux
+
+    mkdir -p ~/.local/share/llvm
+    cd ~/.local/share/llvm 
+    wget https://github.com/lumen/llvm-project/releases/download/lumen-10.0.0-dev_2020-03-08/clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz
+    tar xvfz clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz
+    rm clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz
+    mv clang+llvm-10.0.0-x86_64-linux-gnu lumen
+    cd -
+
+###### MacOS
+
+    mkdir -p ~/.local/share/llvm
+    cd ~/.local/share/llvm 
+    wget https://github.com/lumen/llvm-project/releases/download/lumen-10.0.0-dev_2020-03-08/clang+llvm-10.0.0-x86_64-apple-darwin19.3.0.tar.gz
+    tar xvfz clang+llvm-10.0.0-x86_64-apple-darwin19.3.0.tar.gz
+    rm clang+llvm-10.0.0-x86_64-apple-darwin19.3.0.tar.gz
+    mv clang+llvm-10.0.0-x86_64-apple-darwin19.3.0 lumen
+    cd -
+
+###### Other Operating Systems
+
+You'll need to build from scratch using the below instructions. 
+
+##### Building from scratch
+
 Now that Rust is setup and ready to go, you will also need LLVM for building the compiler.
 
 LLVM requires Cmake, a C/C++ compiler (i.e. GCC/Clang), and Python. It is also
@@ -67,7 +97,12 @@ likewise you can change the setting to use CCache by removing that option as wel
 
 **NOTE:** Building LLVM the first time will take a long time, so grab a coffee, smoke 'em if you got 'em, etc.
 
-Once LLVM is built, you can run `make build` from the root to fetch all dependencies and build the project.
+### Lumen Compiler
+
+Once LLVM is installed, you can run fetch all dependencies and build the project.
+
+    export LLVM_SYS_90_PREFIX=$HOME/.local/share/llvm/lumen
+    make build
 
 <a name="contrib-project"/>
 

--- a/liblumen_alloc/src/blocks.rs
+++ b/liblumen_alloc/src/blocks.rs
@@ -31,7 +31,7 @@ mod tests {
         let size = sysconf::pagesize();
         let usable = size - mem::size_of::<Block>();
         let layout = Layout::from_size_align(size, size).unwrap();
-        let ptr = unsafe {
+        let (ptr, _) = unsafe {
             SYS_ALLOC
                 .alloc(layout.clone())
                 .expect("unable to map memory")
@@ -75,7 +75,7 @@ mod tests {
         let size = sysconf::pagesize();
         let usable = size - mem::size_of::<Block>();
         let layout = Layout::from_size_align(size, size).unwrap();
-        let ptr = unsafe {
+        let (ptr, _) = unsafe {
             SYS_ALLOC
                 .alloc(layout.clone())
                 .expect("unable to map memory")
@@ -125,7 +125,7 @@ mod tests {
         let size = sysconf::pagesize() * 2;
         let usable = sysconf::pagesize() - mem::size_of::<Block>();
         let layout = Layout::from_size_align(size, size).unwrap();
-        let ptr = unsafe {
+        let (ptr, _) = unsafe {
             SYS_ALLOC
                 .alloc(layout.clone())
                 .expect("unable to map memory")

--- a/liblumen_alloc/src/carriers/multi_block.rs
+++ b/liblumen_alloc/src/carriers/multi_block.rs
@@ -280,9 +280,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[rustversion::before(2019-01-30)]
-    use core::alloc::Alloc;
-    #[rustversion::since(2019-01-30)]
     use core::alloc::AllocRef;
 
     use super::*;
@@ -301,7 +298,7 @@ mod tests {
         let size = SUPERALIGNED_CARRIER_SIZE;
         let carrier_layout = Layout::from_size_align(size, size).unwrap();
         // Allocate region
-        let ptr = unsafe { SYS_ALLOC.alloc(carrier_layout).unwrap() };
+        let (ptr, _) = unsafe { SYS_ALLOC.alloc(carrier_layout).unwrap() };
         // Get pointer to carrier header location
         let carrier = ptr.as_ptr() as *mut MultiBlockCarrier<RBTreeLink>;
         // Write initial carrier header

--- a/liblumen_alloc/src/erts/testing.rs
+++ b/liblumen_alloc/src/erts/testing.rs
@@ -37,7 +37,7 @@ impl RegionHeap {
     /// Creates a new scratch heap from the given layout
     pub fn new(layout: Layout) -> Self {
         let size = layout.size();
-        let ptr =
+        let (ptr, _) =
             unsafe { sys_alloc::alloc(layout.clone()).expect("unable to allocate scratch heap!") };
         let raw = ptr.as_ptr();
         let end = unsafe { raw.add(size) };

--- a/liblumen_beam/src/beam/reader.rs
+++ b/liblumen_beam/src/beam/reader.rs
@@ -81,16 +81,6 @@ impl std::fmt::Display for ReadError {
 }
 
 impl std::error::Error for ReadError {
-    fn description(&self) -> &str {
-        use self::ReadError::*;
-        match *self {
-            FileError(ref x) => x.description(),
-            InvalidString(ref x) => x.description(),
-            UnexpectedMagicNumber(_) => "Unexpected magic number",
-            UnexpectedFormType(_) => "Unexpected form type",
-            UnexpectedChunk { .. } => "Unexpected chunk",
-        }
-    }
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             ReadError::FileError(ref x) => Some(x),

--- a/liblumen_core/Cargo.toml
+++ b/liblumen_core/Cargo.toml
@@ -18,7 +18,9 @@ liblumen_core_macros = { path = "../liblumen_core_macros" }
 # On wasm32-unknown-unknown, use dlmalloc for malloc/free
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown"))'.dependencies.dlmalloc]
 version = "0.1"
-features = ["allocator-api"]
+features = ["allocator-api", "nightly"]
+git = "https://github.com/lumen/dlmalloc-rs.git"
+branch = "nightly-2020-03-10"
 
 # We use libc for all platforms except wasm32-unknown-unknown
 # NOTE: On win32 we use libc for malloc/free

--- a/liblumen_core/src/alloc/raw_vec.rs
+++ b/liblumen_core/src/alloc/raw_vec.rs
@@ -722,7 +722,7 @@ mod tests {
             fuel: usize,
         }
         unsafe impl AllocRef for BoundedAlloc {
-            unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
+            unsafe fn alloc(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
                 use crate::alloc::GlobalAlloc;
                 let size = layout.size();
                 if size > self.fuel {
@@ -733,7 +733,7 @@ mod tests {
                     return Err(AllocErr);
                 }
                 self.fuel -= size;
-                Ok(NonNull::new_unchecked(ptr))
+                Ok((NonNull::new_unchecked(ptr), size))
             }
             unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
                 use crate::alloc::GlobalAlloc;

--- a/liblumen_eir_interpreter/Cargo.toml
+++ b/liblumen_eir_interpreter/Cargo.toml
@@ -22,6 +22,7 @@ libeir_intern = { git = "https://github.com/eirproject/eir.git" }
 libeir_ir = { git = "https://github.com/eirproject/eir.git" }
 libeir_passes = { git = "https://github.com/eirproject/eir.git" }
 libeir_syntax_erl = { git = "https://github.com/eirproject/eir.git" }
+libeir_util_parse = { git = "https://github.com/eirproject/eir.git" }
 
 # workspace crates
 liblumen_alloc = { path = "../liblumen_alloc" }

--- a/liblumen_eir_interpreter/src/tests/mod.rs
+++ b/liblumen_eir_interpreter/src/tests/mod.rs
@@ -1,7 +1,5 @@
 use super::VM;
 
-use libeir_diagnostics::{ColorChoice, Emitter, StandardStreamEmitter};
-
 use libeir_ir::Module;
 
 use libeir_passes::PassManager;
@@ -10,36 +8,33 @@ use libeir_syntax_erl::ast::Module as ErlAstModule;
 use libeir_syntax_erl::lower_module;
 use libeir_syntax_erl::{Parse, ParseConfig, Parser};
 
+use libeir_util_parse::{ArcCodemap, Errors};
+
 use liblumen_alloc::erts::term::prelude::*;
 
 use lumen_runtime::scheduler::Scheduler;
 
-fn parse<T>(input: &str, config: ParseConfig) -> (T, Parser)
+fn parse<T>(input: &str, config: ParseConfig) -> (T, ArcCodemap)
 where
     T: Parse<T>,
 {
     let parser = Parser::new(config);
-    let errs = match parser.parse_string::<&str, T>(input) {
-        Ok(ast) => return (ast, parser),
+    let mut errors = Errors::new();
+    let codemap: ArcCodemap = Default::default();
+    match parser.parse_string::<&str, T>(&mut errors, &codemap, input) {
+        Ok(ast) => return (ast, codemap),
         Err(errs) => errs,
     };
-    let emitter =
-        StandardStreamEmitter::new(ColorChoice::Auto).set_codemap(parser.config.codemap.clone());
-    for err in errs.iter() {
-        emitter.diagnostic(&err.to_diagnostic()).unwrap();
-    }
+    errors.print(&codemap);
     panic!("parse failed");
 }
 
 pub fn lower(input: &str, config: ParseConfig) -> Result<Module, ()> {
-    let (parsed, parser): (ErlAstModule, _) = parse(input, config);
-    let (res, messages) = lower_module(&parser.config.codemap, &parsed);
+    let (parsed, codemap): (ErlAstModule, _) = parse(input, config);
 
-    let emitter =
-        StandardStreamEmitter::new(ColorChoice::Auto).set_codemap(parser.config.codemap.clone());
-    for err in messages.iter() {
-        emitter.diagnostic(&err.to_diagnostic()).unwrap();
-    }
+    let mut errors = Errors::new();
+    let res = lower_module(&mut errors, &codemap, &parsed);
+    errors.print(&codemap);
 
     res
 }

--- a/lumen_runtime/src/config.rs
+++ b/lumen_runtime/src/config.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::error::Error;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
@@ -39,11 +38,6 @@ impl std::fmt::Display for ConfigError {
 }
 
 impl std::error::Error for ConfigError {
-    fn description(&self) -> &str {
-        match *self {
-            ConfigError::FileError(_, ref err) => err.to_string(),
-        }
-    }
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             ConfigError::FileError(ref _path, ref err) => Some(err),


### PR DESCRIPTION
# Changelog
## Enhancements
* Update to `nightly-2020-03-10`
  * Can't use `nightly-2020-03-11`, it was missing `rustc` component.
  * Can't use `nightly-2020-03-12`, they removed `unsafe` from `fn alloc` in `AllocRef` in https://github.com/rust-lang/rust/commit/f77afc8f9c63d789519c0b1a733462ca654d894a 6 days ago.