### PR TITLE
Turn static LLVM linking back on temporarily on CI

### DIFF
--- a/.github/workflows/x86_64-apple-darwin-compiler.yml
+++ b/.github/workflows/x86_64-apple-darwin-compiler.yml
@@ -44,4 +44,6 @@ jobs:
           RUST_BACKTRACE: full
         run: make build
       - name: Lumen Test
+        env:
+          LLVM_BUILD_STATIC: 1
         run: cargo test --package lumen

--- a/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
@@ -29,4 +29,6 @@ jobs:
           RUST_BACKTRACE: full
         run: make build
       - name: Lumen Test
+        env:
+          LLVM_BUILD_STATIC: 1
         run: cargo test --package lumen


### PR DESCRIPTION
Related to #465

# Changelog
## Bug Fixes
* Turn static LLVM linking back on temporarily on CI.  Work-around `libLLVM-12-lumen-10.0.0` not being available until a new LLVM is pushed.