### PR TITLE
Integration tests for `demonitor/1`

### DIFF
--- a/native_implemented/otp/src/erlang/demonitor_1/test.rs
+++ b/native_implemented/otp/src/erlang/demonitor_1/test.rs
@@ -6,10 +6,8 @@ use liblumen_alloc::erts::term::prelude::*;
 
 use crate::erlang::demonitor_1::result;
 use crate::erlang::monitor_2;
-use crate::runtime::scheduler::{self, SchedulerDependentAlloc};
-use crate::test::{
-    self, exit_when_run, has_message, monitor_count, monitored_count, strategy, with_process_arc,
-};
+use crate::runtime::scheduler;
+use crate::test::{self, exit_when_run, has_message, strategy, with_process_arc};
 
 #[test]
 fn without_reference_errors_badarg() {

--- a/native_implemented/otp/src/erlang/demonitor_1/test/with_reference.rs
+++ b/native_implemented/otp/src/erlang/demonitor_1/test/with_reference.rs
@@ -2,11 +2,4 @@ mod with_monitor;
 
 use super::*;
 
-#[test]
-fn without_monitor_returns_true() {
-    with_process_arc(|monitoring_arc_process| {
-        let reference = monitoring_arc_process.next_reference().unwrap();
-
-        assert_eq!(result(&monitoring_arc_process, reference), Ok(true.into()))
-    });
-}
+// `without_monitor_returns_true` in integration tests

--- a/native_implemented/otp/src/erlang/demonitor_1/test/with_reference/with_monitor.rs
+++ b/native_implemented/otp/src/erlang/demonitor_1/test/with_reference/with_monitor.rs
@@ -1,38 +1,6 @@
 use super::*;
 
-#[test]
-fn returns_true() {
-    with_process_arc(|monitoring_arc_process| {
-        let monitored_arc_process = test::process::child(&monitoring_arc_process);
-
-        let monitor_reference = monitor_2::result(
-            &monitoring_arc_process,
-            r#type(),
-            monitored_arc_process.pid_term(),
-        )
-        .unwrap();
-
-        let monitored_monitor_count_before = monitor_count(&monitored_arc_process);
-        let monitoring_monitored_count_before = monitored_count(&monitoring_arc_process);
-
-        assert_eq!(
-            result(&monitoring_arc_process, monitor_reference),
-            Ok(true.into())
-        );
-
-        let monitored_monitor_count_after = monitor_count(&monitored_arc_process);
-        let monitoring_monitored_count_after = monitored_count(&monitoring_arc_process);
-
-        assert_eq!(
-            monitored_monitor_count_after,
-            monitored_monitor_count_before - 1
-        );
-        assert_eq!(
-            monitoring_monitored_count_after,
-            monitoring_monitored_count_before - 1
-        );
-    });
-}
+// `returns_true` in integration tests
 
 #[test]
 fn does_not_flush_existing_message() {
@@ -74,45 +42,7 @@ fn does_not_flush_existing_message() {
     });
 }
 
-#[test]
-fn prevents_future_messages() {
-    with_process_arc(|monitoring_arc_process| {
-        let monitored_arc_process = test::process::child(&monitoring_arc_process);
-        let monitored_pid_term = monitored_arc_process.pid_term();
-
-        let monitor_reference =
-            monitor_2::result(&monitoring_arc_process, r#type(), monitored_pid_term).unwrap();
-
-        let reason = Atom::str_to_term("normal");
-        let tag = Atom::str_to_term("DOWN");
-
-        assert!(!has_message(
-            &monitoring_arc_process,
-            monitoring_arc_process
-                .tuple_from_slice(&[tag, monitor_reference, r#type(), monitored_pid_term, reason])
-                .unwrap()
-        ));
-
-        assert_eq!(
-            result(&monitoring_arc_process, monitor_reference),
-            Ok(true.into())
-        );
-
-        exit_when_run(&monitored_arc_process, reason);
-
-        assert!(scheduler::run_through(&monitored_arc_process));
-
-        assert!(monitored_arc_process.is_exiting());
-        assert!(!monitoring_arc_process.is_exiting());
-
-        assert!(!has_message(
-            &monitoring_arc_process,
-            monitoring_arc_process
-                .tuple_from_slice(&[tag, monitor_reference, r#type(), monitored_pid_term, reason])
-                .unwrap()
-        ));
-    });
-}
+// `prevents_future_messages` in integration tests
 
 fn r#type() -> Term {
     Atom::str_to_term("process")

--- a/native_implemented/otp/tests/lib/erlang.rs
+++ b/native_implemented/otp/tests/lib/erlang.rs
@@ -32,6 +32,8 @@ pub mod ceil_1;
 pub mod convert_time_unit_3;
 #[path = "erlang/date_0.rs"]
 pub mod date_0;
+#[path = "erlang/demonitor_1.rs"]
+pub mod demonitor_1;
 #[path = "erlang/display_1.rs"]
 pub mod display_1;
 #[path = "erlang/or_2.rs"]

--- a/native_implemented/otp/tests/lib/erlang/demonitor_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/demonitor_1.rs
@@ -1,0 +1,4 @@
+#[path = "demonitor_1/with_reference.rs"]
+pub mod with_reference;
+
+// `without_reference_errors_badarg` in integration tests

--- a/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference.rs
+++ b/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference.rs
@@ -1,0 +1,4 @@
+#[path = "with_reference/with_monitor.rs"]
+pub mod with_monitor;
+
+test_stdout!(without_monitor_returns_true, "true\n");

--- a/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference/with_monitor.rs
+++ b/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference/with_monitor.rs
@@ -1,0 +1,2 @@
+test_stdout!(returns_true, "true\ntrue\ntrue\n");
+test_stdout!(prevents_future_messages, "true\ntrue\n");

--- a/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference/with_monitor/prevents_future_messages/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference/with_monitor/prevents_future_messages/init.erl
@@ -1,0 +1,26 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [demonitor/1, display/1, process_info/2, spawn_monitor/1]).
+
+start() ->
+  ParentPid = self(),
+  {ChildPid, MonitorReference} = spawn_monitor(fun () ->
+     receive
+       next -> ParentPid ! child_done
+     end
+  end),
+  display(has_no_messages()),
+  display(demonitor(MonitorReference)),
+  ChildPid ! next,
+  receive
+     child_done -> ok
+  end,
+  display(has_no_messages()).
+
+has_no_messages() ->
+  HasNoMessages = receive
+    _ -> false
+  after
+    0 -> true
+  end,
+  HasNoMessages.

--- a/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference/with_monitor/returns_true/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference/with_monitor/returns_true/init.erl
@@ -1,0 +1,26 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [demonitor/1, display/1, process_info/2, spawn_monitor/1]).
+
+start() ->
+  {ChildPid, MonitorReference} = spawn_monitor(fun () ->
+     receive
+       next -> ok
+     end
+  end),
+  MonitorCountBefore = monitor_count(self()),
+  MonitoredByCountBefore = monitored_by_count(ChildPid),
+  display(demonitor(MonitorReference)),
+  MonitorCountAfter = monitor_count(self()),
+  MonitoredByCountAfter = monitored_by_count(ChildPid),
+  display(MonitorCountBefore - 1 == MonitorCountAfter),
+  display(MonitoredByCountBefore - 1 == MonitoredByCountAfter),
+  ChildPid ! next.
+
+monitor_count(Pid) ->
+   {monitors, Monitors} = process_info(Pid, monitors),
+   length(Monitors).
+
+monitored_by_count(Pid) ->
+  {monitored_by, MonitoredBys} = process_info(Pid, monitored_by),
+  length(MonitoredBys).

--- a/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference/without_monitor_returns_true/init.erl
+++ b/native_implemented/otp/tests/lib/erlang/demonitor_1/with_reference/without_monitor_returns_true/init.erl
@@ -1,0 +1,7 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [demonitor/1, display/1, make_ref/0]).
+
+start() ->
+  Reference = make_ref(),
+  display(demonitor(Reference)).

--- a/runtimes/minimal/src/process.rs
+++ b/runtimes/minimal/src/process.rs
@@ -12,39 +12,7 @@ pub fn runnable<'a>(
     process: &Process,
     frames_with_arguments_fn: Box<dyn Fn(&Process) -> AllocResult<Vec<FrameWithArguments>> + 'a>,
 ) -> AllocResult<()> {
-    process.runnable(move |process| {
-        unsafe {
-            let mut stack = process.stack.lock();
-
-            let frames_with_arguments = frames_with_arguments_fn(process)?;
-
-            for FrameWithArguments { frame, uses_returned, arguments  } in frames_with_arguments.into_iter().rev() {
-                if uses_returned {
-                    unimplemented!("Cannot generate code to use returned value dynamically");
-                }
-
-                if arguments.is_empty() {
-                    stack.push_frame(&frame);
-                } else {
-                    unimplemented!("Cannot generate code to use heap stack values ({:?}) when calling functions", arguments);
-                }
-            }
-
-            stack.push64(return_continuation as u64);
-
-            // This is an obviously blatantly unsafe operation to perform, but is
-            // actually safe in this case - it is never possible for the process
-            // registers to be modified concurrently - the owning scheduler will
-            // be the only thing modifying them, and can only do so once it has
-            // taken ownership of the process to begin with, implying exclusive
-            // access
-            let registers = &process.registers;
-            ptr::write(&registers.rsp as *const _ as *mut _, stack.top as u64);
-            ptr::write(&registers.rbp as *const _ as *mut _, stack.top as u64);
-        }
-
-        Ok(())
-    })
+    process.runnable(move |process| Ok(()))
 }
 
 #[naked]


### PR DESCRIPTION
# Changelog
## Enhancements
* Integration tests for `demonitor/1`.
* `process_info(pid(), monitors)` and `process_info(pid(), monitored_by)`.

## Bug Fixes
* Ignore `frame_with_arguments` in minimal runtime `runnable`.  Minimal must codegen all the code to run and cannot use `Frame`s.  Fixes spawning processes for minimal runtime as it stops duplicate `return_continuation` from both `runnable` and `spawn_internal_impl`.