### PR TITLE
Erlang integration tests for non-badarg erlang:and/2

### DIFF
--- a/.github/workflows/x86_64-apple-darwin-runtime_full.yml
+++ b/.github/workflows/x86_64-apple-darwin-runtime_full.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-runtime-full-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build TableGen
-        run: make lumen-tblgen
+      - name: Make Build
+        run: make build
       - name: Test lumen_rt_full
         run: cargo test --package lumen_rt_full
       - name: Test liblumen_otp with runtime_full

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 [[package]]
 name = "libeir_diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "anyhow",
  "codespan",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "libeir_frontend"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "libeir_diagnostics",
  "libeir_ir",
@@ -1001,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "libeir_intern"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "lazy_static 1.4.0",
  "libeir_diagnostics",
@@ -1011,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "libeir_ir"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "bumpalo 3.2.0",
  "cranelift-entity",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "libeir_lowerutils"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "cranelift-entity",
  "libeir_ir",
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "libeir_passes"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "bumpalo 3.2.0",
  "cranelift-entity",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "libeir_syntax_erl"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "bumpalo 3.2.0",
  "codespan-reporting",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "libeir_util_datastructures"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "cranelift-entity",
  "hashbrown 0.7.0",
@@ -1104,12 +1104,12 @@ dependencies = [
 [[package]]
 name = "libeir_util_dot_graph"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 
 [[package]]
 name = "libeir_util_number"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "num-bigint 0.2.2",
  "num-traits",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "libeir_util_parse"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "codespan-reporting",
  "libeir_diagnostics",
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "libeir_util_parse_listing"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "libeir_util_pattern_compiler"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "derivative",
  "either",
@@ -1363,6 +1363,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "liblumen_alloc",
  "liblumen_core",
+ "lumen",
  "lumen_rt_core",
  "lumen_rt_full",
  "native_implemented",
@@ -1649,7 +1650,7 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 [[package]]
 name = "meta_table"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 dependencies = [
  "hashbrown 0.7.0",
 ]
@@ -2442,7 +2443,7 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 [[package]]
 name = "scoped_cell"
 version = "0.1.0"
-source = "git+https://github.com/eirproject/eir.git?branch=lumen#c6ce7bbe500df6780f8fb7296917f8fc83fec4e0"
+source = "git+https://github.com/KronicDeth/eir?branch=and-or#25773795fc0fd8640ffdd04e7ca6c1f200e62a35"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,18 +62,17 @@ default-members = [
 opt-level = 2
 lto = false
 
-#[patch."https://github.com/eirproject/eir"]
-#libeir_diagnostics = { path = "../eir/libeir_diagnostics" }
-#libeir_frontend = { path = "../eir/libeir_frontend" }
-#libeir_syntax_erl = { path = "../eir/libeir_syntax_erl" }
-#libeir_ir = { path = "../eir/libeir_ir" }
-#libeir_intern = { path = "../eir/libeir_intern" }
-#libeir_lowerutils = { path = "../eir/libeir_lowerutils" }
-#libeir_passes = { path = "../eir/libeir_passes" }
-#libeir_util_datastructures = { path = "../eir/util/libeir_util_datastructures" }
-#libeir_util_dot_graph = { path = "../eir/util/libeir_util_dot_graph" }
-#libeir_util_number = { path = "../eir/util/libeir_util_number" }
-#libeir_util_parse = { path = "../eir/util/libeir_util_parse" }
-#libeir_util_parse_listing = { path = "../eir/util/libeir_util_parse_listing" }
-#libeir_util_pattern_compiler = { path = "../eir/util/libeir_util_pattern_compiler" }
-
+[patch."https://github.com/eirproject/eir"]
+libeir_diagnostics = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_frontend = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_syntax_erl = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_ir = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_intern = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_lowerutils = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_passes = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_util_datastructures = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_util_dot_graph = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_util_number = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_util_parse = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_util_parse_listing = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }
+libeir_util_pattern_compiler = { git = "https://github.com/KronicDeth/eir", branch = "and-or" }

--- a/native_implemented/otp/Cargo.toml
+++ b/native_implemented/otp/Cargo.toml
@@ -36,4 +36,5 @@ features = ['console']
 
 [dev-dependencies]
 lumen_rt_full = { path = "../../runtimes/full" }
+lumen = { path = "../../lumen" }
 

--- a/native_implemented/otp/src/erlang/and_2/test.rs
+++ b/native_implemented/otp/src/erlang/and_2/test.rs
@@ -1,9 +1,6 @@
 mod with_false_left;
 mod with_true_left;
 
-use proptest::prop_assert_eq;
-use proptest::test_runner::{Config, TestRunner};
-
 use crate::erlang::and_2::result;
 use crate::test::strategy;
 

--- a/native_implemented/otp/src/erlang/and_2/test/with_false_left.rs
+++ b/native_implemented/otp/src/erlang/and_2/test/with_false_left.rs
@@ -12,13 +12,4 @@ fn without_boolean_right_errors_badarg() {
     );
 }
 
-#[test]
-fn with_boolean_right_returns_false() {
-    TestRunner::new(Config::with_source_file(file!()))
-        .run(&strategy::term::is_boolean(), |right| {
-            prop_assert_eq!(result(false.into(), right), Ok(false.into()));
-
-            Ok(())
-        })
-        .unwrap();
-}
+// `with_boolean_right_returns_false` in integration tests

--- a/native_implemented/otp/src/erlang/and_2/test/with_true_left.rs
+++ b/native_implemented/otp/src/erlang/and_2/test/with_true_left.rs
@@ -12,12 +12,5 @@ fn without_boolean_right_errors_badarg() {
     );
 }
 
-#[test]
-fn with_false_right_returns_false() {
-    assert_eq!(result(true.into(), false.into()), Ok(false.into()));
-}
-
-#[test]
-fn with_true_right_returns_true() {
-    assert_eq!(result(true.into(), true.into()), Ok(true.into()));
-}
+// `with_false_right_returns_false` in integration tests
+// `with_true_right_returns_true` in integration tests

--- a/native_implemented/otp/tests/.gitignore
+++ b/native_implemented/otp/tests/.gitignore
@@ -1,0 +1,2 @@
+bin
+_build

--- a/native_implemented/otp/tests/lib.rs
+++ b/native_implemented/otp/tests/lib.rs
@@ -1,0 +1,9 @@
+#[path = "./test.rs"]
+mod test;
+
+use test::*;
+
+// Linux currently can't compile `lumen` compiler
+#[cfg(not(target_os = "linux"))]
+#[path = "lib/erlang.rs"]
+pub mod erlang;

--- a/native_implemented/otp/tests/lib/erlang.rs
+++ b/native_implemented/otp/tests/lib/erlang.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+#[path = "erlang/and_2.rs"]
+pub mod and_2;

--- a/native_implemented/otp/tests/lib/erlang/and_2.rs
+++ b/native_implemented/otp/tests/lib/erlang/and_2.rs
@@ -1,0 +1,8 @@
+#[path = "and_2/with_false_left.rs"]
+mod with_false_left;
+#[path = "and_2/with_true_left.rs"]
+mod with_true_left;
+
+use super::*;
+
+// `without_boolean_left_errors_badarg` in unit tests

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_false_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_false_left.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+// `without_boolean_right_errors_badarg` in unit tests
+
+#[test]
+fn with_boolean_right_returns_false() {
+    let name = "with_boolean_right_returns_false";
+    let bin_path_buf = compile(file!(), name);
+
+    let output = Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        stdout, ":'false'\n:'true'\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout, stderr
+    );
+}

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_false_left/with_boolean_right_returns_false/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_false_left/with_boolean_right_returns_false/init.erl
@@ -1,0 +1,7 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(false or false),
+  display(false or true).

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_true_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_true_left.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+// `without_boolean_right_errors_badarg` in unit tests
+
+#[test]
+fn with_false_right_returns_false() {
+    let name = "with_false_right_returns_false";
+    let bin_path_buf = compile(file!(), name);
+
+    let output = Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        stdout, ":'false'\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout, stderr
+    );
+}
+
+#[test]
+fn with_true_right_returns_true() {
+    let name = "with_true_right_returns_true";
+    let bin_path_buf = compile(file!(), name);
+
+    let output = Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        stdout, ":'true'\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout, stderr
+    );
+}

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_true_left/with_false_right_returns_false/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_true_left/with_false_right_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(true and false).

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_true_left/with_true_right_returns_true/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_true_left/with_true_right_returns_true/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(true and true).

--- a/native_implemented/otp/tests/test.rs
+++ b/native_implemented/otp/tests/test.rs
@@ -1,0 +1,50 @@
+use std::path::{Path, PathBuf};
+pub use std::process::{Command, Stdio};
+
+pub fn compile(file: &str, name: &str) -> PathBuf {
+    // `file!()` starts with path relative to workspace root, but the `current_dir` will be inside
+    // the crate root, so need to strip the relative crate root.
+    let file_path = Path::new(file);
+    let relative_file_path = file_path.strip_prefix("native_implemented/otp").unwrap();
+    let directory_path = relative_file_path.parent().unwrap();
+    let file_stem = file_path.file_stem().unwrap();
+    let test_directory_path = directory_path.join(file_stem).join(name);
+
+    let build_path_buf = test_directory_path.join("_build");
+    std::fs::create_dir_all(&build_path_buf).unwrap();
+
+    let mut command = Command::new("../../bin/lumen");
+
+    let bin_path_buf = test_directory_path.join("bin");
+    dbg!(&bin_path_buf);
+    std::fs::create_dir_all(&bin_path_buf).unwrap();
+
+    let output_path_buf = bin_path_buf.join(name);
+
+    command
+        .arg("compile")
+        .arg("--output-dir")
+        .arg(build_path_buf)
+        .arg("-o")
+        .arg(&output_path_buf)
+        // Turn off optimizations as work-around for debug info bug in EIR
+        .arg("-O0")
+        .arg("-lc");
+
+    let erlang_path = directory_path.join(file_stem).join(name).join("init.erl");
+
+    let compile_output = command
+        .arg(erlang_path)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    assert!(
+        compile_output.status.success(),
+        "stdout = {}\nstderr = {}",
+        String::from_utf8_lossy(&compile_output.stdout),
+        String::from_utf8_lossy(&compile_output.stderr)
+    );
+
+    output_path_buf
+}


### PR DESCRIPTION
# Changelog
## Enhancements
* Move non-badarg raising `erlang/and:2` to integration tests written in Erlang using the actual `lumen` compiler 🎉 .  (`badarg` raising tests are left out because they don't compile yet.)