### PR TITLE
Display 1 small integer

### DIFF
--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/Conversion/EIRToLLVM/ConstantOpConversions.cpp
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/Conversion/EIRToLLVM/ConstantOpConversions.cpp
@@ -186,11 +186,11 @@ struct ConstantIntOpConversion : public EIROpConversion<ConstantIntOp> {
       ConversionPatternRewriter &rewriter) const override {
     auto ctx = getRewriteContext(op, rewriter);
 
-    auto attr = op.getValue().cast<IntegerAttr>();
+    auto fixnumAttr = op.getValue().cast<FixnumAttr>();
+    auto value = (uint64_t)fixnumAttr.getValue().getLimitedValue();
     auto termTy = ctx.getUsizeType();
-    auto i = (uint64_t)attr.getValue().getLimitedValue();
-    auto taggedInt = ctx.targetInfo.encodeImmediate(TypeKind::Fixnum, i);
-    auto val = llvm_constant(termTy, ctx.getIntegerAttr(taggedInt));
+    auto taggedFixnum = ctx.targetInfo.encodeImmediate(TypeKind::Fixnum, value);
+    auto val = llvm_constant(termTy, ctx.getIntegerAttr(taggedFixnum));
 
     rewriter.replaceOp(op, {val});
     return success();

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRAttributes.cpp
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRAttributes.cpp
@@ -154,6 +154,54 @@ bool BinaryAttr::isPrintable() const {
 }
 
 //===----------------------------------------------------------------------===//
+// FixnumAttr
+//===----------------------------------------------------------------------===//
+
+/// An attribute representing a binary literal value.
+namespace lumen {
+namespace eir {
+namespace detail {
+struct FixnumAttributeStorage : public AttributeStorage {
+  using KeyTy = std::tuple<Type, APInt>;
+
+  FixnumAttributeStorage(Type type, APInt value)
+      : AttributeStorage(type), value(std::move(value)) {}
+
+  /// Key equality function.
+  bool operator==(const KeyTy &key) const {
+    auto keyType = std::get<Type>(key);
+    auto keyValue = std::get<APInt>(key);
+    return keyType == getType() && keyValue == value;
+  }
+
+  static unsigned hashKey(const KeyTy &key) {
+    return hash_combine(hash_value(std::get<Type>(key)),
+                        hash_value(std::get<APInt>(key)));
+  }
+
+  /// Construct a new storage instance.
+  static FixnumAttributeStorage *construct(AttributeStorageAllocator &allocator,
+                                           const KeyTy &key) {
+    auto type = std::get<Type>(key);
+    auto value = new (allocator.allocate<APInt>()) APInt(std::get<APInt>(key));
+    return new (allocator.allocate<AtomAttributeStorage>())
+        FixnumAttributeStorage(type, *value);
+  }
+
+  APInt value;
+};  // struct FixnumAttr
+}  // namespace detail
+}  // namespace eir
+}  // namespace lumen
+
+FixnumAttr FixnumAttr::get(MLIRContext *context, APInt value) {
+  unsigned kind = static_cast<unsigned>(AttributeKind::Fixnum);
+  return Base::get(context, kind, FixnumType::get(context), value);
+}
+
+APInt &FixnumAttr::getValue() const { return getImpl()->value; }
+
+//===----------------------------------------------------------------------===//
 // SeqAttr
 //===----------------------------------------------------------------------===//
 

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRAttributes.h
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRAttributes.h
@@ -26,6 +26,7 @@ namespace eir {
 namespace detail {
 struct AtomAttributeStorage;
 struct BinaryAttributeStorage;
+struct FixnumAttributeStorage;
 struct SeqAttributeStorage;
 }  // namespace detail
 
@@ -33,6 +34,7 @@ namespace AttributeKind {
 enum Kind {
   Atom = Attribute::FIRST_EIR_ATTR,
   Binary,
+  Fixnum,
   Seq,
 };
 }  // namespace AttributeKind
@@ -80,6 +82,24 @@ class BinaryAttr : public Attribute::AttrBase<BinaryAttr, Attribute,
   /// Methods for support type inquiry through isa, cast, and dyn_cast.
   static bool kindof(unsigned kind) {
     return kind == static_cast<unsigned>(AttributeKind::Binary);
+  }
+};
+
+class FixnumAttr : public Attribute::AttrBase<FixnumAttr, Attribute,
+                                              detail::FixnumAttributeStorage> {
+ public:
+  using Base::Base;
+  using ValueType = APInt;
+
+  static FixnumAttr get(MLIRContext *context, APInt value);
+
+  static StringRef getAttrName() { return "fixnum"; }
+
+  APInt &getValue() const;
+
+  /// Methods for support type inquiry through isa, cast, and dyn_cast.
+  static bool kindof(unsigned kind) {
+    return kind == static_cast<unsigned>(AttributeKind::Fixnum);
   }
 };
 

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRBase.td
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRBase.td
@@ -66,6 +66,12 @@ class BaseAtomAttr : Attr<CPred<"$_self.isa<AtomAttr>()">,
   let returnType = [{ APInt }];
 }
 
+class BaseFixnumAttr : Attr<CPred<"$_self.isa<FixnumAttr>()">,
+                                  "fixnum attribute"> {
+  let storageType = [{ FixnumAttr }];
+  let returnType = [{ APInt }];
+}
+
 class BaseBinaryAttr : Attr<CPred<"$_self.isa<BinaryAttr>()">,
                                   "binary attribute"> {
   let storageType = [{ BinaryAttr }];
@@ -80,6 +86,7 @@ class BaseSeqAttr : Attr<CPred<"$_self.isa<SeqAttr>()">,
 
 def eir_AtomAttr : BaseAtomAttr;
 def eir_BinaryAttr : BaseBinaryAttr;
+def eir_FixnumAttr : BaseFixnumAttr;
 def eir_SeqAttr : BaseSeqAttr;
 def eir_GlobalRefAttr : AliasedSymbolRefAttr;
 def eir_FuncRefAttr   : AliasedSymbolRefAttr;

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRDialect.cpp
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRDialect.cpp
@@ -31,7 +31,7 @@ EirDialect::EirDialect(mlir::MLIRContext *ctx)
            TupleType, MapType, ClosureType, BinaryType, HeapBinType,
            ProcBinType, BoxType, RefType, PtrType>();
 
-  addAttributes<AtomAttr, BinaryAttr, SeqAttr>();
+  addAttributes<AtomAttr, BinaryAttr, FixnumAttr, SeqAttr>();
 }
 
 void EirDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIROps.td
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIROps.td
@@ -1482,7 +1482,7 @@ def eir_ConstantFloatOp : eir_ConstantOp<eir_FloatLike, "constant.float"> {
   ];
 }
 
-def eir_ConstantIntOp : eir_ConstantOp<eir_FixnumLike, "constant.int"> {
+def eir_ConstantIntOp : eir_ConstantOp<eir_FixnumType, "constant.int"> {
   let builders = [
     OpBuilder<
     "Builder *builder, OperationState &result, Type type, Attribute val",
@@ -1493,10 +1493,10 @@ def eir_ConstantIntOp : eir_ConstantOp<eir_FixnumLike, "constant.int"> {
     OpBuilder<
     "Builder *builder, OperationState &result, int64_t value",
     [{
-      auto type = builder->getIntegerType(64);
       auto n = static_cast<uint64_t>(value);
       APInt ap(64, n, /*isSigned=*/true);
-      auto attr = builder->getIntegerAttr(type, ap);
+      auto type = builder->getType<FixnumType>();
+      auto attr = FixnumAttr::get(builder->getContext(), ap);
       build(builder, result, type, attr);
     }]>
   ];

--- a/compiler/codegen/lib/lumen/compiler/Translation/ModuleBuilder.cpp
+++ b/compiler/codegen/lib/lumen/compiler/Translation/ModuleBuilder.cpp
@@ -1591,8 +1591,10 @@ extern "C" MLIRValueRef MLIRBuildConstantInt(MLIRModuleBuilderRef b,
 }
 
 Value ModuleBuilder::build_constant_int(Location loc, int64_t value) {
+  edsc::ScopedContext scope(builder, loc);
   auto op = builder.create<ConstantIntOp>(loc, value);
-  return op.getResult();
+  auto termTy = builder.getType<TermType>();
+  return eir_cast(op.getResult(), termTy);
 }
 
 extern "C" MLIRAttributeRef MLIRBuildIntAttr(MLIRModuleBuilderRef b,

--- a/native_implemented/otp/tests/lib/erlang.rs
+++ b/native_implemented/otp/tests/lib/erlang.rs
@@ -2,5 +2,7 @@
 pub mod and_2;
 #[path = "erlang/andalso_2.rs"]
 pub mod andalso_2;
+#[path = "erlang/display_1.rs"]
+pub mod display_1;
 #[path = "erlang/or_2.rs"]
 pub mod or_2;

--- a/native_implemented/otp/tests/lib/erlang/display_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/display_1.rs
@@ -1,3 +1,4 @@
 // `without_number_errors_badarg` in unit tests
 
+test_stdout!(with_atom, ":'atom'\n");
 test_stdout!(with_small_integer, "1\n0\n-1\n");

--- a/native_implemented/otp/tests/lib/erlang/display_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/display_1.rs
@@ -1,0 +1,3 @@
+// `without_number_errors_badarg` in unit tests
+
+test_stdout!(with_small_integer, "1\n0\n-1\n");

--- a/native_implemented/otp/tests/lib/erlang/display_1/with_atom/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/display_1/with_atom/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(atom).

--- a/native_implemented/otp/tests/lib/erlang/display_1/with_small_integer/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/display_1/with_small_integer/init.erl
@@ -1,0 +1,8 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(1),
+  display(0),
+  display(-1).


### PR DESCRIPTION
Fixes #431

# Changelog
## Enhancements
* Test to ensure that constant (small) integers can be generated and used in an `eir.call` by the compiler.
* Test `display/1`
  * atom
  * small integer

## Bug Fixes
* Fix `eir.constant.int` having result type `i64` and not passible to `eir_term` operands for `eir_call`.
  Have custom storage to hold APInt while having external type of fixnum and then always cast that to eir_term.  This is based on the handling of eir_atom.
