### PR TITLE
571

### DIFF
--- a/.github/workflows/wasm32-unknown-unknown-linux.yml
+++ b/.github/workflows/wasm32-unknown-unknown-linux.yml
@@ -33,9 +33,9 @@ jobs:
           git init examples
           cd examples
           git remote add origin https://github.com/lumen/examples
-          git fetch --no-tags --no-tags --prune --progress --depth=1 origin +4fd51a462ba5bffa5194889b41f613e7c82c2684:refs/remotes/origin/lumen/554
-          git checkout --progress --force -B lumen/554 refs/remotes/origin/lumen/554
+          git fetch --no-tags --no-tags --prune --progress --depth=1 origin +bf390b117c02d58f33eeacca4b203769103c9ea7:refs/remotes/origin/spawn-chain-cli
+          git checkout --progress --force -B spawn-chain-cli refs/remotes/origin/spawn-chain-cli
       - name: Spawn Chain Build
-        run: wasm-pack build examples/spawn-chain
+        run: wasm-pack build examples/spawn-chain/wasm
       - name: Spawn Chain Test
-        run: wasm-pack test --headless --chrome --firefox examples/spawn-chain
+        run: wasm-pack test --headless --chrome --firefox examples/spawn-chain/wasm

--- a/.github/workflows/wasm32-unknown-unknown-macOS.yml
+++ b/.github/workflows/wasm32-unknown-unknown-macOS.yml
@@ -86,9 +86,9 @@ jobs:
           git init examples
           cd examples
           git remote add origin https://github.com/lumen/examples
-          git fetch --no-tags --no-tags --prune --progress --depth=1 origin +4fd51a462ba5bffa5194889b41f613e7c82c2684:refs/remotes/origin/lumen/554
-          git checkout --progress --force -B lumen/554 refs/remotes/origin/lumen/554
+          git fetch --no-tags --no-tags --prune --progress --depth=1 origin +bf390b117c02d58f33eeacca4b203769103c9ea7:refs/remotes/origin/spawn-chain-cli
+          git checkout --progress --force -B spawn-chain-cli refs/remotes/origin/spawn-chain-cli
       - name: Spawn Chain Build
-        run: wasm-pack build examples/spawn-chain
+        run: wasm-pack build examples/spawn-chain/wasm
       - name: Spawn Chain Test
-        run: wasm-pack test --headless --chrome --safari examples/spawn-chain
+        run: wasm-pack test --headless --chrome --safari examples/spawn-chain/wasm

--- a/.github/workflows/x86_64-apple-darwin-compiler.yml
+++ b/.github/workflows/x86_64-apple-darwin-compiler.yml
@@ -42,6 +42,18 @@ jobs:
       - name: Make Build
         env:
           RUST_BACKTRACE: full
-        run: make build-shared
+        run: |
+          make build-shared
+          echo "::add-path::$PWD/bin"
       - name: Lumen Test
         run: cargo test --package lumen --no-fail-fast
+      - name: Examples Checkout
+        run: |
+          git init examples
+          cd examples
+          git remote add origin https://github.com/lumen/examples
+          git fetch --no-tags --no-tags --prune --progress --depth=1 origin +bf390b117c02d58f33eeacca4b203769103c9ea7:refs/remotes/origin/spawn-chain-cli
+          git checkout --progress --force -B spawn-chain-cli refs/remotes/origin/spawn-chain-cli
+      - name: Spawn Chain Test
+        working-directory: examples/spawn-chain/cli
+        run: make test

--- a/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
@@ -19,6 +19,18 @@ jobs:
       - name: Make Build
         env:
           RUST_BACKTRACE: full
-        run: make build-shared
+        run: |
+          make build-shared
+          echo "::add-path::$PWD/bin"
       - name: Lumen Test
         run: cargo test --package lumen --no-fail-fast
+      - name: Examples Checkout
+        run: |
+          git init examples
+          cd examples
+          git remote add origin https://github.com/lumen/examples
+          git fetch --no-tags --no-tags --prune --progress --depth=1 origin +bf390b117c02d58f33eeacca4b203769103c9ea7:refs/remotes/origin/spawn-chain-cli
+          git checkout --progress --force -B spawn-chain-cli refs/remotes/origin/spawn-chain-cli
+      - name: Spawn Chain Test
+        working-directory: examples/spawn-chain/cli
+        run: make test

--- a/runtimes/minimal/src/scheduler.rs
+++ b/runtimes/minimal/src/scheduler.rs
@@ -7,8 +7,6 @@ use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use anyhow::anyhow;
-
 use log::info;
 
 use liblumen_core::locks::RwLock;
@@ -16,12 +14,11 @@ use liblumen_core::sys::dynamic_call::DynamicCallee;
 use liblumen_core::util::thread_local::ThreadLocalCell;
 
 use liblumen_alloc::erts::exception::ErlangException;
-use liblumen_alloc::erts::process::trace::Trace;
-use liblumen_alloc::erts::process::{self, CalleeSavedRegisters, Priority, Process, Status};
+use liblumen_alloc::erts::process::{CalleeSavedRegisters, Priority, Process, Status};
 use liblumen_alloc::erts::scheduler::{id, ID};
 use liblumen_alloc::erts::term::prelude::*;
 use liblumen_alloc::erts::ModuleFunctionArity;
-use liblumen_alloc::{atom, Arity, CloneToProcess};
+use liblumen_alloc::{Arity, CloneToProcess};
 
 use lumen_rt_core::process::spawn::options::Options;
 use lumen_rt_core::process::{log_exit, propagate_exit, CURRENT_PROCESS};


### PR DESCRIPTION
Fixes #571

# Changelog
## Enhancements
* Use spawn-chain/cli demo as regression test for #571.
  As #571 was revealed when the spawn-chain/cli demo used a count of 177 or greater, use a count of 200 as a regression test in lumen/examples#6.

## Bug Fixes
* Fix unused warnings in minimal scheduler.rs
* Allocate a fragment if allocating on process fails in `builtin_malloc`.