### PR TITLE
Match Erlang-native binary display

### DIFF
--- a/liblumen_alloc/src/erts/term/binary/aligned_binary.rs
+++ b/liblumen_alloc/src/erts/term/binary/aligned_binary.rs
@@ -215,11 +215,11 @@ impl_aligned_try_into!(BinaryLiteral);
 
 /// Displays a binary using Erlang-style formatting
 pub(super) fn display(bytes: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
-    match str::from_utf8(bytes) {
-        Ok(s) => write!(f, "\"{}\"", s.escape_default().to_string()),
-        Err(_) => {
-            f.write_str("<<")?;
+    f.write_str("<<")?;
 
+    match str::from_utf8(bytes) {
+        Ok(s) => write!(f, "\"{}\"", s.escape_default().to_string())?,
+        Err(_) => {
             let mut iter = bytes.iter();
 
             if let Some(byte) = iter.next() {
@@ -229,10 +229,10 @@ pub(super) fn display(bytes: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
                     write!(f, ", {:#04x}", byte)?;
                 }
             }
-
-            f.write_str(">>")
         }
     }
+
+    f.write_str(">>")
 }
 
 // Has to have explicit types to prevent E0119: conflicting implementations of trait

--- a/lumen/tests/cli.rs
+++ b/lumen/tests/cli.rs
@@ -13,7 +13,7 @@ mod cli {
 
         assert_eq!(
             String::from_utf8_lossy(&cli_output.stdout),
-            "\"Nothing to say.\"\n",
+            "<<\"Nothing to say.\">>\n",
             "\nstdout = {}\nstderr = {}",
             stdout,
             stderr
@@ -34,7 +34,7 @@ mod cli {
         let stderr = String::from_utf8_lossy(&cli_output.stderr);
 
         assert_eq!(
-            stdout, "\"Nothing to say.\"\n",
+            stdout, "<<\"Nothing to say.\">>\n",
             "\nstdout = {}\nstderr = {}",
             stdout, stderr
         );
@@ -54,7 +54,7 @@ mod cli {
         let stderr = String::from_utf8_lossy(&cli_output.stderr);
 
         assert_eq!(
-            stdout, "\"Hello, world!\"\n",
+            stdout, "<<\"Hello, world!\">>\n",
             "\nstdout = {}\nstderr = {}",
             stdout, stderr
         );

--- a/lumen/tests/hello_world.rs
+++ b/lumen/tests/hello_world.rs
@@ -37,7 +37,7 @@ mod hello_world {
         let hello_world_stderr = String::from_utf8_lossy(&hello_world_output.stderr);
 
         assert_eq!(
-            hello_world_stdout, "\"Hello, world!\"\n",
+            hello_world_stdout, "<<\"Hello, world!\">>\n",
             "\nstdout = {}\nstderr = {}",
             hello_world_stdout, hello_world_stderr
         );

--- a/native_implemented/otp/src/erlang/atom_to_binary_2/test.rs
+++ b/native_implemented/otp/src/erlang/atom_to_binary_2/test.rs
@@ -1,8 +1,6 @@
 use std::convert::TryInto;
 
-use proptest::arbitrary::any;
-use proptest::prop_assert_eq;
-use proptest::strategy::{Just, Strategy};
+use proptest::strategy::Just;
 
 use liblumen_alloc::erts::term::prelude::Atom;
 

--- a/native_implemented/otp/src/erlang/binary_to_float_1.rs
+++ b/native_implemented/otp/src/erlang/binary_to_float_1.rs
@@ -12,5 +12,5 @@ use crate::runtime::binary_to_string::binary_to_string;
 pub fn result(process: &Process, binary: Term) -> exception::Result<Term> {
     let string = binary_to_string(binary)?;
 
-    string_to_float(process, "binary", &string, '"').map_err(From::from)
+    string_to_float(process, "binary", binary, &string).map_err(From::from)
 }

--- a/native_implemented/otp/src/erlang/binary_to_integer_1.rs
+++ b/native_implemented/otp/src/erlang/binary_to_integer_1.rs
@@ -12,5 +12,5 @@ use crate::runtime::binary_to_string::binary_to_string;
 pub fn result(process: &Process, binary: Term) -> exception::Result<Term> {
     let string: String = binary_to_string(binary)?;
 
-    decimal_string_to_integer(process, "binary", '"', &string).map_err(From::from)
+    decimal_string_to_integer(process, "binary", binary, &string).map_err(From::from)
 }

--- a/native_implemented/otp/src/erlang/binary_to_integer_2.rs
+++ b/native_implemented/otp/src/erlang/binary_to_integer_2.rs
@@ -12,5 +12,5 @@ use crate::runtime::binary_to_string::binary_to_string;
 pub fn result(process: &Process, binary: Term, base: Term) -> exception::Result<Term> {
     let string: String = binary_to_string(binary)?;
 
-    base_string_to_integer(process, base, "binary", '"', &string).map_err(From::from)
+    base_string_to_integer(process, base, "binary", binary, &string).map_err(From::from)
 }

--- a/native_implemented/otp/src/erlang/list_to_float_1.rs
+++ b/native_implemented/otp/src/erlang/list_to_float_1.rs
@@ -12,5 +12,5 @@ use crate::erlang::string_to_float::string_to_float;
 pub fn result(process: &Process, list: Term) -> exception::Result<Term> {
     let string = charlist_to_string(list)?;
 
-    string_to_float(process, "list", &string, '\'').map_err(From::from)
+    string_to_float(process, "list", list, &string).map_err(From::from)
 }

--- a/native_implemented/otp/src/erlang/list_to_float_1/test.rs
+++ b/native_implemented/otp/src/erlang/list_to_float_1/test.rs
@@ -40,7 +40,7 @@ fn with_list_with_integer_errors_badarg() {
         |(arc_process, string, list)| {
             prop_assert_badarg!(
                 result(&arc_process, list),
-                format!("list ('{}') does not contain decimal point", string)
+                format!("list ({}) does not contain decimal point", list)
             );
 
             Ok(())

--- a/native_implemented/otp/src/erlang/list_to_integer_1.rs
+++ b/native_implemented/otp/src/erlang/list_to_integer_1.rs
@@ -12,5 +12,5 @@ use crate::erlang::string_to_integer::decimal_string_to_integer;
 pub fn result(process: &Process, list: Term) -> exception::Result<Term> {
     let string: String = list_to_string(list)?;
 
-    decimal_string_to_integer(process, "list", '\'', &string).map_err(From::from)
+    decimal_string_to_integer(process, "list", list, &string).map_err(From::from)
 }

--- a/native_implemented/otp/src/erlang/list_to_integer_1/test/with_list.rs
+++ b/native_implemented/otp/src/erlang/list_to_integer_1/test/with_list.rs
@@ -80,7 +80,7 @@ fn with_non_decimal_errors_badarg() {
 
         assert_badarg!(
             result(&arc_process, list),
-            format!("list ('{}') is not base 10", string)
+            format!("list ({}) is not base 10", list)
         );
     });
 }

--- a/native_implemented/otp/src/erlang/list_to_integer_2.rs
+++ b/native_implemented/otp/src/erlang/list_to_integer_2.rs
@@ -12,5 +12,5 @@ use crate::erlang::string_to_integer::base_string_to_integer;
 pub fn result(process: &Process, list: Term, base: Term) -> exception::Result<Term> {
     let string: String = list_to_string(list)?;
 
-    base_string_to_integer(process, base, "list", '\'', &string).map_err(From::from)
+    base_string_to_integer(process, base, "list", list, &string).map_err(From::from)
 }

--- a/native_implemented/otp/src/erlang/list_to_integer_2/test.rs
+++ b/native_implemented/otp/src/erlang/list_to_integer_2/test.rs
@@ -111,7 +111,7 @@ fn with_list_without_integer_in_base_errors_badarg() {
         |(arc_process, string, list, base)| {
             prop_assert_badarg!(
                 result(&arc_process, list, base),
-                format!("list ('{}') is not in base ({})", string, base)
+                format!("list ({}) is not in base ({})", list, base)
             );
 
             Ok(())

--- a/native_implemented/otp/src/erlang/string_to_integer.rs
+++ b/native_implemented/otp/src/erlang/string_to_integer.rs
@@ -14,7 +14,7 @@ pub fn base_string_to_integer(
     process: &Process,
     base: Term,
     name: &'static str,
-    quote: char,
+    term: Term,
     string: &str,
 ) -> InternalResult<Term> {
     let base_base: Base = base.try_into()?;
@@ -22,23 +22,18 @@ pub fn base_string_to_integer(
 
     match BigInt::parse_bytes(bytes, base_base.radix()) {
         Some(big_int) => process.integer(big_int).map_err(|error| error.into()),
-        None => Err(anyhow!(
-            "{} is not in base ({})",
-            context::string(name, quote, string),
-            base
-        )
-        .into()),
+        None => Err(anyhow!("{} is not in base ({})", context::string(name, term), base).into()),
     }
 }
 
 pub fn decimal_string_to_integer(
     process: &Process,
     name: &'static str,
-    quote: char,
-    value: &str,
+    term: Term,
+    string: &str,
 ) -> InternalResult<Term> {
-    match BigInt::parse_bytes(value.as_bytes(), 10) {
+    match BigInt::parse_bytes(string.as_bytes(), 10) {
         Some(big_int) => process.integer(big_int).map_err(|error| error.into()),
-        None => Err(anyhow!("{} is not base 10", context::string(name, quote, value)).into()),
+        None => Err(anyhow!("{} is not base 10", context::string(name, term)).into()),
     }
 }

--- a/native_implemented/otp/tests/lib/erlang/atom_to_binary_2.rs
+++ b/native_implemented/otp/tests/lib/erlang/atom_to_binary_2.rs
@@ -4,5 +4,5 @@
 
 test_stdout!(
     with_atom_with_encoding_atom_returns_name_in_binary,
-    "\"one\"\n\"two\"\n\"three\"\n"
+    "<<\"one\">>\n<<\"two\">>\n<<\"three\">>\n"
 );

--- a/runtimes/core/src/context.rs
+++ b/runtimes/core/src/context.rs
@@ -10,8 +10,8 @@ use liblumen_alloc::erts::term::prelude::*;
 
 use crate::time;
 
-pub fn string(name: &'static str, quote: char, value: &str) -> String {
-    format!("{} ({}{}{})", name, quote, value.escape_default(), quote)
+pub fn string(name: &'static str, term: Term) -> String {
+    format!("{} ({})", name, term)
 }
 
 pub fn term_is_not_type(name: &str, value: Term, r#type: &str) -> String {

--- a/runtimes/minimal/src/builtins.rs
+++ b/runtimes/minimal/src/builtins.rs
@@ -7,13 +7,10 @@ use anyhow::anyhow;
 
 use liblumen_alloc::erts::process::ffi::process_raise;
 use liblumen_alloc::erts::term::prelude::*;
-use liblumen_alloc::erts::Process;
 
 use lumen_rt_core::process::current_process;
 use lumen_rt_core::registry;
 use lumen_rt_core::scheduler::from_id;
-
-use crate::scheduler::Scheduler;
 
 #[export_name = "erlang:!/2"]
 pub extern "C" fn builtin_send(to_term: Term, msg: Term) -> Term {


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Match Erlang-native binary display.
  Erlang always surrounds binaries with `<<` `>>` even if it is quoting a printable string.