### PR TITLE
Mimic Erlang's term printer when printing atoms

### DIFF
--- a/native_implemented/otp/src/erlang/spawn_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/src/erlang/spawn_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -96,7 +96,7 @@ fn without_valid_arguments_when_run_exits_and_parent_does_not_exit() {
     );
     assert_exits_badarith(
         &child_arc_process,
-        "number (:'zero') is not an integer or a float",
+        "number (zero) is not an integer or a float",
     );
 
     assert!(!parent_arc_process.is_exiting())

--- a/native_implemented/otp/src/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/src/erlang/spawn_link_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -94,7 +94,7 @@ fn without_valid_arguments_when_run_exits_and_parent_exits() {
     );
     assert_exits_badarith(
         &child_arc_process,
-        "number (:'zero') is not an integer or a float",
+        "number (zero) is not an integer or a float",
     );
 
     assert!(parent_arc_process.is_exiting())

--- a/native_implemented/otp/src/erlang/spawn_monitor_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/src/erlang/spawn_monitor_3/test/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -137,7 +137,7 @@ fn without_valid_arguments_when_run_exits_and_sends_parent_exit_message() {
     );
     assert_exits_badarith(
         &child_arc_process,
-        "number (:'zero') is not an integer or a float",
+        "number (zero) is not an integer or a float",
     );
 
     assert!(!parent_arc_process.is_exiting());

--- a/native_implemented/otp/src/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/w_a.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_4/test/with_empty_list_options/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/w_a.rs
@@ -108,7 +108,7 @@ fn without_valid_arguments_when_run_exits_and_parent_does_not_exit() {
     );
     assert_exits_badarith(
         &child_arc_process,
-        "number (:'zero') is not an integer or a float",
+        "number (zero) is not an integer or a float",
     );
 
     assert!(!parent_arc_process.is_exiting())

--- a/native_implemented/otp/src/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/w_e_f/w_a.rs
+++ b/native_implemented/otp/src/erlang/spawn_opt_4/test/with_link_in_options_list/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/w_e_f/w_a.rs
@@ -106,7 +106,7 @@ fn without_valid_arguments_when_run_exits_and_parent_exits() {
     );
     assert_exits_badarith(
         &child_arc_process,
-        "number (:'zero') is not an integer or a float",
+        "number (zero) is not an integer or a float",
     );
 
     assert!(parent_arc_process.is_exiting())

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_false_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_false_left.rs
@@ -1,3 +1,3 @@
 // `without_boolean_right_errors_badarg` in unit tests
 
-test_stdout!(with_boolean_right_returns_false, ":'false'\n:'true'\n");
+test_stdout!(with_boolean_right_returns_false, "false\ntrue\n");

--- a/native_implemented/otp/tests/lib/erlang/and_2/with_true_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/and_2/with_true_left.rs
@@ -1,4 +1,4 @@
 // `without_boolean_right_errors_badarg` in unit tests
 
-test_stdout!(with_false_right_returns_false, ":'false'\n");
-test_stdout!(with_true_right_returns_true, ":'true'\n");
+test_stdout!(with_false_right_returns_false, "false\n");
+test_stdout!(with_true_right_returns_true, "true\n");

--- a/native_implemented/otp/tests/lib/erlang/andalso_2.rs
+++ b/native_implemented/otp/tests/lib/erlang/andalso_2.rs
@@ -1,4 +1,4 @@
 // `without_boolean_left_errors_badarg` in unit tests
 
-test_stdout!(with_false_left_returns_false, ":'false'\n");
-test_stdout!(with_true_left_returns_right, ":'right'\n");
+test_stdout!(with_false_left_returns_false, "false\n");
+test_stdout!(with_true_left_returns_right, "right\n");

--- a/native_implemented/otp/tests/lib/erlang/display_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/display_1.rs
@@ -1,4 +1,4 @@
 // `without_number_errors_badarg` in unit tests
 
-test_stdout!(with_atom, ":'atom'\n");
+test_stdout!(with_atom, "atom\n");
 test_stdout!(with_small_integer, "1\n0\n-1\n");

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_false_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_false_left.rs
@@ -1,4 +1,4 @@
 // `without_boolean_right_errors_badarg` in unit tests
 
-test_stdout!(with_false_right_returns_false, ":'false'\n");
-test_stdout!(with_true_right_returns_true, ":'true'\n");
+test_stdout!(with_false_right_returns_false, "false\n");
+test_stdout!(with_true_right_returns_true, "true\n");

--- a/native_implemented/otp/tests/lib/erlang/or_2/with_true_left.rs
+++ b/native_implemented/otp/tests/lib/erlang/or_2/with_true_left.rs
@@ -1,3 +1,3 @@
 // `without_boolean_right_errors_badarg` in unit tests
 
-test_stdout!(with_boolean_right_returns_true, ":'true'\n:'true'\n");
+test_stdout!(with_boolean_right_returns_true, "true\ntrue\n");


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Mimic Erlang's term printer when printing atoms. As the Erlang term printer does not quote all lower case atoms, this also means that boolean atoms look right now as they print as `true` and `false` without any boolean special-casing.