### PR TITLE
Fix assertion in tuple primop builder

### DIFF
--- a/compiler/codegen/src/builder/function.rs
+++ b/compiler/codegen/src/builder/function.rs
@@ -1395,7 +1395,7 @@ impl<'f, 'o> ScopedFunctionBuilder<'f, 'o> {
             ir::PrimOpKind::Tuple => {
                 debug_in!(self, "primop is tuple constructor");
                 assert!(
-                    num_reads > 1,
+                    num_reads >= 1,
                     "expected tuple primop to have at least one operand"
                 );
                 let mut elements = Vec::with_capacity(num_reads);


### PR DESCRIPTION
The tuple primop builder is only supposed to receive nonempty tuples,
empty ones get folded to a constant in eir.

Therefore, there should be an an assertion in the tuple primop builder
that the arity of the tuple is always `>= 1`.

This was mistakingly `> 1` before, this PR changes it to `>= 1`.