### PR TITLE
Integration tests for binary_to_term/1

### DIFF
--- a/liblumen_alloc/src/erts/term/binary/maybe_aligned_maybe_binary.rs
+++ b/liblumen_alloc/src/erts/term/binary/maybe_aligned_maybe_binary.rs
@@ -56,14 +56,18 @@ macro_rules! display {
 
                     if let Some(bit) = partial_byte_bit_iter.next() {
                         if has_full_bytes {
-                            f.write_str(", ")?;
+                            f.write_str(",")?;
                         }
 
-                        write!(f, "{} :: 1", bit)?;
+                        let mut partial_byte = bit;
+                        let mut partial_byte_bit_len = 1;
 
                         for bit in partial_byte_bit_iter {
-                            write!(f, ", {} :: 1", bit)?;
+                            partial_byte_bit_len += 1;
+                            partial_byte = (partial_byte << 1) | bit;
                         }
+
+                        write!(f, "{}:{}", partial_byte, partial_byte_bit_len)?;
                     }
 
                     f.write_str(">>")

--- a/native_implemented/otp/src/erlang/binary_to_term_1/test.rs
+++ b/native_implemented/otp/src/erlang/binary_to_term_1/test.rs
@@ -1,8 +1,4 @@
-use proptest::prop_assert_eq;
 use proptest::strategy::Just;
-
-use liblumen_alloc::erts::process::Process;
-use liblumen_alloc::erts::term::prelude::{Atom, Term};
 
 use crate::erlang::binary_to_term_1::result;
 use crate::test::strategy;
@@ -27,163 +23,15 @@ fn without_binary_errors_badarg() {
     );
 }
 
-#[test]
-fn with_binary_encoding_atom_returns_atom() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary(:atom)
-        vec![131, 100, 0, 4, 97, 116, 111, 109],
-        |_| Atom::str_to_term("atom"),
-    );
-}
-
-#[test]
-fn with_binary_encoding_empty_list_returns_empty_list() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary([])
-        vec![131, 106],
-        |_| Term::NIL,
-    );
-}
-
-#[test]
-fn with_binary_encoding_list_returns_list() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary([:zero, 1])
-        vec![
-            131, 108, 0, 0, 0, 2, 100, 0, 4, 122, 101, 114, 111, 97, 1, 106,
-        ],
-        |process| {
-            process
-                .cons(
-                    Atom::str_to_term("zero"),
-                    process
-                        .cons(process.integer(1).unwrap(), Term::NIL)
-                        .unwrap(),
-                )
-                .unwrap()
-        },
-    );
-}
-
-#[test]
-fn with_binary_encoding_small_integer_returns_small_integer() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary(0)
-        vec![131, 97, 0],
-        |process| process.integer(0).unwrap(),
-    );
-}
-
-#[test]
-fn with_binary_encoding_integer_returns_integer() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary(-2147483648)
-        vec![131, 98, 128, 0, 0, 0],
-        |process| process.integer(-2147483648_isize).unwrap(),
-    );
-}
-
-#[test]
-fn with_binary_encoding_new_float_returns_float() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary(1.0)
-        vec![131, 70, 63, 240, 0, 0, 0, 0, 0, 0],
-        |process| process.float(1.0).unwrap(),
-    );
-}
-
-#[test]
-fn with_binary_encoding_small_tuple_returns_tuple() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary({:zero, 1})
-        vec![131, 104, 2, 100, 0, 4, 122, 101, 114, 111, 97, 1],
-        |process| {
-            process
-                .tuple_from_slice(&[Atom::str_to_term("zero"), process.integer(1).unwrap()])
-                .unwrap()
-        },
-    );
-}
-
-#[test]
-fn with_binary_encoding_byte_list_returns_list() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary([?0, ?1])
-        vec![131, 107, 0, 2, 48, 49],
-        |process| {
-            process
-                .cons(
-                    process.integer(48).unwrap(),
-                    process
-                        .cons(process.integer(49).unwrap(), Term::NIL)
-                        .unwrap(),
-                )
-                .unwrap()
-        },
-    );
-}
-
-#[test]
-fn with_binary_encoding_binary_returns_binary() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary(<<0, 1>>)
-        vec![131, 109, 0, 0, 0, 2, 0, 1],
-        |process| process.binary_from_bytes(&[0, 1]).unwrap(),
-    );
-}
-
-#[test]
-fn with_binary_encoding_small_big_integer_returns_big_integer() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary(4294967295)
-        vec![131, 110, 4, 0, 255, 255, 255, 255],
-        |process| process.integer(4294967295_usize).unwrap(),
-    );
-}
-
-#[test]
-fn with_binary_encoding_bit_string_returns_subbinary() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary(<<1, 2::3>>)
-        vec![131, 77, 0, 0, 0, 2, 3, 1, 64],
-        |process| {
-            process
-                .subbinary_from_original(
-                    process.binary_from_bytes(&[1, 0b010_00000]).unwrap(),
-                    0,
-                    0,
-                    1,
-                    3,
-                )
-                .unwrap()
-        },
-    );
-}
-
-#[test]
-fn with_binary_encoding_small_atom_utf8_returns_atom() {
-    with_binary_returns_term(
-        // :erlang.term_to_binary(:"😈")
-        vec![131, 119, 4, 240, 159, 152, 136],
-        |_| Atom::str_to_term("😈"),
-    );
-}
-
-fn with_binary_returns_term<T>(byte_vec: Vec<u8>, term: T)
-where
-    T: Fn(&Process) -> Term,
-{
-    run!(
-        |arc_process| {
-            (
-                Just(arc_process.clone()),
-                strategy::term::binary::containing_bytes(byte_vec.clone(), arc_process.clone()),
-            )
-        },
-        |(arc_process, binary)| {
-            prop_assert_eq!(result(&arc_process, binary), Ok(term(&arc_process)));
-
-            Ok(())
-        },
-    );
-}
+// `with_binary_encoding_atom_returns_atom` in integration tests
+// `with_binary_encoding_empty_list_returns_empty_list` in integration tests
+// `with_binary_encoding_list_returns_list` in integration tests
+// `with_binary_encoding_small_integer_returns_small_integer` in integration tests
+// `with_binary_encoding_integer_returns_integer` in integration tests
+// `with_binary_encoding_new_float_returns_float` in integration tests
+// `with_binary_encoding_small_tuple_returns_tuple` in integration tests
+// `with_binary_encoding_byte_list_returns_list` in integration tests
+// `with_binary_encoding_binary_returns_binary` in integration tests
+// `with_binary_encoding_small_big_integer_returns_big_integer` in integration tests
+// `with_binary_encoding_bit_string_returns_subbinary` in integration tests
+// `with_binary_encoding_small_atom_utf8_returns_atom` in integration tests

--- a/native_implemented/otp/src/erlang/split_binary_2/test/with_bitstring_binary/with_subbinary/with_non_negative_integer_position.rs
+++ b/native_implemented/otp/src/erlang/split_binary_2/test/with_bitstring_binary/with_subbinary/with_non_negative_integer_position.rs
@@ -42,7 +42,7 @@ fn with_byte_len_with_bit_count_errors_badarg() {
         let binary = bitstring!(1, 2 :: 2, &process);
         let position = process.integer(2).unwrap();
 
-        assert_badarg!(result(process, binary, position), "bitstring (<<1, 1 :: 1, 0 :: 1>>) has 2 bits in its partial bytes, so the index (2) cannot equal the total byte length (2)");
+        assert_badarg!(result(process, binary, position), "bitstring (<<1,2:2>>) has 2 bits in its partial bytes, so the index (2) cannot equal the total byte length (2)");
     });
 }
 
@@ -54,7 +54,7 @@ fn with_greater_than_byte_len_errors_badarg() {
 
         assert_badarg!(
             result(process, binary, position),
-            "index (3) exceeds total byte length (2) of bitstring (<<1, 1 :: 1, 0 :: 1>>)"
+            "index (3) exceeds total byte length (2) of bitstring (<<1,2:2>>)"
         );
     });
 }

--- a/native_implemented/otp/tests/lib/erlang.rs
+++ b/native_implemented/otp/tests/lib/erlang.rs
@@ -20,6 +20,8 @@ pub mod binary_to_integer_2;
 pub mod binary_to_list_1;
 #[path = "erlang/binary_to_list_3.rs"]
 pub mod binary_to_list_3;
+#[path = "erlang/binary_to_term_1.rs"]
+pub mod binary_to_term_1;
 #[path = "erlang/display_1.rs"]
 pub mod display_1;
 #[path = "erlang/or_2.rs"]

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1.rs
@@ -1,0 +1,29 @@
+// `without_binary_errors_badarg` in unit tests
+
+test_stdout!(with_binary_encoding_atom_returns_atom, "atom\n");
+test_stdout!(with_binary_encoding_empty_list_returns_empty_list, "[]\n");
+test_stdout!(with_binary_encoding_list_returns_list, "[zero, 1]\n");
+test_stdout!(
+    with_binary_encoding_small_integer_returns_small_integer,
+    "0\n"
+);
+test_stdout!(
+    with_binary_encoding_integer_returns_integer,
+    "-2147483648\n"
+);
+test_stdout!(with_binary_encoding_new_float_returns_float, "1.0\n");
+test_stdout!(
+    with_binary_encoding_small_tuple_returns_tuple,
+    "{zero, 1}\n"
+);
+test_stdout!(with_binary_encoding_byte_list_returns_list, "\"01\"\n");
+test_stdout!(with_binary_encoding_binary_returns_binary, "<<0,1>>\n");
+test_stdout!(
+    with_binary_encoding_small_big_integer_returns_big_integer,
+    "4294967295\n"
+);
+test_stdout!(
+    with_binary_encoding_bit_string_returns_subbinary,
+    "<<1,2:3>>\n"
+);
+test_stdout!(with_binary_encoding_small_atom_utf8_returns_atom, "'😈'\n");

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_atom_returns_atom/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_atom_returns_atom/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 100, 0, 4, 97, 116, 111, 109>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_binary_returns_binary/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_binary_returns_binary/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 109, 0, 0, 0, 2, 0, 1>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_bit_string_returns_subbinary/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_bit_string_returns_subbinary/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 77, 0, 0, 0, 2, 3, 1, 64>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_byte_list_returns_list/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_byte_list_returns_list/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 107, 0, 2, 48, 49>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_empty_list_returns_empty_list/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_empty_list_returns_empty_list/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 106>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_integer_returns_integer/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_integer_returns_integer/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 98, 128, 0, 0, 0>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_list_returns_list/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_list_returns_list/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 108, 0, 0, 0, 2, 100, 0, 4, 122, 101, 114, 111, 97, 1, 106>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_new_float_returns_float/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_new_float_returns_float/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 70, 63, 240, 0, 0, 0, 0, 0, 0>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_small_atom_utf8_returns_atom/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_small_atom_utf8_returns_atom/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 119, 4, 240, 159, 152, 136>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_small_big_integer_returns_big_integer/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_small_big_integer_returns_big_integer/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 110, 4, 0, 255, 255, 255, 255>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_small_integer_returns_small_integer/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_small_integer_returns_small_integer/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 97, 0>>)).

--- a/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_small_tuple_returns_tuple/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/binary_to_term_1/with_binary_encoding_small_tuple_returns_tuple/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [binary_to_term/1, display/1]).
+
+start() ->
+  display(binary_to_term(<<131, 104, 2, 100, 0, 4, 122, 101, 114, 111, 97, 1>>)).


### PR DESCRIPTION
# Changelog
## Enhancements
* Integration tests for `binary_to_term/1`.

## Bug Fixes
* Match Erlang format of displaying subbinary with partial bytes more closely by printing partial byte with bit length instead of individual bits.
* Match atom escaping to Erlang-native