### PR TITLE
Log exit trace format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ dependencies = [
  "panic-control",
  "proptest",
  "radix_fmt",
+ "strip-ansi-escapes",
  "thiserror",
  "web-sys",
 ]
@@ -2676,6 +2677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,6 +2883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
+
+[[package]]
 name = "uuid"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +2902,15 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vte"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/liblumen_alloc/src/erts/exception/classes.rs
+++ b/liblumen_alloc/src/erts/exception/classes.rs
@@ -87,6 +87,7 @@ impl fmt::Display for Throw {
         self.stacktrace
             .format(
                 f,
+                None,
                 Atom::str_to_term("throw"),
                 self.reason,
                 self.source.clone(),
@@ -181,6 +182,7 @@ impl fmt::Display for Error {
         self.stacktrace
             .format(
                 f,
+                None,
                 Atom::str_to_term("error"),
                 self.reason,
                 self.source.clone(),
@@ -262,6 +264,7 @@ impl fmt::Display for Exit {
         self.stacktrace
             .format(
                 f,
+                None,
                 Atom::str_to_term("exit"),
                 self.reason,
                 self.source.clone(),

--- a/liblumen_alloc/src/erts/exception/classes.rs
+++ b/liblumen_alloc/src/erts/exception/classes.rs
@@ -276,6 +276,19 @@ pub enum Class {
     Exit,
     Throw,
 }
+impl Class {
+    pub fn as_atom(&self) -> Atom {
+        match self {
+            Self::Error { .. } => Atom::ERROR,
+            Self::Exit => Atom::EXIT,
+            Self::Throw => Atom::THROW,
+        }
+    }
+
+    pub fn as_term(&self) -> Term {
+        self.as_atom().as_term()
+    }
+}
 impl fmt::Display for Class {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/liblumen_alloc/src/erts/process/trace/backtrace.rs
+++ b/liblumen_alloc/src/erts/process/trace/backtrace.rs
@@ -9,7 +9,7 @@ use liblumen_core::util::thread_local::ThreadLocalCell;
 use crate::borrow::CloneToProcess;
 use crate::erts::exception::ArcError;
 use crate::erts::process::alloc::TermAlloc;
-use crate::erts::process::{AllocResult, ModuleFunctionArity};
+use crate::erts::process::{AllocResult, ModuleFunctionArity, Process};
 use crate::erts::term::prelude::*;
 use crate::erts::HeapFragment;
 
@@ -88,19 +88,20 @@ impl Trace {
     }
 
     #[inline]
-    pub fn print(&self, kind: Term, reason: Term, source: Option<ArcError>) -> std::io::Result<()> {
-        format::print(self, kind, reason, source)
+    pub fn print(&self, process: &Process, kind: Term, reason: Term, source: Option<ArcError>) -> std::io::Result<()> {
+        format::print(self, process, kind, reason, source)
     }
 
     #[inline]
     pub fn format(
         &self,
         f: &mut fmt::Formatter,
+        process: Option<&Process>,
         kind: Term,
         reason: Term,
         source: Option<ArcError>,
     ) -> std::io::Result<()> {
-        format::format(self, f, kind, reason, source)
+        format::format(self, f, process, kind, reason, source)
     }
 
     /// Sets the top frame of the stacktrace to a specific module/function/arity,

--- a/liblumen_alloc/src/erts/process/trace/fallback.rs
+++ b/liblumen_alloc/src/erts/process/trace/fallback.rs
@@ -8,7 +8,7 @@ use liblumen_core::util::thread_local::ThreadLocalCell;
 use crate::borrow::CloneToProcess;
 use crate::erts::exception::ArcError;
 use crate::erts::process::alloc::TermAlloc;
-use crate::erts::process::{AllocResult, ModuleFunctionArity};
+use crate::erts::process::{AllocResult, ModuleFunctionArity, Process};
 use crate::erts::term::prelude::*;
 use crate::erts::HeapFragment;
 
@@ -65,13 +65,13 @@ impl Trace {
     }
 
     #[inline]
-    pub fn print(&self, kind: Term, reason: Term, source: Option<ArcError>) -> std::io::Result<()> {
-        format::print(self, kind, reason, source)
+    pub fn print(&self, process: &Process, kind: Term, reason: Term, source: Option<ArcError>) -> std::io::Result<()> {
+        format::print(self, process, kind, reason, source)
     }
 
     #[inline]
-    pub fn format(&self, f: &mut fmt::Formatter, kind: Term, reason: Term, source: Option<ArcError>) -> std::io::Result<()> {
-        format::format(self, f, kind, reason, source)
+    pub fn format(&self, f: &mut fmt::Formatter, process: Option<&Process>, kind: Term, reason: Term, source: Option<ArcError>) -> std::io::Result<()> {
+        format::format(self, f, process, kind, reason, source)
     }
 
     #[inline]

--- a/liblumen_alloc/src/erts/process/trace/format.rs
+++ b/liblumen_alloc/src/erts/process/trace/format.rs
@@ -95,7 +95,6 @@ where
     writeln!(out, "Backtrace (most recent call last):")?;
 
     for symbol in trace.iter_symbols().rev() {
-        println!("{:?}", &symbol);
         let mfa = symbol.module_function_arity();
         if mfa.is_none() {
             continue;

--- a/native_implemented/otp/Cargo.toml
+++ b/native_implemented/otp/Cargo.toml
@@ -39,4 +39,6 @@ libc = "0.2.74"
 lumen_rt_full = { path = "../../runtimes/full" }
 lumen = { path = "../../lumen" }
 panic-control = "0.1.4"
+# get rid of colors in backtraces for easier matching in integration tests
+strip-ansi-escapes = "0.1.0"
 

--- a/native_implemented/otp/tests/lib.rs
+++ b/native_implemented/otp/tests/lib.rs
@@ -13,7 +13,7 @@ test_stderr_substrings!(
         "native_implemented/otp/tests/lib/backtrace/init.erl:9, in init:bad_reverse/1",
         "native_implemented/otp/tests/lib/backtrace/init.erl:11, in init:bad_reverse/1",
         "native_implemented/otp/src/erlang/tl_1.rs:7, in erlang:tl/1",
-        "Process exited abnormally.",
+        "Process (#PID<0.2.0>) exited abnormally.",
         "badarg"
     ]
 );

--- a/native_implemented/otp/tests/lib.rs
+++ b/native_implemented/otp/tests/lib.rs
@@ -6,3 +6,14 @@ mod test;
 pub mod erlang;
 #[path = "lib/maps.rs"]
 pub mod maps;
+
+test_stderr_substrings!(
+    backtrace,
+    vec![
+        "native_implemented/otp/tests/lib/backtrace/init.erl:9, in init:bad_reverse/1",
+        "native_implemented/otp/tests/lib/backtrace/init.erl:11, in init:bad_reverse/1",
+        "native_implemented/otp/src/erlang/tl_1.rs:7, in erlang:tl/1",
+        "Process exited abnormally.",
+        "badarg"
+    ]
+);

--- a/native_implemented/otp/tests/lib/backtrace/init.erl
+++ b/native_implemented/otp/tests/lib/backtrace/init.erl
@@ -1,0 +1,11 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1]).
+
+start() ->
+  bad_reverse([0, 1, 2, 3]).
+
+bad_reverse([H|T]) ->
+  bad_reverse(T) ++ [H];
+bad_reverse(L) ->
+  [tl(L) | hd(L)].

--- a/native_implemented/otp/tests/lib/erlang/exit_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/exit_1.rs
@@ -1,1 +1,1 @@
-test_stdout_substrings!(atom, vec!["exited with reason: atom"]);
+test_stderr_substrings!(atom, vec!["Process exited abnormally.", "atom"]);

--- a/native_implemented/otp/tests/lib/erlang/exit_1.rs
+++ b/native_implemented/otp/tests/lib/erlang/exit_1.rs
@@ -1,1 +1,4 @@
-test_stderr_substrings!(atom, vec!["Process exited abnormally.", "atom"]);
+test_stderr_substrings!(
+    atom,
+    vec!["Process (#PID<0.2.0>) exited abnormally.", "atom"]
+);

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_does_not_exit,
     vec!["{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -1,7 +1,8 @@
 #[path = "with_empty_list_arguments/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_does_not_exit,
-    vec!["exited with reason: undef", "{parent, alive, true}"]
+    vec!["{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_does_not_exit,
     vec!["{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_does_not_exit,
-    vec!["exited with reason: undef", "{parent, alive, true}"]
+    vec!["{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -6,7 +6,8 @@ test_stdout_substrings!(
         "{parent, alive, true}"
     ]
 );
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_parent_does_not_exit,
-    vec!["exited with reason: undef", "{parent, alive, true}"]
+    vec!["{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -9,5 +9,5 @@ test_stdout_substrings!(
 test_substrings!(
     without_arity_when_run_exits_undef_and_parent_does_not_exit,
     vec!["{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_does_not_exit,
     vec!["{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -1,7 +1,8 @@
 #[path = "with_non_empty_proper_list_arguments/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_does_not_exit,
-    vec!["exited with reason: undef", "{parent, alive, true}"]
+    vec!["{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_does_not_exit,
     vec!["{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_does_not_exit,
-    vec!["exited with reason: undef", "{parent, alive, true}"]
+    vec!["{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_parent_does_not_exit,
-    vec!["exited with reason: undef", "{parent, alive, true}"]
+    vec!["{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_parent_does_not_exit,
     vec!["{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_valid_arguments_when_run_exits_normal_and_parent_does_not_exit,
     "{child, sum, 3}\n{child, exited, normal}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_valid_arguments_when_run_exits_and_parent_does_not_exit,
-    vec![
-        "exited with reason: function_clause",
-        "{child, exited, function_clause}",
-        "{parent, alive, true}"
-    ]
+    vec!["{child, exited, function_clause}", "{parent, alive, true}"],
+    vec!["Process exited abnormally.", "function_clause"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,8 @@ test_stdout!(
 test_substrings!(
     without_valid_arguments_when_run_exits_and_parent_does_not_exit,
     vec!["{child, exited, function_clause}", "{parent, alive, true}"],
-    vec!["Process exited abnormally.", "function_clause"]
+    vec![
+        "Process (#PID<0.3.0>) exited abnormally.",
+        "function_clause"
+    ]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -1,7 +1,8 @@
 #[path = "with_empty_list_arguments/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_exits_normal_arent_does_not_exit,
     "{in, child}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_exits_normal_arent_does_not_exit,
-    vec![
-        "{in, child}",
-        "exited with reason: abnormal",
-        "{parent, exited, abnormal}"
-    ]
+    vec!["{in, child}", "{parent, exited, abnormal}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_exits_normal_arent_does_not_exit,
     vec!["{in, child}", "{parent, exited, abnormal}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -1,7 +1,8 @@
 #[path = "with_non_empty_proper_list_arguments/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,10 +2,8 @@ test_stdout!(
     with_valid_arguments_when_run_exits_normal_and_parent_does_not_exit,
     "{child, sum, 3}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_valid_arguments_when_run_exits_and_parent_exits,
-    vec![
-        "exited with reason: function_clause",
-        "{parent, exited, function_clause}"
-    ]
+    vec!["{parent, exited, function_clause}"],
+    vec!["Process exited abnormally.", "function_clause"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_link_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,8 @@ test_stdout!(
 test_substrings!(
     without_valid_arguments_when_run_exits_and_parent_exits,
     vec!["{parent, exited, function_clause}"],
-    vec!["Process exited abnormally.", "function_clause"]
+    vec![
+        "Process (#PID<0.3.0>) exited abnormally.",
+        "function_clause"
+    ]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_sends_exit_message_to_parent,
     vec!["{child, exited, undef}", "{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments.rs
@@ -1,11 +1,8 @@
 #[path = "with_empty_list_arguments/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec![
-        "exited with reason: undef",
-        "{child, exited, undef}",
-        "{parent, alive, true}"
-    ]
+    vec!["{child, exited, undef}", "{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -1,11 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec![
-        "exited with reason: undef",
-        "{child, exited, undef}",
-        "{parent, alive, true}"
-    ]
+    vec!["{child, exited, undef}", "{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_sends_exit_message_to_parent,
     vec!["{child, exited, undef}", "{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_arity_when_run_exits_undef_and_send_exit_message_to_parent,
     vec!["{child, exited, undef}", "{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_empty_list_arguments/with_loaded_module/with_exported_function.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_arity_when_run_exits_normal_and_sends_exit_message_to_parent,
     "{child, ran}\n{child, exited, normal}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_send_exit_message_to_parent,
-    vec![
-        "exited with reason: undef",
-        "{child, exited, undef}",
-        "{parent, alive, true}"
-    ]
+    vec!["{child, exited, undef}", "{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
     vec!["{child, exited, undef}", "{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments.rs
@@ -1,11 +1,8 @@
 #[path = "with_non_empty_proper_list_arguments/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
-    vec![
-        "exited with reason: undef",
-        "{child, exited, undef}",
-        "{parent, alive, true}"
-    ]
+    vec!["{child, exited, undef}", "{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
@@ -1,11 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec![
-        "exited with reason: undef",
-        "{child, exited, undef}",
-        "{parent, alive, true}"
-    ]
+    vec!["{child, exited, undef}", "{parent, alive, true}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_sends_exit_message_to_parent,
     vec!["{child, exited, undef}", "{parent, alive, true}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,7 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_stderr_substrings!(
     without_arity_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec!["exited with reason: undef"]
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function.rs
@@ -3,5 +3,5 @@ mod with_arity;
 
 test_stderr_substrings!(
     without_arity_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_valid_arguments_when_run_exits_normal_and_sends_exit_message_to_parent,
     "{child, sum, 3}\n{child, exited, normal}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_valid_arguments_when_run_exits_and_sends_exit_message_to_parent,
-    vec![
-        "exited with reason: function_clause",
-        "{child, exited, function_clause}",
-        "{parent, alive, true}"
-    ]
+    vec!["{child, exited, function_clause}", "{parent, alive, true}"],
+    vec!["Process exited abnormally.", "function_clause"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_monitor_3/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,8 @@ test_stdout!(
 test_substrings!(
     without_valid_arguments_when_run_exits_and_sends_exit_message_to_parent,
     vec!["{child, exited, function_clause}", "{parent, alive, true}"],
-    vec!["Process exited abnormally.", "function_clause"]
+    vec![
+        "Process (#PID<0.3.0>) exited abnormally.",
+        "function_clause"
+    ]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_empty_list_options.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_empty_list_options.rs
@@ -1,7 +1,8 @@
 #[path = "with_empty_list_options/with_arity_zero.rs"]
 mod with_arity_zero;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_zero_returns_pid_to_parent_and_child_process_exits_undef,
-    vec!["exited with reason: undef", "{parent, alive}"]
+    vec!["{parent, alive}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_empty_list_options.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_empty_list_options.rs
@@ -4,5 +4,5 @@ mod with_arity_zero;
 test_substrings!(
     without_arity_zero_returns_pid_to_parent_and_child_process_exits_undef,
     vec!["{parent, alive}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_empty_list_options/with_arity_zero.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_empty_list_options/with_arity_zero.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_normal_exit_does_not_exit_parent_or_send_exit_message,
     vec!["{in, child}", "{parent, alive}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_empty_list_options/with_arity_zero.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_empty_list_options/with_arity_zero.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_normal_exit_does_not_exit_parent_or_send_exit_message,
     "{in, child}\n{parent, alive}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_normal_exit_does_not_exit_parent_or_send_exit_message,
-    vec![
-        "{in, child}",
-        "exited with reason: abnormal",
-        "{parent, alive}"
-    ]
+    vec!["{in, child}", "{parent, alive}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list.rs
@@ -1,7 +1,8 @@
 #[path = "with_link_and_monitor_in_options_list/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_exits_normal_arent_does_not_exit,
     "{in, child}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_exits_normal_arent_does_not_exit,
-    vec![
-        "{in, child}",
-        "exited with reason: abnormal",
-        "{parent, exited, abnormal}"
-    ]
+    vec!["{in, child}", "{parent, exited, abnormal}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_exits_normal_arent_does_not_exit,
     vec!["{in, child}", "{parent, exited, abnormal}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list.rs
@@ -1,7 +1,8 @@
 #[path = "with_link_in_options_list/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_exits_normal_arent_does_not_exit,
     "{in, child}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_exits_normal_arent_does_not_exit,
-    vec![
-        "{in, child}",
-        "exited with reason: abnormal",
-        "{parent, exited, abnormal}"
-    ]
+    vec!["{in, child}", "{parent, exited, abnormal}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_exits_normal_arent_does_not_exit,
     vec!["{in, child}", "{parent, exited, abnormal}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list.rs
@@ -1,7 +1,8 @@
 #[path = "with_monitor_in_options_list/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec!["exited with reason: undef", "{child, exited, undef}"]
+    vec!["{child, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_sends_exit_message_to_parent,
     vec!["{child, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec!["exited with reason: undef", "{child, exited, undef}"]
+    vec!["{child, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_sends_exit_message_to_parent,
     vec!["{child, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_send_exit_message_to_parent,
     vec!["{child, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_send_exit_message_to_parent,
-    vec!["exited with reason: undef", "{child, exited, undef}"]
+    vec!["{child, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_normal_exit_sends_exit_message_to_parent,
     vec!["{in, child}", "{child, exited, abnormal}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_empty_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_normal_exit_sends_exit_message_to_parent,
     "{in, child}\n{child, exited, normal}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_normal_exit_sends_exit_message_to_parent,
-    vec![
-        "{in, child}",
-        "exited with reason: abnormal",
-        "{child, exited, abnormal}"
-    ]
+    vec!["{in, child}", "{child, exited, abnormal}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_empty_list_options.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_empty_list_options.rs
@@ -1,7 +1,8 @@
 #[path = "with_empty_list_options/with_arity_zero.rs"]
 mod with_arity_zero;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_zero_returns_pid_to_parent_and_child_process_exits_undef,
-    vec!["exited with reason: undef", "{parent, alive}"]
+    vec!["{parent, alive}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_empty_list_options.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_empty_list_options.rs
@@ -4,5 +4,5 @@ mod with_arity_zero;
 test_substrings!(
     without_arity_zero_returns_pid_to_parent_and_child_process_exits_undef,
     vec!["{parent, alive}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_empty_list_options/with_arity_zero.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_empty_list_options/with_arity_zero.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_normal_exit_does_not_exit_parent_or_send_exit_message,
     vec!["{in, child, 1, 2}", "{parent, alive}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_empty_list_options/with_arity_zero.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_empty_list_options/with_arity_zero.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_normal_exit_does_not_exit_parent_or_send_exit_message,
     "{in, child, 1, 2}\n{parent, alive}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_normal_exit_does_not_exit_parent_or_send_exit_message,
-    vec![
-        "{in, child, 1, 2}",
-        "exited with reason: abnormal",
-        "{parent, alive}"
-    ]
+    vec!["{in, child, 1, 2}", "{parent, alive}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list.rs
@@ -1,7 +1,8 @@
 #[path = "with_link_and_monitor_in_options_list/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_exits_normal_arent_does_not_exit,
     vec!["{in, child, 1, 2}", "{parent, exited, abnormal}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_and_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_exits_normal_arent_does_not_exit,
     "{in, child, 1, 2}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_exits_normal_arent_does_not_exit,
-    vec![
-        "{in, child, 1, 2}",
-        "exited with reason: abnormal",
-        "{parent, exited, abnormal}"
-    ]
+    vec!["{in, child, 1, 2}", "{parent, exited, abnormal}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list.rs
@@ -1,7 +1,8 @@
 #[path = "with_link_in_options_list/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_parent_exits,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
-    vec!["exited with reason: undef", "{parent, exited, undef}"]
+    vec!["{parent, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_exits_parent,
     vec!["{parent, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_exits_normal_arent_does_not_exit,
     vec!["{in, child, 1, 2}", "{parent, exited, abnormal}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_link_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_exits_normal_arent_does_not_exit,
     "{in, child, 1, 2}\n{parent, alive, true}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_exits_normal_arent_does_not_exit,
-    vec![
-        "{in, child, 1, 2}",
-        "exited with reason: abnormal",
-        "{parent, exited, abnormal}"
-    ]
+    vec!["{in, child, 1, 2}", "{parent, exited, abnormal}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list.rs
@@ -1,7 +1,8 @@
 #[path = "with_monitor_in_options_list/with_loaded_module.rs"]
 mod with_loaded_module;
 
-test_stdout_substrings!(
+test_substrings!(
     without_loaded_module_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec!["exited with reason: undef", "{child, exited, undef}"]
+    vec!["{child, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list.rs
@@ -4,5 +4,5 @@ mod with_loaded_module;
 test_substrings!(
     without_loaded_module_when_run_exits_undef_and_sends_exit_message_to_parent,
     vec!["{child, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module.rs
@@ -1,7 +1,8 @@
 #[path = "with_loaded_module/with_exported_function.rs"]
 mod with_exported_function;
 
-test_stdout_substrings!(
+test_substrings!(
     without_exported_function_when_run_exits_undef_and_sends_exit_message_to_parent,
-    vec!["exited with reason: undef", "{child, exited, undef}"]
+    vec!["{child, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module.rs
@@ -4,5 +4,5 @@ mod with_exported_function;
 test_substrings!(
     without_exported_function_when_run_exits_undef_and_sends_exit_message_to_parent,
     vec!["{child, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function.rs
@@ -4,5 +4,5 @@ mod with_arity;
 test_substrings!(
     without_arity_when_run_exits_undef_and_send_exit_message_to_parent,
     vec!["{child, exited, undef}"],
-    vec!["Process exited abnormally.", "undef"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function.rs
@@ -1,7 +1,8 @@
 #[path = "with_exported_function/with_arity.rs"]
 mod with_arity;
 
-test_stdout_substrings!(
+test_substrings!(
     without_arity_when_run_exits_undef_and_send_exit_message_to_parent,
-    vec!["exited with reason: undef", "{child, exited, undef}"]
+    vec!["{child, exited, undef}"],
+    vec!["Process exited abnormally.", "undef"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -2,11 +2,8 @@ test_stdout!(
     with_normal_exit_sends_exit_message_to_parent,
     "{in, child, 1, 2}\n{child, exited, normal}\n"
 );
-test_stdout_substrings!(
+test_substrings!(
     without_normal_exit_sends_exit_message_to_parent,
-    vec![
-        "{in, child, 1, 2}",
-        "exited with reason: abnormal",
-        "{child, exited, abnormal}"
-    ]
+    vec!["{in, child, 1, 2}", "{child, exited, abnormal}"],
+    vec!["Process exited abnormally.", "abnormal"]
 );

--- a/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
+++ b/native_implemented/otp/tests/lib/erlang/spawn_opt_4/with_atom_module/with_atom_function/with_non_empty_proper_list_arguments/with_monitor_in_options_list/with_loaded_module/with_exported_function/with_arity.rs
@@ -5,5 +5,5 @@ test_stdout!(
 test_substrings!(
     without_normal_exit_sends_exit_message_to_parent,
     vec!["{in, child, 1, 2}", "{child, exited, abnormal}"],
-    vec!["Process exited abnormally.", "abnormal"]
+    vec!["Process (#PID<0.3.0>) exited abnormally.", "abnormal"]
 );

--- a/runtimes/core/src/process.rs
+++ b/runtimes/core/src/process.rs
@@ -41,7 +41,7 @@ fn is_expected_exit_reason(reason: Term) -> bool {
     }
 }
 
-pub fn log_exit(exception: &RuntimeException) {
+pub fn log_exit(process: &Process, exception: &RuntimeException) {
     let reason = exception.reason();
 
     if !is_expected_exit_reason(reason) {
@@ -49,6 +49,7 @@ pub fn log_exit(exception: &RuntimeException) {
             exception
                 .stacktrace()
                 .print(
+                    process,
                     exception.class().as_term(),
                     exception.reason(),
                     exception.source(),

--- a/runtimes/full/src/scheduler.rs
+++ b/runtimes/full/src/scheduler.rs
@@ -249,7 +249,7 @@ impl SchedulerTrait for Scheduler {
                                 propagate_exit(&exiting_arc_process, None);
                             }
                             Status::RuntimeException(ref exception) => {
-                                log_exit(exception);
+                                log_exit(&exiting_arc_process, exception);
                                 propagate_exit(&exiting_arc_process, Some(exception));
                             }
                             _ => unreachable!(),

--- a/runtimes/full/src/scheduler.rs
+++ b/runtimes/full/src/scheduler.rs
@@ -249,7 +249,7 @@ impl SchedulerTrait for Scheduler {
                                 propagate_exit(&exiting_arc_process, None);
                             }
                             Status::RuntimeException(ref exception) => {
-                                log_exit(&exiting_arc_process, exception);
+                                log_exit(exception);
                                 propagate_exit(&exiting_arc_process, Some(exception));
                             }
                             _ => unreachable!(),

--- a/runtimes/minimal/src/builtins/exceptions.rs
+++ b/runtimes/minimal/src/builtins/exceptions.rs
@@ -27,7 +27,9 @@ pub extern "C" fn builtin_trace_capture() -> *mut Trace {
 #[export_name = "__lumen_builtin_trace.print"]
 pub extern "C" fn builtin_trace_print(kind: Term, reason: Term, trace: &mut Trace) -> *mut Trace {
     let source = None;
-    trace.print(kind, reason, source).unwrap();
+    trace
+        .print(&current_process(), kind, reason, source)
+        .unwrap();
     trace
 }
 

--- a/runtimes/minimal/src/scheduler.rs
+++ b/runtimes/minimal/src/scheduler.rs
@@ -588,7 +588,7 @@ impl Scheduler {
                                 propagate_exit(&exiting_arc_process, None);
                             }
                             Status::RuntimeException(ref exception) => {
-                                log_exit(&exiting_arc_process, exception);
+                                log_exit(exception);
                                 propagate_exit(&exiting_arc_process, Some(exception));
                             }
                             _ => unreachable!(),

--- a/runtimes/minimal/src/scheduler.rs
+++ b/runtimes/minimal/src/scheduler.rs
@@ -588,7 +588,7 @@ impl Scheduler {
                                 propagate_exit(&exiting_arc_process, None);
                             }
                             Status::RuntimeException(ref exception) => {
-                                log_exit(exception);
+                                log_exit(&exiting_arc_process, exception);
                                 propagate_exit(&exiting_arc_process, Some(exception));
                             }
                             _ => unreachable!(),


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Use the `trace::format::print` in `log_exit` to print the improved backtraces instead of `Process::stacktrace()`, as that only works with runtime full `Frame`s anyway.