### PR TITLE
x86_64-unknown-linux-gnu compiler workflow

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -5,13 +5,13 @@ RUN cd /tmp \
   && tar -xvzf clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz \
   && rm -f clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz \
   && mv clang+llvm-10.0.0-x86_64-linux-gnu /opt/llvm \
-  && ln -s clang /opt/llvm/bin/cc \
-  && ln -s lld /opt/llvm/bin/ld
+  && update-alternatives --install /usr/bin/cc cc /opt/llvm/bin/clang 90 \
+  && update-alternatives --install /usr/bin/c++ c++ /opt/llvm/bin/clang++ 90 \
+  && update-alternatives --install /usr/bin/cpp cpp /opt/llvm/bin/clang++ 90 \
+  && update-alternatives --install /usr/bin/ld ld /opt/llvm/bin/lld 90
 
 ENV PATH="/opt/llvm/bin:${PATH}"
 ENV LLVM_PREFIX="/opt/llvm"
-ENV CC=/opt/llvm/bin/clang
-ENV CXX=/opt/llvm/bin/clang++
 
 RUN apt-get update \
   && apt-get install -y cmake jq libc++-dev libc++abi-dev libunwind-dev ninja-build rsync

--- a/.github/workflows/wasm32-unknown-unknown-linux.yml
+++ b/.github/workflows/wasm32-unknown-unknown-linux.yml
@@ -6,7 +6,7 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     container:
-      image: kronicdeth/lumen-development@sha256:adee04bab3a607633d8550235b261a6412524be8f8ad0b0189d97ff9e2100ccd
+      image: kronicdeth/lumen-development@sha256:8625315ed528ac92ebbd31023a333755a9325d51f042f02f393877d0356e20ff
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/wasm32-unknown-unknown-linux.yml
+++ b/.github/workflows/wasm32-unknown-unknown-linux.yml
@@ -6,7 +6,7 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     container:
-      image: kronicdeth/lumen-development@sha256:8625315ed528ac92ebbd31023a333755a9325d51f042f02f393877d0356e20ff
+      image: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
@@ -1,0 +1,32 @@
+name: x86_64-unknown-linux-gnu compiler
+
+on: push
+
+jobs:
+  compiler:
+    runs-on: ubuntu-latest
+    container: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-formatted-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-formatted-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-formatted-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Make Build
+        env:
+          RUST_BACKTRACE: full
+        run: make build
+      - name: Lumen Test
+        run: cargo test --package lumen

--- a/.github/workflows/x86_64-unknown-linux-gnu-libraries.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-libraries.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   formatted:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:8625315ed528ac92ebbd31023a333755a9325d51f042f02f393877d0356e20ff
+    container: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
 
   libraries:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:8625315ed528ac92ebbd31023a333755a9325d51f042f02f393877d0356e20ff
+    container: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-libraries.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-libraries.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   formatted:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:adee04bab3a607633d8550235b261a6412524be8f8ad0b0189d97ff9e2100ccd
+    container: kronicdeth/lumen-development@sha256:8625315ed528ac92ebbd31023a333755a9325d51f042f02f393877d0356e20ff
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
 
   libraries:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:adee04bab3a607633d8550235b261a6412524be8f8ad0b0189d97ff9e2100ccd
+    container: kronicdeth/lumen-development@sha256:8625315ed528ac92ebbd31023a333755a9325d51f042f02f393877d0356e20ff
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   runtime:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:8625315ed528ac92ebbd31023a333755a9325d51f042f02f393877d0356e20ff
+    container: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   runtime:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:adee04bab3a607633d8550235b261a6412524be8f8ad0b0189d97ff9e2100ccd
+    container: kronicdeth/lumen-development@sha256:8625315ed528ac92ebbd31023a333755a9325d51f042f02f393877d0356e20ff
 
     steps:
       - uses: actions/checkout@v2

--- a/compiler/llvm/build.rs
+++ b/compiler/llvm/build.rs
@@ -239,7 +239,6 @@ fn main() {
     println!("cargo:ldflags={}", shared_ldflags.as_slice().join(";"));
 
     let llvm_static_stdcpp = env::var_os("LLVM_STATIC_STDCPP");
-    let llvm_use_libcxx = env::var_os("LLVM_USE_LIBCXX");
 
     let stdcppname = if target.contains("openbsd") {
         if target.contains("sparc64") {
@@ -254,8 +253,6 @@ fn main() {
     } else if target.contains("netbsd") && llvm_static_stdcpp.is_some() {
         // NetBSD uses a separate library when relocation is required
         "stdc++_pic"
-    } else if llvm_use_libcxx.is_some() {
-        "c++"
     } else {
         "stdc++"
     };


### PR DESCRIPTION
Fixes #447
Fixes #446

# Changelog
## Bug Fixes
* Restore `x86_64-unknown-linux-gnu` `compiler` workflow
  * Set our LLVM as compiler and linker using `update-alternatives`
  * Don't check `LLVM_USE_LIBCXX` as it was causing `c++` to be used instead of the correct `stdc++`.