### PR TITLE
Fail build script if lumen-tblgen errors

### DIFF
--- a/compiler/term/build.rs
+++ b/compiler/term/build.rs
@@ -76,6 +76,7 @@ fn tblgen(args: &[String]) {
             String::from_utf8(output.stderr)
                 .map(|s| println!("{}", s.trim_end()))
                 .unwrap();
+            fail("lumen-tblgen invocation failed");
         }
         Err(e) => fail(&format!("command failed: {}", e)),
     }


### PR DESCRIPTION
If `lumen-tblgen` fails to run, the build script can still succeed.

This will panic if `lumen-tblgen` returns an error.

