### PR TITLE
Define __lumen_process_signal and __lumen_start_panic for lumen_rt_full tests

### DIFF
--- a/runtimes/full/src/lib.rs
+++ b/runtimes/full/src/lib.rs
@@ -30,6 +30,8 @@
 #![feature(termination_trait_lib)]
 // `PROCESS_SIGNAL` for tests
 #![feature(thread_local)]
+// `__lumen_start_panic` for tests
+#![feature(unwind_attributes)]
 
 extern crate alloc;
 extern crate cfg_if;

--- a/runtimes/full/src/lib.rs
+++ b/runtimes/full/src/lib.rs
@@ -28,6 +28,8 @@
 // Layout helpers
 #![feature(alloc_layout_extra)]
 #![feature(termination_trait_lib)]
+// `PROCESS_SIGNAL` for tests
+#![feature(thread_local)]
 
 extern crate alloc;
 extern crate cfg_if;

--- a/runtimes/full/src/test.rs
+++ b/runtimes/full/src/test.rs
@@ -4,9 +4,9 @@ pub mod loop_0;
 pub mod process;
 
 #[cfg(test)]
-use liblumen_alloc::erts::term::prelude::*;
+use liblumen_alloc::erts::process::ffi::{process_error, ProcessSignal};
 #[cfg(test)]
-use liblumen_alloc::erts::process::ffi::ProcessSignal;
+use liblumen_alloc::erts::term::prelude::*;
 
 pub use lumen_rt_core::test::*;
 
@@ -27,3 +27,10 @@ pub(crate) fn once_crate() {
 #[export_name = "__lumen_process_signal"]
 #[thread_local]
 static mut PROCESS_SIGNAL: ProcessSignal = ProcessSignal::None;
+
+#[cfg(test)]
+#[unwind(allowed)]
+#[no_mangle]
+pub unsafe extern "C" fn __lumen_start_panic(_payload: usize) -> u32 {
+    panic!(process_error().unwrap());
+}

--- a/runtimes/full/src/test.rs
+++ b/runtimes/full/src/test.rs
@@ -5,6 +5,8 @@ pub mod process;
 
 #[cfg(test)]
 use liblumen_alloc::erts::term::prelude::*;
+#[cfg(test)]
+use liblumen_alloc::erts::process::ffi::ProcessSignal;
 
 pub use lumen_rt_core::test::*;
 
@@ -20,3 +22,8 @@ fn module() -> Atom {
 pub(crate) fn once_crate() {
     once(&[]);
 }
+
+#[cfg(test)]
+#[export_name = "__lumen_process_signal"]
+#[thread_local]
+static mut PROCESS_SIGNAL: ProcessSignal = ProcessSignal::None;


### PR DESCRIPTION
Fixes #531

# Changelog
## Bug Fixes
* Fix `lumen_rt_full` tests
  * Define `__lumen_process_signal`
  * Define `__lumen_start_panic`
    Rust `panic!` with `RuntimeException` in `PROCESS_ERROR` then `catch_unwind` in `call_current_native` to turn the panic back into a `Status::RuntimeException`.