### PR TITLE
Pass `NonNull` to closure functions in tests

### DIFF
--- a/.github/workflows/wasm32-unknown-unknown-macOS.yml
+++ b/.github/workflows/wasm32-unknown-unknown-macOS.yml
@@ -23,9 +23,9 @@ jobs:
         run: |
           mkdir -p ~/.local/share/llvm
           pushd ~/.local/share/llvm
-          wget https://github.com/lumen/llvm-project/releases/download/lumen-10.0.0-dev_2020-04-26/clang+llvm-10.0.0-x86_64-apple-darwin19.3.0.tar.gz
-          tar xvfz clang+llvm-10.0.0-x86_64-apple-darwin19.3.0.tar.gz
-          mv clang+llvm-10.0.0-x86_64-apple-darwin19.3.0 lumen
+          wget https://github.com/lumen/llvm-project/releases/download/lumen-12.0.0-dev_2020-08-04/clang+llvm-10.0.0-x86_64-apple-darwin19.5.0.tar.gz
+          tar xvfz clang+llvm-10.0.0-x86_64-apple-darwin19.5.0.tar.gz
+          mv clang+llvm-10.0.0-x86_64-apple-darwin19.5.0 lumen
           popd
           echo "::set-env name=LLVM_PREFIX::$HOME/.local/share/llvm/lumen"
       - name: Cache cargo registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,12 +3096,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "2.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
- "failure",
  "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -38,7 +38,7 @@ libeir_util_datastructures = { git = "https://github.com/eirproject/eir.git", br
 # llvm crates
 [build-dependencies]
 cmake = "0.1"
-which = "2.0.1"
+which = "4.0"
 walkdir = "2.3"
 liblumen_term = { path = "../term" }
 liblumen_llvm = { path = "../llvm" }

--- a/compiler/driver/Cargo.toml
+++ b/compiler/driver/Cargo.toml
@@ -39,4 +39,4 @@ libeir_passes = { git = "https://github.com/eirproject/eir", branch = "lumen" }
 libeir_syntax_erl = { git = "https://github.com/eirproject/eir.git", branch = "lumen" }
 
 [build-dependencies]
-which = "2.0"
+which = "4.0"

--- a/compiler/llvm/Cargo.toml
+++ b/compiler/llvm/Cargo.toml
@@ -21,5 +21,5 @@ liblumen_profiling = { path = "../profiling" }
 
 [build-dependencies]
 cc = "1.0"
-which = "2.0.1"
+which = "4.0"
 walkdir = "2.3"

--- a/compiler/term/Cargo.toml
+++ b/compiler/term/Cargo.toml
@@ -16,4 +16,4 @@ crate-type = ["rlib", "staticlib"]
 
 
 [build-dependencies]
-which = "2.0.1"
+which = "4.0"

--- a/examples/spawn-chain/src/elixir/chain/console_output_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/console_output_1.rs
@@ -6,8 +6,6 @@
 
 mod label_1;
 
-use std::ffi::c_void;
-
 use liblumen_alloc::erts::exception::Alloc;
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::prelude::*;
@@ -15,12 +13,7 @@ use liblumen_alloc::erts::term::prelude::*;
 use liblumen_otp::erlang;
 
 pub fn closure(process: &Process) -> Result<Term, Alloc> {
-    process.export_closure(
-        function(),
-        super::module(),
-        ARITY,
-        Some(native as *const c_void),
-    )
+    process.export_closure(function(), super::module(), ARITY, CLOSURE_NATIVE)
 }
 
 #[native_implemented::function(Elixir.Chain:console_output/1)]

--- a/examples/spawn-chain/src/elixir/chain/create_processes_reducer_3.rs
+++ b/examples/spawn-chain/src/elixir/chain/create_processes_reducer_3.rs
@@ -9,8 +9,6 @@
 //! end
 //! ```
 
-use std::ffi::c_void;
-
 use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::exception::Alloc;
 use liblumen_alloc::erts::process::Process;
@@ -25,7 +23,7 @@ pub fn closure(process: &Process, output: Term) -> std::result::Result<Term, All
         Default::default(),
         Default::default(),
         2,
-        Some(native as *const c_void),
+        CLOSURE_NATIVE,
         process.pid().into(),
         &[output],
     )

--- a/examples/spawn-chain/src/elixir/chain/dom_output_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/dom_output_1.rs
@@ -35,19 +35,12 @@ mod label_7;
 mod label_8;
 mod label_9;
 
-use std::ffi::c_void;
-
 use liblumen_alloc::erts::exception::Alloc;
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::prelude::*;
 
 pub fn closure(process: &Process) -> Result<Term, Alloc> {
-    process.export_closure(
-        super::module(),
-        function(),
-        ARITY,
-        Some(native as *const c_void),
-    )
+    process.export_closure(super::module(), function(), ARITY, CLOSURE_NATIVE)
 }
 
 // Private

--- a/examples/spawn-chain/src/elixir/chain/none_output_1.rs
+++ b/examples/spawn-chain/src/elixir/chain/none_output_1.rs
@@ -2,20 +2,13 @@
 //!   :ok
 //! end
 
-use std::ffi::c_void;
-
 use liblumen_alloc::atom;
 use liblumen_alloc::erts::exception::Alloc;
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::prelude::*;
 
 pub fn closure(process: &Process) -> Result<Term, Alloc> {
-    process.export_closure(
-        super::module(),
-        function(),
-        ARITY,
-        Some(native as *const c_void),
-    )
+    process.export_closure(super::module(), function(), ARITY, CLOSURE_NATIVE)
 }
 
 // Private

--- a/liblumen_alloc/src/erts/process.rs
+++ b/liblumen_alloc/src/erts/process.rs
@@ -600,7 +600,7 @@ impl Process {
         old_unique: OldUnique,
         unique: Unique,
         arity: Arity,
-        native: Option<*const c_void>,
+        native: Option<NonNull<c_void>>,
         creator: Creator,
         slice: &[Term],
     ) -> AllocResult<Term> {
@@ -616,7 +616,7 @@ impl Process {
         module: Atom,
         function: Atom,
         arity: u8,
-        native: Option<*const c_void>,
+        native: Option<NonNull<c_void>>,
     ) -> AllocResult<Term> {
         self.acquire_heap()
             .export_closure(module, function, arity, native)

--- a/liblumen_alloc/src/erts/process/alloc/term_alloc.rs
+++ b/liblumen_alloc/src/erts/process/alloc/term_alloc.rs
@@ -539,11 +539,10 @@ pub trait TermAlloc: Heap {
         old_unique: OldUnique,
         unique: Unique,
         arity: Arity,
-        native: Option<*const c_void>,
+        native: Option<NonNull<c_void>>,
         creator: Creator,
         slice: &[Term],
     ) -> AllocResult<Boxed<Closure>> {
-        let native = native.and_then(|ptr| NonNull::new(ptr as *mut c_void));
         Closure::from_slice(
             self, module, index, old_unique, unique, arity, native, creator, slice,
         )
@@ -564,11 +563,10 @@ pub trait TermAlloc: Heap {
         old_unique: OldUnique,
         unique: Unique,
         arity: Arity,
-        native: Option<*const c_void>,
+        native: Option<NonNull<c_void>>,
         creator: Creator,
         slices: &[&[Term]],
     ) -> AllocResult<Boxed<Closure>> {
-        let native = native.and_then(|ptr| NonNull::new(ptr as *mut c_void));
         let len = slices.iter().map(|slice| slice.len()).sum();
         let mut closure_box = Closure::new_anonymous(
             self, module, index, old_unique, unique, arity, native, creator, len,
@@ -596,9 +594,8 @@ pub trait TermAlloc: Heap {
         module: Atom,
         function: Atom,
         arity: u8,
-        native: Option<*const c_void>,
+        native: Option<NonNull<c_void>>,
     ) -> AllocResult<Boxed<Closure>> {
-        let native = native.and_then(|ptr| NonNull::new(ptr as *mut c_void));
         Closure::new_export(self, module, function, arity, native)
     }
 }

--- a/liblumen_alloc/src/erts/process/gc/tests/collector.rs
+++ b/liblumen_alloc/src/erts/process/gc/tests/collector.rs
@@ -1,8 +1,8 @@
 use core::alloc::Layout;
 use core::convert::TryInto;
-use core::ffi::c_void;
 use core::mem;
 use core::ops::Deref;
+use core::ptr::NonNull;
 
 use crate::erts::process::alloc::TermAlloc;
 use crate::erts::process::test::process;
@@ -115,7 +115,7 @@ fn simple_gc_test(process: Process) {
             old_unique,
             unique,
             2,
-            Some(native as *const c_void),
+            NonNull::new(native as _),
             Creator::Local(creator),
             &[&[closure_num, closure_string_term]],
         )

--- a/liblumen_alloc/src/erts/term/arch/arch_x86_64.rs
+++ b/liblumen_alloc/src/erts/term/arch/arch_x86_64.rs
@@ -472,7 +472,7 @@ impl core::hash::Hash for RawTerm {
 #[cfg(all(test, target_pointer_width = "64", target_arch = "x86_64"))]
 mod tests {
     use core::convert::TryInto;
-    use core::ffi::c_void;
+    use core::ptr::NonNull;
 
     use crate::borrow::CloneToProcess;
     use crate::erts::process::alloc::TermAlloc;
@@ -791,7 +791,7 @@ mod tests {
                 old_unique,
                 unique,
                 arity,
-                Some(native as *const c_void),
+                NonNull::new(native as _),
                 Creator::Local(creator),
                 &[&[one, two]],
             )

--- a/liblumen_alloc/src/erts/term/tuple.rs
+++ b/liblumen_alloc/src/erts/term/tuple.rs
@@ -336,7 +336,7 @@ mod tests {
     use super::*;
 
     use alloc::sync::Arc;
-    use core::ffi::c_void;
+    use core::ptr::NonNull;
 
     use crate::erts::testing::RegionHeap;
     use crate::erts::{scheduler, Node};
@@ -544,7 +544,7 @@ mod tests {
             Term::NONE
         }
 
-        heap.export_closure(module, function, arity, Some(native as *const c_void))
+        heap.export_closure(module, function, arity, NonNull::new(native as _))
             .unwrap()
             .into()
     }

--- a/native_implemented/macro/src/lib.rs
+++ b/native_implemented/macro/src/lib.rs
@@ -55,6 +55,7 @@ pub fn function(
         Ok(signatures) => {
             let const_arity = signatures.const_arity();
             let const_native = signatures.const_native();
+            let const_closure_native = signatures.const_closure_native();
             let frame = frame_for_entry_point();
             let frame_for_native = frame_for_native();
             let function = module_function_arity.function();
@@ -66,6 +67,7 @@ pub fn function(
             let all_tokens = quote! {
                 #const_arity
                 #const_native
+                #const_closure_native
 
                 #frame
                 #frame_for_native
@@ -647,6 +649,12 @@ impl Signatures {
 
         quote! {
              pub const NATIVE: liblumen_alloc::erts::process::Native = #native_variant;
+        }
+    }
+
+    fn const_closure_native(&self) -> proc_macro2::TokenStream {
+        quote! {
+             pub const CLOSURE_NATIVE: Option<std::ptr::NonNull<std::ffi::c_void>> = Some(unsafe { std::ptr::NonNull::new_unchecked(native as *mut std::ffi::c_void) });
         }
     }
 

--- a/native_implemented/otp/src/erlang/are_equal_after_conversion_2/test.rs
+++ b/native_implemented/otp/src/erlang/are_equal_after_conversion_2/test.rs
@@ -14,6 +14,7 @@ mod with_subbinary_left;
 mod with_tuple_left;
 
 use std::convert::TryInto;
+use std::ptr::NonNull;
 
 use proptest::arbitrary::any;
 use proptest::prop_assert_eq;

--- a/native_implemented/otp/src/erlang/are_equal_after_conversion_2/test/with_function_left.rs
+++ b/native_implemented/otp/src/erlang/are_equal_after_conversion_2/test/with_function_left.rs
@@ -48,10 +48,10 @@ fn with_same_value_native_right_returns_true() {
                     };
 
                     let left_term = arc_process
-                        .export_closure(module, function, arity, Some(native as _))
+                        .export_closure(module, function, arity, NonNull::new(native as _))
                         .unwrap();
                     let right_term = arc_process
-                        .export_closure(module, function, arity, Some(native as _))
+                        .export_closure(module, function, arity, NonNull::new(native as _))
                         .unwrap();
 
                     (left_term, right_term)
@@ -80,14 +80,14 @@ fn with_different_native_right_returns_false() {
                         Term::NONE
                     };
                     let left_term = arc_process
-                        .export_closure(module, function, arity, Some(left_native as _))
+                        .export_closure(module, function, arity, NonNull::new(left_native as _))
                         .unwrap();
 
                     extern "C" fn right_native() -> Term {
                         Term::NONE
                     };
                     let right_term = arc_process
-                        .export_closure(module, function, arity, Some(right_native as _))
+                        .export_closure(module, function, arity, NonNull::new(right_native as _))
                         .unwrap();
 
                     (left_term, right_term)

--- a/native_implemented/otp/src/erlang/are_exactly_equal_2/test.rs
+++ b/native_implemented/otp/src/erlang/are_exactly_equal_2/test.rs
@@ -14,6 +14,7 @@ mod with_subbinary_left;
 mod with_tuple_left;
 
 use std::convert::TryInto;
+use std::ptr::NonNull;
 
 use proptest::arbitrary::any;
 use proptest::prop_assert_eq;

--- a/native_implemented/otp/src/erlang/are_exactly_equal_2/test/with_function_left.rs
+++ b/native_implemented/otp/src/erlang/are_exactly_equal_2/test/with_function_left.rs
@@ -47,10 +47,10 @@ fn with_same_value_function_right_returns_true() {
                     }
 
                     let left_term = arc_process
-                        .export_closure(module, function, arity, Some(native as _))
+                        .export_closure(module, function, arity, NonNull::new(native as _))
                         .unwrap();
                     let right_term = arc_process
-                        .export_closure(module, function, arity, Some(native as _))
+                        .export_closure(module, function, arity, NonNull::new(native as _))
                         .unwrap();
 
                     (left_term, right_term)
@@ -78,14 +78,14 @@ fn with_different_function_right_returns_false() {
                         Term::NONE
                     }
                     let left_term = arc_process
-                        .export_closure(module, function, arity, Some(left_native as _))
+                        .export_closure(module, function, arity, NonNull::new(left_native as _))
                         .unwrap();
 
                     extern "C" fn right_native() -> Term {
                         Term::NONE
                     }
                     let right_term = arc_process
-                        .export_closure(module, function, arity, Some(right_native as _))
+                        .export_closure(module, function, arity, NonNull::new(right_native as _))
                         .unwrap();
 
                     (left_term, right_term)

--- a/native_implemented/otp/src/erlang/are_exactly_not_equal_2/test.rs
+++ b/native_implemented/otp/src/erlang/are_exactly_not_equal_2/test.rs
@@ -14,6 +14,7 @@ mod with_subbinary_left;
 mod with_tuple_left;
 
 use std::convert::TryInto;
+use std::ptr::NonNull;
 
 use proptest::arbitrary::any;
 use proptest::prop_assert_eq;

--- a/native_implemented/otp/src/erlang/are_exactly_not_equal_2/test/with_function_left.rs
+++ b/native_implemented/otp/src/erlang/are_exactly_not_equal_2/test/with_function_left.rs
@@ -47,10 +47,10 @@ fn with_same_value_function_right_returns_false() {
                     };
 
                     let left_term = arc_process
-                        .export_closure(module, function, arity, Some(native as _))
+                        .export_closure(module, function, arity, NonNull::new(native as _))
                         .unwrap();
                     let right_term = arc_process
-                        .export_closure(module, function, arity, Some(native as _))
+                        .export_closure(module, function, arity, NonNull::new(native as _))
                         .unwrap();
 
                     (left_term, right_term)
@@ -78,14 +78,14 @@ fn with_different_function_right_returns_true() {
                         Term::NONE
                     };
                     let left_term = arc_process
-                        .export_closure(module, function, arity, Some(left_native as _))
+                        .export_closure(module, function, arity, NonNull::new(left_native as _))
                         .unwrap();
 
                     extern "C" fn right_native() -> Term {
                         Term::NONE
                     };
                     let right_term = arc_process
-                        .export_closure(module, function, arity, Some(right_native as _))
+                        .export_closure(module, function, arity, NonNull::new(right_native as _))
                         .unwrap();
 
                     (left_term, right_term)

--- a/native_implemented/otp/src/erlang/are_not_equal_after_conversion_2/test.rs
+++ b/native_implemented/otp/src/erlang/are_not_equal_after_conversion_2/test.rs
@@ -14,6 +14,7 @@ mod with_subbinary_left;
 mod with_tuple_left;
 
 use std::convert::TryInto;
+use std::ptr::NonNull;
 
 use proptest::arbitrary::any;
 use proptest::prop_assert_eq;

--- a/native_implemented/otp/src/erlang/are_not_equal_after_conversion_2/test/with_function_left.rs
+++ b/native_implemented/otp/src/erlang/are_not_equal_after_conversion_2/test/with_function_left.rs
@@ -47,10 +47,10 @@ fn with_same_value_function_right_returns_false() {
                     };
 
                     let left_term = arc_process
-                        .export_closure(module, function, arity, Some(native as _))
+                        .export_closure(module, function, arity, NonNull::new(native as _))
                         .unwrap();
                     let right_term = arc_process
-                        .export_closure(module, function, arity, Some(native as _))
+                        .export_closure(module, function, arity, NonNull::new(native as _))
                         .unwrap();
 
                     (left_term, right_term)
@@ -78,14 +78,14 @@ fn with_different_function_right_returns_true() {
                         Term::NONE
                     };
                     let left_term = arc_process
-                        .export_closure(module, function, arity, Some(left_native as _))
+                        .export_closure(module, function, arity, NonNull::new(left_native as _))
                         .unwrap();
 
                     extern "C" fn right_native() -> Term {
                         Term::NONE
                     };
                     let right_term = arc_process
-                        .export_closure(module, function, arity, Some(right_native as _))
+                        .export_closure(module, function, arity, NonNull::new(right_native as _))
                         .unwrap();
 
                     (left_term, right_term)

--- a/native_implemented/otp/src/erlang/spawn_1/test.rs
+++ b/native_implemented/otp/src/erlang/spawn_1/test.rs
@@ -1,6 +1,7 @@
 mod with_function;
 
 use std::convert::TryInto;
+use std::ptr::NonNull;
 
 use proptest::prop_assert_eq;
 use proptest::strategy::Just;

--- a/native_implemented/otp/src/erlang/spawn_1/test/with_function/with_arity_zero.rs
+++ b/native_implemented/otp/src/erlang/spawn_1/test/with_function/with_arity_zero.rs
@@ -84,7 +84,7 @@ fn with_environment_runs_function_in_child_process() {
                                 old_unique,
                                 unique,
                                 arity,
-                                Some(native as _),
+                                NonNull::new(native as _),
                                 creator,
                                 &[Atom::str_to_term("first"), Atom::str_to_term("second")],
                             )

--- a/native_implemented/otp/src/erlang/spawn_link_1/test.rs
+++ b/native_implemented/otp/src/erlang/spawn_link_1/test.rs
@@ -1,6 +1,7 @@
 mod with_function;
 
 use std::convert::TryInto;
+use std::ptr::NonNull;
 
 use anyhow::*;
 

--- a/native_implemented/otp/src/erlang/spawn_link_1/test/with_function/with_arity_zero/with_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_link_1/test/with_function/with_arity_zero/with_environment.rs
@@ -41,7 +41,7 @@ fn without_expected_exit_in_child_process_exits_linked_parent_process() {
                                 old_unique,
                                 unique,
                                 arity,
-                                Some(native as _),
+                                NonNull::new(native as _),
                                 creator,
                                 &[Atom::str_to_term("first"), Atom::str_to_term("second")],
                             )
@@ -159,7 +159,7 @@ fn with_expected_exit_in_child_process_does_not_exit_linked_parent_process() {
                                 old_unique,
                                 unique,
                                 arity,
-                                Some(native as _),
+                                NonNull::new(native as _),
                                 creator,
                                 &[
                                     Atom::str_to_term("shutdown"),

--- a/native_implemented/otp/src/erlang/spawn_link_1/test/with_function/with_arity_zero/without_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_link_1/test/with_function/with_arity_zero/without_environment.rs
@@ -26,7 +26,7 @@ fn without_expected_exit_in_child_process_exits_linked_parent_process() {
                     (
                         arc_process.clone(),
                         arc_process
-                            .export_closure(module, function, arity, Some(native as _))
+                            .export_closure(module, function, arity, NonNull::new(native as _))
                             .unwrap(),
                     )
                 }),
@@ -110,7 +110,7 @@ fn with_expected_exit_in_child_process_does_not_exit_linked_parent_process() {
                     (
                         arc_process.clone(),
                         arc_process
-                            .export_closure(module, function, arity, Some(native as _))
+                            .export_closure(module, function, arity, NonNull::new(native as _))
                             .unwrap(),
                     )
                 }),

--- a/native_implemented/otp/src/erlang/spawn_monitor_1/test.rs
+++ b/native_implemented/otp/src/erlang/spawn_monitor_1/test.rs
@@ -1,6 +1,7 @@
 mod with_function;
 
 use std::convert::TryInto;
+use std::ptr::NonNull;
 
 use anyhow::*;
 

--- a/native_implemented/otp/src/erlang/spawn_monitor_1/test/with_function/with_arity_zero/with_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_monitor_1/test/with_function/with_arity_zero/with_environment.rs
@@ -41,7 +41,7 @@ fn without_expected_exit_in_child_process_sends_exit_message_to_parent() {
                                 old_unique,
                                 unique,
                                 arity,
-                                Some(native as _),
+                                NonNull::new(native as _),
                                 creator,
                                 &[Atom::str_to_term("first"), Atom::str_to_term("second")],
                             )
@@ -157,7 +157,7 @@ fn with_expected_exit_in_child_process_send_exit_message_to_parent() {
                                 old_unique,
                                 unique,
                                 arity,
-                                Some(native as _),
+                                NonNull::new(native as _),
                                 creator,
                                 &[
                                     Atom::str_to_term("shutdown"),

--- a/native_implemented/otp/src/erlang/spawn_monitor_1/test/with_function/with_arity_zero/without_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_monitor_1/test/with_function/with_arity_zero/without_environment.rs
@@ -19,7 +19,7 @@ fn without_expected_exit_in_child_process_sends_exit_message_to_parent() {
     }
 
     let function = parent_arc_process
-        .export_closure(module, function, arity, Some(native as _))
+        .export_closure(module, function, arity, NonNull::new(native as _))
         .unwrap();
     let result = result(&parent_arc_process, function);
 
@@ -97,7 +97,7 @@ fn with_expected_exit_in_child_process_sends_exit_message_to_parent() {
     let function = Atom::from_str("function");
     let arity = 0;
     let function = parent_arc_process
-        .export_closure(module, function, arity, Some(native as _))
+        .export_closure(module, function, arity, NonNull::new(native as _))
         .unwrap();
     let result = result(&parent_arc_process, function);
 

--- a/native_implemented/otp/src/erlang/spawn_opt_2/test.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_2/test.rs
@@ -1,6 +1,7 @@
 mod with_function;
 
 use std::convert::TryInto;
+use std::ptr::NonNull;
 
 use anyhow::*;
 

--- a/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_empty_list_options/with_arity_zero.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_empty_list_options/with_arity_zero.rs
@@ -19,7 +19,7 @@ fn without_environment_runs_function_in_child_process() {
     }
 
     let function = arc_process
-        .export_closure(module, function, arity, Some(native as _))
+        .export_closure(module, function, arity, NonNull::new(native as _))
         .unwrap();
     let result = result(&arc_process, function, options(&arc_process));
 
@@ -79,7 +79,7 @@ fn with_environment_runs_function_in_child_process() {
             old_unique,
             unique,
             arity,
-            Some(native as _),
+            NonNull::new(native as _),
             creator,
             &[Atom::str_to_term("first"), Atom::str_to_term("second")],
         )

--- a/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_link_and_monitor_in_options_list/with_arity_zero/with_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_link_and_monitor_in_options_list/with_arity_zero/with_environment.rs
@@ -30,7 +30,7 @@ fn without_expected_exit_in_child_process_sends_exit_message_to_parent() {
             old_unique,
             unique,
             arity,
-            Some(native as _),
+            NonNull::new(native as _),
             creator,
             &[Atom::str_to_term("first"), Atom::str_to_term("second")],
         )
@@ -135,7 +135,7 @@ fn with_expected_exit_in_child_process_send_exit_message_to_parent() {
             old_unique,
             unique,
             arity,
-            Some(native as _),
+            NonNull::new(native as _),
             creator,
             &[
                 Atom::str_to_term("shutdown"),

--- a/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_link_and_monitor_in_options_list/with_arity_zero/without_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_link_and_monitor_in_options_list/with_arity_zero/without_environment.rs
@@ -26,7 +26,7 @@ fn without_expected_exit_in_child_process_sends_exit_message_to_parent_and_paren
                     (
                         arc_process.clone(),
                         arc_process
-                            .export_closure(module, function, arity, Some(native as _))
+                            .export_closure(module, function, arity, NonNull::new(native as _))
                             .unwrap(),
                     )
                 }),
@@ -145,7 +145,7 @@ fn with_expected_exit_in_child_process_sends_exit_message_to_parent() {
                     (
                         arc_process.clone(),
                         arc_process
-                            .export_closure(module, function, arity, Some(native as _))
+                            .export_closure(module, function, arity, NonNull::new(native as _))
                             .unwrap(),
                     )
                 }),

--- a/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_link_in_options_list/with_arity_zero/with_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_link_in_options_list/with_arity_zero/with_environment.rs
@@ -29,7 +29,7 @@ fn without_expected_exit_in_child_process_exits_linked_parent_process() {
             old_unique,
             unique,
             arity,
-            Some(native as _),
+            NonNull::new(native as _),
             creator,
             &[Atom::str_to_term("first"), Atom::str_to_term("second")],
         )
@@ -114,7 +114,7 @@ fn with_expected_exit_in_child_process_does_not_exit_linked_parent_process() {
             old_unique,
             unique,
             arity,
-            Some(native as _),
+            NonNull::new(native as _),
             creator,
             &[
                 Atom::str_to_term("shutdown"),

--- a/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_link_in_options_list/with_arity_zero/without_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_link_in_options_list/with_arity_zero/without_environment.rs
@@ -26,7 +26,7 @@ fn without_expected_exit_in_child_process_exits_linked_parent_process() {
                     (
                         arc_process.clone(),
                         arc_process
-                            .export_closure(module, function, arity, Some(native as _))
+                            .export_closure(module, function, arity, NonNull::new(native as _))
                             .unwrap(),
                     )
                 }),
@@ -110,7 +110,7 @@ fn with_expected_exit_in_child_process_does_not_exit_linked_parent_process() {
                     (
                         arc_process.clone(),
                         arc_process
-                            .export_closure(module, function, arity, Some(native as _))
+                            .export_closure(module, function, arity, NonNull::new(native as _))
                             .unwrap(),
                     )
                 }),

--- a/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_monitor_in_options_list/with_arity_zero/with_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_monitor_in_options_list/with_arity_zero/with_environment.rs
@@ -41,7 +41,7 @@ fn without_expected_exit_in_child_process_sends_exit_message_to_parent() {
                                 old_unique,
                                 unique,
                                 arity,
-                                Some(native as _),
+                                NonNull::new(native as _),
                                 creator,
                                 &[Atom::str_to_term("first"), Atom::str_to_term("second")],
                             )
@@ -149,7 +149,7 @@ fn with_expected_exit_in_child_process_send_exit_message_to_parent() {
             old_unique,
             unique,
             arity,
-            Some(native as _),
+            NonNull::new(native as _),
             creator,
             &[
                 Atom::str_to_term("shutdown"),

--- a/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_monitor_in_options_list/with_arity_zero/without_environment.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_2/test/with_function/with_monitor_in_options_list/with_arity_zero/without_environment.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::ptr::NonNull;
 
 #[test]
 fn without_expected_exit_in_child_process_sends_exit_message_to_parent() {
@@ -26,7 +27,7 @@ fn without_expected_exit_in_child_process_sends_exit_message_to_parent() {
                     (
                         arc_process.clone(),
                         arc_process
-                            .export_closure(module, function, arity, Some(native as _))
+                            .export_closure(module, function, arity, NonNull::new(native as _))
                             .unwrap(),
                     )
                 }),
@@ -128,7 +129,7 @@ fn with_expected_exit_in_child_process_sends_exit_message_to_parent() {
                     (
                         arc_process.clone(),
                         arc_process
-                            .export_closure(module, function, arity, Some(native as _))
+                            .export_closure(module, function, arity, NonNull::new(native as _))
                             .unwrap(),
                     )
                 }),

--- a/native_implemented/otp/src/test/anonymous_0.rs
+++ b/native_implemented/otp/src/test/anonymous_0.rs
@@ -1,5 +1,3 @@
-use std::ffi::c_void;
-
 use liblumen_alloc::erts::exception::AllocResult;
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::closure::*;
@@ -12,7 +10,7 @@ pub fn anonymous_closure(process: &Process) -> AllocResult<Term> {
         OLD_UNIQUE,
         UNIQUE,
         ARITY,
-        Some(native as *const c_void),
+        CLOSURE_NATIVE,
         process.pid().into(),
         &[],
     )

--- a/native_implemented/otp/src/test/anonymous_1.rs
+++ b/native_implemented/otp/src/test/anonymous_1.rs
@@ -1,5 +1,3 @@
-use std::ffi::c_void;
-
 use liblumen_alloc::erts::exception::AllocResult;
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::closure::*;
@@ -12,7 +10,7 @@ pub fn anonymous_closure(process: &Process) -> AllocResult<Term> {
         OLD_UNIQUE,
         UNIQUE,
         ARITY,
-        Some(native as *const c_void),
+        CLOSURE_NATIVE,
         process.pid().into(),
         &[],
     )

--- a/native_implemented/otp/src/test/return_from_fn_0.rs
+++ b/native_implemented/otp/src/test/return_from_fn_0.rs
@@ -1,16 +1,9 @@
-use std::ffi::c_void;
-
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::prelude::*;
 
 pub fn export_closure(process: &Process) -> Term {
     process
-        .export_closure(
-            super::module(),
-            function(),
-            ARITY,
-            Some(native as *const c_void),
-        )
+        .export_closure(super::module(), function(), ARITY, CLOSURE_NATIVE)
         .unwrap()
 }
 

--- a/native_implemented/otp/src/test/return_from_fn_1.rs
+++ b/native_implemented/otp/src/test/return_from_fn_1.rs
@@ -1,16 +1,9 @@
-use std::ffi::c_void;
-
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::prelude::*;
 
 pub fn export_closure(process: &Process) -> Term {
     process
-        .export_closure(
-            super::module(),
-            function(),
-            ARITY,
-            Some(native as *const c_void),
-        )
+        .export_closure(super::module(), function(), ARITY, CLOSURE_NATIVE)
         .unwrap()
 }
 

--- a/native_implemented/otp/src/test/strategy/term.rs
+++ b/native_implemented/otp/src/test/strategy/term.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 use std::ffi::c_void;
 use std::num::FpCategory;
 use std::ops::RangeInclusive;
+use std::ptr::NonNull;
 use std::sync::Arc;
 
 use proptest::arbitrary::any;
@@ -181,7 +182,7 @@ pub fn export_closure(process: &Process, module: Atom, function: Atom, arity: u8
     };
 
     process
-        .export_closure(module, function, arity, Some(native as _))
+        .export_closure(module, function, arity, NonNull::new(native as _))
         .unwrap()
 }
 

--- a/native_implemented/otp/src/test/strategy/term/function/export.rs
+++ b/native_implemented/otp/src/test/strategy/term/function/export.rs
@@ -26,7 +26,7 @@ pub fn with_arity(arc_process: Arc<Process>, arity: u8) -> BoxedStrategy<Term> {
                         erlang::module(),
                         erlang::self_0::function(),
                         erlang::self_0::ARITY,
-                        Some(erlang::self_0::native as _)
+                        erlang::self_0::CLOSURE_NATIVE
                     )
                     .unwrap()
             ),
@@ -40,7 +40,7 @@ pub fn with_arity(arc_process: Arc<Process>, arity: u8) -> BoxedStrategy<Term> {
                         erlang::module(),
                         erlang::number_or_badarith_1::function(),
                         erlang::number_or_badarith_1::ARITY,
-                        Some(erlang::number_or_badarith_1::native as _)
+                        erlang::number_or_badarith_1::CLOSURE_NATIVE
                     )
                     .unwrap()
             ),
@@ -74,7 +74,7 @@ pub fn with_native(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
                         module,
                         erlang::self_0::function(),
                         erlang::self_0::ARITY,
-                        Some(erlang::self_0::native as _),
+                        erlang::self_0::CLOSURE_NATIVE,
                     )
                     .unwrap(),
                 1 => arc_process
@@ -82,7 +82,7 @@ pub fn with_native(arc_process: Arc<Process>) -> BoxedStrategy<Term> {
                         module,
                         erlang::number_or_badarith_1::function(),
                         erlang::number_or_badarith_1::ARITY,
-                        Some(erlang::number_or_badarith_1::native as _),
+                        erlang::number_or_badarith_1::CLOSURE_NATIVE,
                     )
                     .unwrap(),
                 _ => unreachable!("arity {}", arity),

--- a/runtimes/core/src/distribution/external_term_format/export.rs
+++ b/runtimes/core/src/distribution/external_term_format/export.rs
@@ -1,5 +1,6 @@
 use std::ffi::c_void;
 use std::mem;
+use std::ptr::NonNull;
 
 use liblumen_alloc::erts::exception::InternalResult;
 use liblumen_alloc::erts::term::prelude::*;
@@ -24,8 +25,10 @@ pub fn decode<'a>(
         arity,
     };
 
-    let option_native = find_symbol(&module_function_arity)
-        .map(|dynamic_callee| unsafe { mem::transmute::<_, *const c_void>(dynamic_callee) });
+    let option_native = find_symbol(&module_function_arity).map(|dynamic_callee| unsafe {
+        let ptr = mem::transmute::<_, *mut c_void>(dynamic_callee);
+        NonNull::new_unchecked(ptr)
+    });
 
     let closure = process.export_closure(module, function, arity, option_native)?;
 

--- a/runtimes/core/src/distribution/external_term_format/new_function.rs
+++ b/runtimes/core/src/distribution/external_term_format/new_function.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 use std::ffi::c_void;
 use std::mem;
+use std::ptr::NonNull;
 
 use liblumen_alloc::erts::apply::find_symbol;
 use liblumen_alloc::erts::exception::InternalResult;
@@ -53,8 +54,10 @@ pub fn decode<'a>(
         arity,
     };
 
-    let option_native = find_symbol(&module_function_arity)
-        .map(|dynamic_callee| unsafe { mem::transmute::<_, *const c_void>(dynamic_callee) });
+    let option_native = find_symbol(&module_function_arity).map(|dynamic_callee| unsafe {
+        let ptr = mem::transmute::<_, *mut c_void>(dynamic_callee);
+        NonNull::new_unchecked(ptr)
+    });
 
     let closure = process.anonymous_closure_with_env_from_slice(
         module,


### PR DESCRIPTION
# Changelog
## Enhancements
* Pass `NonNull` to closure functions in tests.
  * Can revert the quick fix of removing `NonNull` as using `Option<NonNull<c_void>` is 8 bytes instead of 16 bytes for `Option<*mut c_void>`.
  * The #[native_implemented::function] macro generates a `CLOSURE_NATIVE` const that is a `Option<NonNull<c_void>>`, so no in-place casting is needed when using an NIF instead of an inline `native` in tests.