### PR TITLE
Remove -1 from display(small_integer()) tests

### DIFF
--- a/native_implemented/otp/tests/lib/erlang/display_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/display_1.rs
@@ -1,4 +1,4 @@
 // `without_number_errors_badarg` in unit tests
 
 test_stdout!(with_atom, "atom\n");
-test_stdout!(with_small_integer, "1\n0\n-1\n");
+test_stdout!(with_small_integer, "1\n0\n");

--- a/native_implemented/otp/tests/lib/erlang/display_1/with_small_integer/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/display_1/with_small_integer/init.erl
@@ -4,5 +4,4 @@
 
 start() ->
   display(1),
-  display(0),
-  display(-1).
+  display(0).


### PR DESCRIPTION
Related to #460.

# Changelog
## Bug Fixes
* Remove `-1` from `display(small_integer())` tests.
  Temporary work-around for #460