### PR TITLE
Update Linux docker sha

### DIFF
--- a/.github/workflows/wasm32-unknown-unknown-linux.yml
+++ b/.github/workflows/wasm32-unknown-unknown-linux.yml
@@ -6,7 +6,7 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     container:
-      image: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
+      image: kronicdeth/lumen-development@sha256:50910ed07e49eaeb7b3bcea8a79a9e4c05a6607be1e7091c3eb8955132707e0c
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   compiler:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
+    container: kronicdeth/lumen-development@sha256:50910ed07e49eaeb7b3bcea8a79a9e4c05a6607be1e7091c3eb8955132707e0c
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-libraries.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-libraries.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   formatted:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
+    container: kronicdeth/lumen-development@sha256:50910ed07e49eaeb7b3bcea8a79a9e4c05a6607be1e7091c3eb8955132707e0c
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
 
   libraries:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
+    container: kronicdeth/lumen-development@sha256:50910ed07e49eaeb7b3bcea8a79a9e4c05a6607be1e7091c3eb8955132707e0c
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   runtime:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:985b21718f2d290db7efb585046161ccf5116d046e90cae922985a02e3a3d8bf
+    container: kronicdeth/lumen-development@sha256:50910ed07e49eaeb7b3bcea8a79a9e4c05a6607be1e7091c3eb8955132707e0c
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Update Linux docker sha to use image with LLVM Lumen 12.0.0-dev (2020-08-04).