### PR TITLE
Fix CaptureFunction primop read assertion

### DIFF
--- a/compiler/codegen/src/builder/function.rs
+++ b/compiler/codegen/src/builder/function.rs
@@ -1438,8 +1438,8 @@ impl<'f, 'o> ScopedFunctionBuilder<'f, 'o> {
             ir::PrimOpKind::CaptureFunction => {
                 debug_in!(self, "primop is function capture");
                 assert_eq!(
-                    num_reads, 4,
-                    "expected capture function primop to have four operands"
+                    num_reads, 3,
+                    "expected capture function primop to have three operands"
                 );
                 let callee = Callee::new(self, ir_value)?;
                 OpKind::FunctionRef(FunctionRef { loc, callee })


### PR DESCRIPTION
The CaptureFunction primop will always take 3 reads, not 4.

This is because primops does not include control flow, so the reads will always be [M, F, A]. This format is identical for all function captures, even local ones.

This PR fixes https://github.com/lumen/lumen/issues/544.