### PR TITLE
Erlang integration tests for atom_to_list/1

### DIFF
--- a/native_implemented/otp/src/erlang/atom_to_list_1/test.rs
+++ b/native_implemented/otp/src/erlang/atom_to_list_1/test.rs
@@ -1,9 +1,4 @@
-use proptest::arbitrary::any;
-use proptest::prop_assert_eq;
-use proptest::strategy::{Just, Strategy};
 use proptest::test_runner::{Config, TestRunner};
-
-use liblumen_alloc::erts::term::prelude::{Atom, Term};
 
 use crate::erlang::atom_to_list_1::result;
 use crate::test::strategy;
@@ -22,26 +17,4 @@ fn without_atom_errors_badarg() {
     });
 }
 
-#[test]
-#[ignore]
-fn with_atom_returns_chars_in_list() {
-    run!(
-        |arc_process| {
-            (Just(arc_process.clone()), any::<String>())
-                .prop_map(|(arc_process, string)| (arc_process, Atom::str_to_term(&string), string))
-        },
-        |(arc_process, atom, string)| {
-            let codepoint_terms: Vec<Term> = string
-                .chars()
-                .map(|c| arc_process.integer(c).unwrap())
-                .collect();
-
-            prop_assert_eq!(
-                result(&arc_process, atom),
-                Ok(arc_process.list_from_slice(&codepoint_terms).unwrap())
-            );
-
-            Ok(())
-        },
-    );
-}
+// `with_atom_returns_chars_in_list` in integration tests

--- a/native_implemented/otp/src/erlang/list_to_pid_1/test.rs
+++ b/native_implemented/otp/src/erlang/list_to_pid_1/test.rs
@@ -74,7 +74,7 @@ fn with_list_encoding_local_pid() {
 
         assert_badarg!(
             result(&process, process.charlist_from_str("<0.1.2>?").unwrap()),
-            "extra characters ([63]) beyond end of formatted pid"
+            "extra characters (\"?\") beyond end of formatted pid"
         );
     })
 }
@@ -135,7 +135,7 @@ fn with_list_encoding_external_pid_without_known_node_errors_badarg() {
 
         assert_badarg!(
             result(&process, process.charlist_from_str("<2.3.4>?").unwrap()),
-            "extra characters ([63]) beyond end of formatted pid"
+            "extra characters (\"?\") beyond end of formatted pid"
         );
     });
 }

--- a/native_implemented/otp/tests/lib/erlang.rs
+++ b/native_implemented/otp/tests/lib/erlang.rs
@@ -6,6 +6,8 @@ pub mod and_2;
 pub mod andalso_2;
 #[path = "erlang/atom_to_binary_2.rs"]
 pub mod atom_to_binary_2;
+#[path = "erlang/atom_to_list_1.rs"]
+pub mod atom_to_list_1;
 #[path = "erlang/display_1.rs"]
 pub mod display_1;
 #[path = "erlang/or_2.rs"]

--- a/native_implemented/otp/tests/lib/erlang/atom_to_list_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/atom_to_list_1.rs
@@ -1,0 +1,6 @@
+// `without_atom_errors_badarg` in unit tests
+
+test_stdout!(
+    with_atom_returns_chars_in_list,
+    "\"one\"\n\"two\"\n\"three\"\n"
+);

--- a/native_implemented/otp/tests/lib/erlang/atom_to_list_1/with_atom_returns_chars_in_list/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/atom_to_list_1/with_atom_returns_chars_in_list/init.erl
@@ -1,0 +1,8 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [atom_to_list/1, display/1]).
+
+start() ->
+  display(atom_to_list(one)),
+  display(atom_to_list(two)),
+  display(atom_to_list(three)).


### PR DESCRIPTION
# Changelog
## Enhancements
* Erlang integration tests for `atom_to_list/1`.

## Bug Fixes
* Match Erlang-native list display.
  Erlang strings are lists with printable characters, so if we have such a printable list, print it as a double quoted string as is done with Erlang natively.