### PR TITLE
Fix constant float encoding and decoding on x86_64

### DIFF
--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/Conversion/EIRToLLVM/ConstantOpConversions.cpp
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/Conversion/EIRToLLVM/ConstantOpConversions.cpp
@@ -129,9 +129,7 @@ struct ConstantFloatOpConversion : public EIROpConversion<ConstantFloatOp> {
 
     // On nanboxed targets, floats are treated normally
     if (!ctx.targetInfo.requiresPackedFloats()) {
-      // although floats have no additional tag bits in nanboxing, they need to be stored as integer to act as a
-      // lowered Term
-      Value term = llvm_constant(termTy, ctx.getIntegerAttr(rawVal.bitcastToAPInt().getLimitedValue()));
+      Value term = llvm_constant(termTy, ctx.getIntegerAttr(rawVal.bitcastToAPInt().getLimitedValue() + 2251799813685247));
       rewriter.replaceOp(op, term);
       return success();
     }

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/Conversion/EIRToLLVM/ConstantOpConversions.cpp
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/Conversion/EIRToLLVM/ConstantOpConversions.cpp
@@ -127,7 +127,7 @@ struct ConstantFloatOpConversion : public EIROpConversion<ConstantFloatOp> {
     auto rawVal = attr.getValue();
     auto floatTy = ctx.targetInfo.getFloatType();
     auto val = llvm_constant(floatTy,
-                             rewriter.getF64FloatAttr(attr.getValueAsDouble()));
+                             rewriter.getF64FloatAttr(attr.getValue().convertToDouble()));
 
     // On nanboxed targets, floats are treated normally
     if (!ctx.targetInfo.requiresPackedFloats()) {
@@ -623,7 +623,7 @@ static Value lowerElementValue(RewritePatternContext<Op> &ctx,
       return llvm_constant(termTy, ctx.getIntegerAttr(f.getLimitedValue()));
     }
     // Packed float
-    return eir_cast(eir_constant_float(floatAttr.getValue()), eirTermType);
+    return eir_cast(eir_constant_float(floatAttr.getValue().convertToDouble()), eirTermType);
   }
   // Binaries
   if (auto binAttr = elementAttr.dyn_cast_or_null<BinaryAttr>()) {

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRAttributes.h
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRAttributes.h
@@ -1,10 +1,12 @@
 #ifndef EIR_ATTRIBUTES_H
 #define EIR_ATTRIBUTES_H
 
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "mlir/IR/Attributes.h"
 
 namespace llvm {
+class APFloat;
 class APInt;
 }
 
@@ -13,6 +15,7 @@ class MLIRContext;
 class Type;
 }  // namespace mlir
 
+using ::llvm::APFloat;
 using ::llvm::APInt;
 using ::llvm::ArrayRef;
 using ::llvm::StringRef;
@@ -26,6 +29,7 @@ namespace eir {
 namespace detail {
 struct AtomAttributeStorage;
 struct FixnumAttributeStorage;
+struct FloatAttributeStorage;
 struct BinaryAttributeStorage;
 struct SeqAttributeStorage;
 }  // namespace detail
@@ -34,6 +38,7 @@ namespace AttributeKind {
 enum Kind {
   Atom = Attribute::FIRST_EIR_ATTR,
   Fixnum,
+  Float,
   Binary,
   Seq,
 };
@@ -59,7 +64,7 @@ class AtomAttr : public Attribute::AttrBase<AtomAttr, Attribute,
 };
 
 class FixnumAttr : public Attribute::AttrBase<FixnumAttr, Attribute,
-                                            detail::FixnumAttributeStorage> {
+                                              detail::FixnumAttributeStorage> {
  public:
   using Base::Base;
   using ValueType = APInt;
@@ -73,6 +78,24 @@ class FixnumAttr : public Attribute::AttrBase<FixnumAttr, Attribute,
   /// Methods for support type inquiry through isa, cast, and dyn_cast.
   static bool kindof(unsigned kind) {
     return kind == static_cast<unsigned>(AttributeKind::Fixnum);
+  }
+};
+
+class FloatAttr : public Attribute::AttrBase<FloatAttr, Attribute,
+                                             detail::FloatAttributeStorage> {
+ public:
+  using Base::Base;
+  using ValueType = APFloat;
+
+  static FloatAttr get(MLIRContext *context, APFloat value);
+
+  static StringRef getAttrName() { return "float"; }
+
+  APFloat &getValue() const;
+
+  /// Methods for support type inquiry through isa, cast, and dyn_cast.
+  static bool kindof(unsigned kind) {
+    return kind == static_cast<unsigned>(AttributeKind::Float);
   }
 };
 

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRBase.td
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRBase.td
@@ -72,6 +72,12 @@ class BaseFixnumAttr : Attr<CPred<"$_self.isa<FixnumAttr>()">,
   let returnType = [{ APInt }];
 }
 
+class BaseFloatAttr : Attr<CPred<"$_self.isa<FloatAttr>()">,
+                                 "float attribute"> {
+  let storageType = [{ FloatAttr }];
+  let returnType = [{ APFloat }];
+}
+
 class BaseBinaryAttr : Attr<CPred<"$_self.isa<BinaryAttr>()">,
                                   "binary attribute"> {
   let storageType = [{ BinaryAttr }];
@@ -87,6 +93,7 @@ class BaseSeqAttr : Attr<CPred<"$_self.isa<SeqAttr>()">,
 def eir_AtomAttr : BaseAtomAttr;
 def eir_BinaryAttr : BaseBinaryAttr;
 def eir_FixnumAttr : BaseFixnumAttr;
+def eir_FloatAttr : BaseFloatAttr;
 def eir_SeqAttr : BaseSeqAttr;
 def eir_GlobalRefAttr : AliasedSymbolRefAttr;
 def eir_FuncRefAttr   : AliasedSymbolRefAttr;

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRDialect.cpp
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRDialect.cpp
@@ -31,7 +31,7 @@ EirDialect::EirDialect(mlir::MLIRContext *ctx)
            TupleType, MapType, ClosureType, BinaryType, HeapBinType,
            ProcBinType, BoxType, RefType, PtrType>();
 
-  addAttributes<AtomAttr, FixnumAttr, BinaryAttr, SeqAttr>();
+  addAttributes<AtomAttr, FixnumAttr, ::lumen::eir::FloatAttr, BinaryAttr, SeqAttr>();
 }
 
 void EirDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
@@ -51,6 +51,11 @@ void EirDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
       auto fixnumAttr = attr.cast<FixnumAttr>();
       os << FixnumAttr::getAttrName() << '<';
       os << "{ value = " << fixnumAttr.getValue() << " }>";
+    } break;
+    case AttributeKind::Float: {
+      auto floatAttr = attr.cast<eir::FloatAttr>();
+      os << eir::FloatAttr::getAttrName() << '<';
+      os << "{ value = " << floatAttr.getValue().convertToDouble() << " }>";
     } break;
     case AttributeKind::Binary: {
       auto binAttr = attr.cast<BinaryAttr>();

--- a/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIROps.td
+++ b/compiler/codegen/lib/lumen/compiler/Dialect/EIR/IR/EIROps.td
@@ -1464,7 +1464,7 @@ class eir_ConstantOp<Type type, string mnemonic> : eir_Op<mnemonic, [ConstantLik
   let hasFolder = 1;
 }
 
-def eir_ConstantFloatOp : eir_ConstantOp<eir_FloatLike, "constant.float"> {
+def eir_ConstantFloatOp : eir_ConstantOp<eir_FloatType, "constant.float"> {
   let builders = [
     OpBuilder<
     "Builder *builder, OperationState &result, Type type, Attribute val",
@@ -1473,10 +1473,11 @@ def eir_ConstantFloatOp : eir_ConstantOp<eir_FloatLike, "constant.float"> {
       result.addTypes(type);
     }]>,
     OpBuilder<
-    "Builder *builder, OperationState &result, APFloat &value",
+    "Builder *builder, OperationState &result, double value",
     [{
       auto type = builder->getType<eir::FloatType>();
-      auto attr = builder->getFloatAttr(type, value);
+      APFloat ap(value);
+      auto attr = eir::FloatAttr::get(builder->getContext(), ap);
       build(builder, result, type, attr);
     }]>
   ];

--- a/compiler/codegen/lib/lumen/compiler/Translation/ModuleBuilder.h
+++ b/compiler/codegen/lib/lumen/compiler/Translation/ModuleBuilder.h
@@ -118,7 +118,7 @@ class ModuleBuilder {
   // Constants
   //===----------------------------------------------------------------------===//
 
-  Attribute build_float_attr(Type type, double value);
+  Attribute build_float_attr(double value);
   Value build_constant_float(Location loc, double value);
   Value build_constant_int(Location loc, int64_t value);
   Attribute build_int_attr(int64_t value, bool isSigned = true);

--- a/liblumen_alloc/src/erts/term/arch/arch_x86_64.rs
+++ b/liblumen_alloc/src/erts/term/arch/arch_x86_64.rs
@@ -315,7 +315,7 @@ impl Encoded for RawTerm {
             Tag::List => Ok(TypedTerm::List(unsafe { self.decode_list() })),
             Tag::SmallInteger => Ok(TypedTerm::SmallInteger(self.decode_smallint())),
             // When compiling for non-x86_64, we use boxed floats, so
-            // we accomodate that by boxing the float.
+            // we accommodate that by boxing the float.
             #[cfg(all(target_pointer_width = "64", target_arch = "x86_64"))]
             Tag::Float => Ok(TypedTerm::Float(self.decode_float())),
             #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]

--- a/native_implemented/otp/tests/lib/erlang/display_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/display_1.rs
@@ -2,3 +2,4 @@
 
 test_stdout!(with_atom, ":'atom'\n");
 test_stdout!(with_small_integer, "1\n0\n-1\n");
+test_stdout!(with_float, "1.2\n0.3\n-4.5\n");

--- a/native_implemented/otp/tests/lib/erlang/display_1/with_float/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/display_1/with_float/init.erl
@@ -1,0 +1,8 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  display(1.2),
+  display(0.3),
+  display(-4.5).

--- a/native_implemented/otp/tests/test.rs
+++ b/native_implemented/otp/tests/test.rs
@@ -47,7 +47,8 @@ fn compile(file: &str, name: &str) -> PathBuf {
         .arg(&output_path_buf)
         // Turn off optimizations as work-around for debug info bug in EIR
         .arg("-O0")
-        .arg("-lc");
+        .arg("-lc")
+        .arg("--emit=all");
 
     let erlang_path = directory_path.join(file_stem).join(name).join("init.erl");
 


### PR DESCRIPTION
Fixes #440

# Changelog
## Enhancements
* Test for `display(float())`.

## Bug Fixes
* Fix constant float encoding and decoding on x86_64 to work with nanboxing in `liblumen_alloc`.
* Fix typo in comments.