### PR TITLE
fix 2 typos in installing prebuilt llvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ the usual default for this XDG variable.
 
     mkdir -p $XDG_DATA_HOME/llvm/lumen
     cd $XDG_DATA_HOME/llvm/lumen
-    https://github.com/lumen/llvm-project/releases/download/lumen-12.0.0-dev_2020-08-04/clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz
+    wget https://github.com/lumen/llvm-project/releases/download/lumen-12.0.0-dev_2020-08-04/clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz
     tar -xz --strip-components 1 -f clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz
     rm clang+llvm-10.0.0-x86_64-linux-gnu.tar.gz
     cd -
 
 ###### MacOS
 
-    mkdir -p $XDG_DATA_HOME/llvm
+    mkdir -p $XDG_DATA_HOME/llvm/lumen
     cd $XDG_DATA_HOME/llvm/lumen
     wget https://github.com/lumen/llvm-project/releases/download/lumen-12.0.0-dev_2020-08-04/clang+llvm-10.0.0-x86_64-apple-darwin19.5.0.tar.gz
     tar -xzf clang+llvm-10.0.0-x86_64-apple-darwin19.5.0.tar.gz


### PR DESCRIPTION
I came across 2 tiny typos in README:

- added /lumen when creating $XDG_DATA_HOME/llvm/lumen (MacOS)
- use `wget` for linux as well to download prebuilt llvm