### PR TITLE
andalso/2 erlang tests

### DIFF
--- a/native_implemented/otp/src/erlang/andalso_2/test.rs
+++ b/native_implemented/otp/src/erlang/andalso_2/test.rs
@@ -1,5 +1,3 @@
-use proptest::prop_assert_eq;
-
 use crate::erlang::andalso_2::result;
 use crate::test::strategy;
 
@@ -20,20 +18,6 @@ fn without_boolean_left_errors_badarg() {
     );
 }
 
-#[test]
-fn with_false_left_returns_false() {
-    run!(|arc_process| strategy::term(arc_process.clone()), |right| {
-        prop_assert_eq!(result(false.into(), right), Ok(false.into()));
+// `with_false_left_returns_false` in integration tests
 
-        Ok(())
-    },);
-}
-
-#[test]
-fn with_true_left_returns_right() {
-    run!(|arc_process| strategy::term(arc_process.clone()), |right| {
-        prop_assert_eq!(result(true.into(), right), Ok(right));
-
-        Ok(())
-    },);
-}
+// `with_true_left_returns_right` in integration tests

--- a/native_implemented/otp/tests/lib.rs
+++ b/native_implemented/otp/tests/lib.rs
@@ -1,7 +1,6 @@
+#[macro_use]
 #[path = "./test.rs"]
 mod test;
-
-use test::*;
 
 // Linux currently can't compile `lumen` compiler
 #[cfg(not(target_os = "linux"))]

--- a/native_implemented/otp/tests/lib/erlang.rs
+++ b/native_implemented/otp/tests/lib/erlang.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 #[path = "erlang/and_2.rs"]
 pub mod and_2;
 #[path = "erlang/andalso_2.rs"]

--- a/native_implemented/otp/tests/lib/erlang.rs
+++ b/native_implemented/otp/tests/lib/erlang.rs
@@ -2,5 +2,7 @@ use super::*;
 
 #[path = "erlang/and_2.rs"]
 pub mod and_2;
+#[path = "erlang/andalso_2.rs"]
+pub mod andalso_2;
 #[path = "erlang/or_2.rs"]
 pub mod or_2;

--- a/native_implemented/otp/tests/lib/erlang/and_2.rs
+++ b/native_implemented/otp/tests/lib/erlang/and_2.rs
@@ -3,6 +3,4 @@ mod with_false_left;
 #[path = "and_2/with_true_left.rs"]
 mod with_true_left;
 
-use super::*;
-
 // `without_boolean_left_errors_badarg` in unit tests

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_false_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_false_left.rs
@@ -1,23 +1,3 @@
-use super::*;
-
 // `without_boolean_right_errors_badarg` in unit tests
 
-#[test]
-fn with_boolean_right_returns_false() {
-    let name = "with_boolean_right_returns_false";
-    let bin_path_buf = compile(file!(), name);
-
-    let output = Command::new(bin_path_buf)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        stdout, ":'false'\n:'true'\n",
-        "\nstdout = {}\nstderr = {}",
-        stdout, stderr
-    );
-}
+test_stdout!(with_boolean_right_returns_false, ":'false'\n:'true'\n");

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_true_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_true_left.rs
@@ -1,43 +1,4 @@
-use super::*;
-
 // `without_boolean_right_errors_badarg` in unit tests
 
-#[test]
-fn with_false_right_returns_false() {
-    let name = "with_false_right_returns_false";
-    let bin_path_buf = compile(file!(), name);
-
-    let output = Command::new(bin_path_buf)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        stdout, ":'false'\n",
-        "\nstdout = {}\nstderr = {}",
-        stdout, stderr
-    );
-}
-
-#[test]
-fn with_true_right_returns_true() {
-    let name = "with_true_right_returns_true";
-    let bin_path_buf = compile(file!(), name);
-
-    let output = Command::new(bin_path_buf)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        stdout, ":'true'\n",
-        "\nstdout = {}\nstderr = {}",
-        stdout, stderr
-    );
-}
+test_stdout!(with_false_right_returns_false, ":'false'\n");
+test_stdout!(with_true_right_returns_true, ":'true'\n");

--- a/native_implemented/otp/tests/lib/erlang/andalso_2.rs
+++ b/native_implemented/otp/tests/lib/erlang/andalso_2.rs
@@ -1,43 +1,4 @@
-use super::*;
-
 // `without_boolean_left_errors_badarg` in unit tests
 
-#[test]
-fn with_false_left_returns_false() {
-    let name = "with_false_left_returns_false";
-    let bin_path_buf = compile(file!(), name);
-
-    let output = Command::new(bin_path_buf)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        stdout, ":'false'\n",
-        "\nstdout = {}\nstderr = {}",
-        stdout, stderr
-    );
-}
-
-#[test]
-fn with_true_left_returns_right() {
-    let name = "with_true_left_returns_right";
-    let bin_path_buf = compile(file!(), name);
-
-    let output = Command::new(bin_path_buf)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        stdout, ":'right'\n",
-        "\nstdout = {}\nstderr = {}",
-        stdout, stderr
-    );
-}
+test_stdout!(with_false_left_returns_false, ":'false'\n");
+test_stdout!(with_true_left_returns_right, ":'right'\n");

--- a/native_implemented/otp/tests/lib/erlang/andalso_2.rs
+++ b/native_implemented/otp/tests/lib/erlang/andalso_2.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+// `without_boolean_left_errors_badarg` in unit tests
+
+#[test]
+fn with_false_left_returns_false() {
+    let name = "with_false_left_returns_false";
+    let bin_path_buf = compile(file!(), name);
+
+    let output = Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        stdout, ":'false'\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout, stderr
+    );
+}
+
+#[test]
+fn with_true_left_returns_right() {
+    let name = "with_true_left_returns_right";
+    let bin_path_buf = compile(file!(), name);
+
+    let output = Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        stdout, ":'right'\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout, stderr
+    );
+}

--- a/native_implemented/otp/tests/lib/erlang/andalso_2/with_false_left_returns_false/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/andalso_2/with_false_left_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(false andalso true).

--- a/native_implemented/otp/tests/lib/erlang/andalso_2/with_true_left_returns_right/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/andalso_2/with_true_left_returns_right/init.erl
@@ -1,0 +1,9 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(true andalso right()).
+
+right() ->
+  right.

--- a/native_implemented/otp/tests/lib/erlang/or_2.rs
+++ b/native_implemented/otp/tests/lib/erlang/or_2.rs
@@ -3,6 +3,4 @@ mod with_false_left;
 #[path = "and_2/with_true_left.rs"]
 mod with_true_left;
 
-use super::*;
-
 // `without_boolean_left_errors_badarg` in unit tests

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_false_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_false_left.rs
@@ -1,43 +1,4 @@
-use super::*;
-
 // `without_boolean_right_errors_badarg` in unit tests
 
-#[test]
-fn with_false_right_returns_false() {
-    let name = "with_false_right_returns_false";
-    let bin_path_buf = compile(file!(), name);
-
-    let output = Command::new(bin_path_buf)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        stdout, ":'false'\n",
-        "\nstdout = {}\nstderr = {}",
-        stdout, stderr
-    );
-}
-
-#[test]
-fn with_true_right_returns_true() {
-    let name = "with_true_right_returns_true";
-    let bin_path_buf = compile(file!(), name);
-
-    let output = Command::new(bin_path_buf)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        stdout, ":'true'\n",
-        "\nstdout = {}\nstderr = {}",
-        stdout, stderr
-    );
-}
+test_stdout!(with_false_right_returns_false, ":'false'\n");
+test_stdout!(with_true_right_returns_true, ":'true'\n");

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_true_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_true_left.rs
@@ -1,23 +1,3 @@
-use super::*;
-
 // `without_boolean_right_errors_badarg` in unit tests
 
-#[test]
-fn with_boolean_right_returns_true() {
-    let name = "with_boolean_right_returns_true";
-    let bin_path_buf = compile(file!(), name);
-
-    let output = Command::new(bin_path_buf)
-        .stdin(Stdio::null())
-        .output()
-        .unwrap();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert_eq!(
-        stdout, ":'true'\n:'true'\n",
-        "\nstdout = {}\nstderr = {}",
-        stdout, stderr
-    );
-}
+test_stdout!(with_boolean_right_returns_true, ":'true'\n:'true'\n");

--- a/native_implemented/otp/tests/test.rs
+++ b/native_implemented/otp/tests/test.rs
@@ -16,7 +16,6 @@ pub fn compile(file: &str, name: &str) -> PathBuf {
     let mut command = Command::new("../../bin/lumen");
 
     let bin_path_buf = test_directory_path.join("bin");
-    dbg!(&bin_path_buf);
     std::fs::create_dir_all(&bin_path_buf).unwrap();
 
     let output_path_buf = bin_path_buf.join(name);

--- a/native_implemented/otp/tests/test.rs
+++ b/native_implemented/otp/tests/test.rs
@@ -1,7 +1,26 @@
 use std::path::{Path, PathBuf};
-pub use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
 
-pub fn compile(file: &str, name: &str) -> PathBuf {
+#[allow(unused_macros)]
+macro_rules! test_stdout {
+    ($func_name:ident, $expected_stdout:literal) => {
+        #[test]
+        fn $func_name() {
+            let output = $crate::test::output(file!(), stringify!($func_name));
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            assert_eq!(
+                stdout, $expected_stdout,
+                "\nstdout = {}\nstderr = {}",
+                stdout, stderr
+            );
+        }
+    };
+}
+
+fn compile(file: &str, name: &str) -> PathBuf {
     // `file!()` starts with path relative to workspace root, but the `current_dir` will be inside
     // the crate root, so need to strip the relative crate root.
     let file_path = Path::new(file);
@@ -46,4 +65,13 @@ pub fn compile(file: &str, name: &str) -> PathBuf {
     );
 
     output_path_buf
+}
+
+pub fn output(file: &str, name: &str) -> Output {
+    let bin_path_buf = compile(file, name);
+
+    Command::new(bin_path_buf)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap()
 }


### PR DESCRIPTION
# Changelog
## Enhancements
* Erlang integration tests for non-badarg `erlang:andalso/2`.
* `test_stdout!` macro to remove duplication from Erlang tests.

## Bug Fixes
* Remove `dbg!` from tests