### PR TITLE
Fix (some) build errors

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,6 +36,8 @@ task:
   name: Linux x86_64 compiler
   container:
     image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
+    cpu: 4
+    memory: 12
   linux_x86_64_cargo_cache:
     folder: $CARGO_HOME/registry
     fingerprint_script: cat Cargo.lock

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -95,7 +95,7 @@ task:
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 task:
-  name: Windows x86_64
+  name: Windows x86_64 libraries
   windows_container:
     image: cirrusci/windowsservercore:cmake
     os_version: 2019

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,7 +104,7 @@ task:
     CIRRUS_SHELL: powershell
     CARGO_HOME: $USERPROFILE\.cargo
     PATH: $PATH;$CARGO_HOME\bin
-  install_rustup_script: "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -URI https://win.rustup.rs -OutFile rustup-init.exe; ./rustup-init.exe -y --default-toolchain nightly-x86_64-pc-windows-msvc"
+  install_rustup_script: "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -URI https://win.rustup.rs -OutFile rustup-init.exe; ./rustup-init.exe -y --default-toolchain nightly-2020-03-10-x86_64-pc-windows-msvc"
   build_script: cargo build
   # `*_test_script`s in order of crate dependency graph
   liblumen_arena_test_script: |

--- a/liblumen_alloc/src/erts/process/gc/rootset.rs
+++ b/liblumen_alloc/src/erts/process/gc/rootset.rs
@@ -1,5 +1,5 @@
-use core::slice;
 use core::fmt;
+use core::slice;
 
 use alloc::vec::Vec;
 
@@ -77,7 +77,7 @@ impl Default for RootSet {
 impl fmt::Debug for RootSet {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for root in self.0.iter().map(|b| b.as_ptr()) {
-             unsafe {
+            unsafe {
                 let term = &*root;
                 let decoded = term.decode();
                 f.write_fmt(format_args!(
@@ -92,7 +92,6 @@ impl fmt::Debug for RootSet {
         Ok(())
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/liblumen_alloc/src/erts/process/gc/young_heap.rs
+++ b/liblumen_alloc/src/erts/process/gc/young_heap.rs
@@ -528,7 +528,7 @@ impl Drop for YoungHeap {
 impl fmt::Debug for YoungHeap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use crate::erts::term::arch::repr::Repr;
-       
+
         f.write_fmt(format_args!(
             "YoungHeap (heap: {:p}-{:p}, stack: {:p}-{:p}, used: {}, unused: {}) [\n",
             self.heap_start(),

--- a/liblumen_alloc/src/erts/term/encoding.rs
+++ b/liblumen_alloc/src/erts/term/encoding.rs
@@ -12,7 +12,7 @@ use std::backtrace::Backtrace;
 use hashbrown::HashMap;
 use thiserror::Error;
 
-use liblumen_term::{Tag, Encoding as TermEncoding};
+use liblumen_term::{Encoding as TermEncoding, Tag};
 
 use crate::borrow::CloneToProcess;
 use crate::erts::exception::{AllocResult, InternalResult};


### PR DESCRIPTION
# Changelog
## Bug Fixes
* `cargo fmt`
* Increase CPU and memory for Linux x86_64 compiler.  Need more memory because of [OOMKiller](https://cirrus-ci.com/task/6025330578161664).  Increasing CPUs to match Linux x86_64 libraries to speed up build.
* Install nightly-2020-03-10 on windows
* Rename Windows x86_64 to Windows x86_64 libraries.  Matches other OS and emphasizes we can't build the compiler for Windows yet.
