### PR TITLE
Exclude examples from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ default-members = [
   "runtimes/full",
 ]
 
+exclude = [
+  "examples"
+]
+
 [profile.release]
 # Experimentally determined to give the smallest size out of all `opt-level`s (0-3,'s','z') and
 # `lto`s (true and false) for `examples/spawn-chain/pkg/spawn_chaing_bg.wasm`


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Exclude `examples` from workspace. Fixes wasm32 builds due to this error:

  ```
  Error: Error during execution of `cargo metadata`: error: current package believes it's in a workspace when it's not:
  current:   /__w/lumen/lumen/examples/spawn-chain/Cargo.toml
  workspace: /__w/lumen/lumen/Cargo.toml
  ```