### PR TITLE
Erlang integration tests for non-badarg erlang:or/2

### DIFF
--- a/native_implemented/otp/src/erlang/or_2/test/with_false_left.rs
+++ b/native_implemented/otp/src/erlang/or_2/test/with_false_left.rs
@@ -12,12 +12,6 @@ fn without_boolean_right_errors_badarg() {
     );
 }
 
-#[test]
-fn with_false_right_returns_false() {
-    assert_eq!(result(false.into(), false.into()), Ok(false.into()));
-}
+// `with_false_right_returns_false` in integration tests
 
-#[test]
-fn with_true_right_returns_true() {
-    assert_eq!(result(false.into(), true.into()), Ok(true.into()));
-}
+// `with_true_right_returns_true` in integration tests

--- a/native_implemented/otp/tests/lib/erlang.rs
+++ b/native_implemented/otp/tests/lib/erlang.rs
@@ -2,3 +2,5 @@ use super::*;
 
 #[path = "erlang/and_2.rs"]
 pub mod and_2;
+#[path = "erlang/or_2.rs"]
+pub mod or_2;

--- a/native_implemented/otp/tests/lib/erlang/or_2.rs
+++ b/native_implemented/otp/tests/lib/erlang/or_2.rs
@@ -1,0 +1,8 @@
+#[path = "and_2/with_false_left.rs"]
+mod with_false_left;
+#[path = "and_2/with_true_left.rs"]
+mod with_true_left;
+
+use super::*;
+
+// `without_boolean_left_errors_badarg` in unit tests

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_false_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_false_left.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+// `without_boolean_right_errors_badarg` in unit tests
+
+#[test]
+fn with_false_right_returns_false() {
+    let name = "with_false_right_returns_false";
+    let bin_path_buf = compile(file!(), name);
+
+    let output = Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        stdout, ":'false'\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout, stderr
+    );
+}
+
+#[test]
+fn with_true_right_returns_true() {
+    let name = "with_true_right_returns_true";
+    let bin_path_buf = compile(file!(), name);
+
+    let output = Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        stdout, ":'true'\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout, stderr
+    );
+}

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_false_left/with_false_right_returns_false/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_false_left/with_false_right_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(false or false).

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_false_left/with_true_right_returns_true/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_false_left/with_true_right_returns_true/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(false or true).

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_true_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_true_left.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+// `without_boolean_right_errors_badarg` in unit tests
+
+#[test]
+fn with_boolean_right_returns_true() {
+    let name = "with_boolean_right_returns_true";
+    let bin_path_buf = compile(file!(), name);
+
+    let output = Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        stdout, ":'true'\n:'true'\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout, stderr
+    );
+}

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_true_left/with_boolean_right_returns_true/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_true_left/with_boolean_right_returns_true/init.erl
@@ -1,0 +1,7 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(true or false),
+  display(true or true).


### PR DESCRIPTION
# Changelog
## Enhancements
* Move non-badarg raising `erlang/or:2` to integration tests written in Erlang using the actual `lumen` compiler 🎉 .  (`badarg` raising tests are left out because they don't compile yet.)