### PR TITLE
Update Linux docker image sha256

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: Check Formatted
   container:
-    image: kronicdeth/lumen-development@sha256:bbd32a07a7eb90f2dd1970525a34d5b1b8c5944dcfe4120de564a6fb4421d688
+    image: kronicdeth/lumen-development@sha256:a91994aa0332b7f0d94c7342cc4edde50295f73ad2b7b9db3c7da8524f340b12
   script: cargo fmt -- --check
 
 x86_64_task_template: &x86_64_TASK_TEMPLATE
@@ -23,7 +23,7 @@ x86_64_task_template: &x86_64_TASK_TEMPLATE
 task:
   name: Linux x86_64 libraries
   container:
-    image: kronicdeth/lumen-development@sha256:bbd32a07a7eb90f2dd1970525a34d5b1b8c5944dcfe4120de564a6fb4421d688
+    image: kronicdeth/lumen-development@sha256:a91994aa0332b7f0d94c7342cc4edde50295f73ad2b7b9db3c7da8524f340b12
     cpu: 4
     memory: 12
   linux_x86_64_cargo_cache:
@@ -35,7 +35,7 @@ task:
 task:
   name: Linux x86_64 compiler
   container:
-    image: kronicdeth/lumen-development@sha256:bbd32a07a7eb90f2dd1970525a34d5b1b8c5944dcfe4120de564a6fb4421d688
+    image: kronicdeth/lumen-development@sha256:a91994aa0332b7f0d94c7342cc4edde50295f73ad2b7b9db3c7da8524f340b12
     cpu: 4
     memory: 12
   linux_x86_64_cargo_cache:
@@ -141,7 +141,7 @@ task:
 task:
   name: Linux wasm32
   container:
-    image: kronicdeth/lumen-development@sha256:bbd32a07a7eb90f2dd1970525a34d5b1b8c5944dcfe4120de564a6fb4421d688
+    image: kronicdeth/lumen-development@sha256:a91994aa0332b7f0d94c7342cc4edde50295f73ad2b7b9db3c7da8524f340b12
     memory: 6
   linux_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: Check Formatted
   container:
-    image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
+    image: kronicdeth/lumen-development@sha256:bbd32a07a7eb90f2dd1970525a34d5b1b8c5944dcfe4120de564a6fb4421d688
   script: cargo fmt -- --check
 
 x86_64_task_template: &x86_64_TASK_TEMPLATE
@@ -23,7 +23,7 @@ x86_64_task_template: &x86_64_TASK_TEMPLATE
 task:
   name: Linux x86_64 libraries
   container:
-    image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
+    image: kronicdeth/lumen-development@sha256:bbd32a07a7eb90f2dd1970525a34d5b1b8c5944dcfe4120de564a6fb4421d688
     cpu: 4
     memory: 12
   linux_x86_64_cargo_cache:
@@ -35,7 +35,7 @@ task:
 task:
   name: Linux x86_64 compiler
   container:
-    image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
+    image: kronicdeth/lumen-development@sha256:bbd32a07a7eb90f2dd1970525a34d5b1b8c5944dcfe4120de564a6fb4421d688
     cpu: 4
     memory: 12
   linux_x86_64_cargo_cache:
@@ -141,7 +141,7 @@ task:
 task:
   name: Linux wasm32
   container:
-    image: kronicdeth/lumen-development@sha256:99f157b5ef2b5a7a57e25c7d0ff4ca75151d141934c9ac2bb4125461fc3f4673
+    image: kronicdeth/lumen-development@sha256:bbd32a07a7eb90f2dd1970525a34d5b1b8c5944dcfe4120de564a6fb4421d688
     memory: 6
   linux_wasm32_cargo_cache:
     folder: $CARGO_HOME/registry

--- a/.cirrus/Dockerfile
+++ b/.cirrus/Dockerfile
@@ -8,6 +8,8 @@ RUN cd /tmp \
 
 ENV PATH="/opt/llvm/bin:${PATH}"
 ENV LLVM_SYS_90_PREFIX="/opt/llvm"
+ENV CC=/opt/llvm/bin/clang
+ENV CXX=/opt/llvm/bin/clang++
 
 RUN apt-get update \
   && apt-get install -y cmake jq libc++-dev libc++abi-dev libunwind-dev ninja-build rsync

--- a/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/Conversion/EIRToLLVM/ConversionSupport.h
+++ b/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/Conversion/EIRToLLVM/ConversionSupport.h
@@ -403,7 +403,7 @@ class EIROpConversion : public mlir::OpConversionPattern<Op> {
   ConversionContext ctx;
 
  protected:
-  ConversionContext &getContext() const { return ctx; }
+  ConversionContext const &getContext() const { return ctx; }
 
   RewritePatternContext<Op> getRewriteContext(
       Op op, ConversionPatternRewriter &rewriter) const {


### PR DESCRIPTION
# Changelog
## Bug FIxes
* Update Linux docker image `sha256`.  Sha256 got out of sync when both @bitwalker and I were making changes.
* Use `clang` for `CC` and `clang++` for CXX on Linux to fix undeclared errors.
* Make `getContext` double `const`.