### PR TITLE
Re-enable liblumen_otp integration tests for Linux

### DIFF
--- a/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           path: target
           key: ${{ github.workflow }}-${{ github.job }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build TableGen
-        run: make lumen-tblgen
+      - name: Make Build
+        run: make build
       - name: Test lumen_rt_full
         run: cargo test --package lumen_rt_full
       - name: Test liblumen_otp with runtime_full

--- a/native_implemented/otp/tests/lib.rs
+++ b/native_implemented/otp/tests/lib.rs
@@ -2,7 +2,5 @@
 #[path = "./test.rs"]
 mod test;
 
-// Linux currently can't compile `lumen` compiler
-#[cfg(not(target_os = "linux"))]
 #[path = "lib/erlang.rs"]
 pub mod erlang;


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Re-enable `liblumen_otp` integration tests for Linux.
  Linux has been able to build the compiler since b15aa3faae232ecf38b6d910bc0d811ef26f593c, so these should have been
re-enabled then.