### PR TITLE
Quality-of-life improvements for lumen compile

### DIFF
--- a/compiler/driver/src/argparser.rs
+++ b/compiler/driver/src/argparser.rs
@@ -82,16 +82,16 @@ fn compile_command<'a, 'b>() -> App<'a, 'b> {
         .about("Compiles Erlang sources to an executable or shared library")
         .setting(AppSettings::DeriveDisplayOrder)
         .arg(
-            Arg::with_name("input")
+            Arg::with_name("inputs")
                 .index(1)
                 .help(
-                    "Path to the source file or directory to compile.\n\
+                    "Path(s) to the source file(s) or director(y|ies) to compile.\n\
                      You may also use `-` as a file name to read a file from stdin.\n\
                      If not provided, the compiler will use the current directory as input.",
                 )
                 .next_line_help(true)
-                .takes_value(true)
-                .value_name("PATH"),
+                .multiple(true)
+                .value_name("PATHS"),
         )
         .arg(
             Arg::with_name("raw")

--- a/lumen/tests/cli.rs
+++ b/lumen/tests/cli.rs
@@ -69,8 +69,6 @@ mod cli {
     }
 
     fn compile() {
-        std::fs::create_dir_all("_build").unwrap();
-
         let mut command = Command::new("../bin/lumen");
 
         command

--- a/lumen/tests/cli.rs
+++ b/lumen/tests/cli.rs
@@ -75,7 +75,7 @@ mod cli {
             .arg("compile")
             .arg("--output-dir")
             .arg("_build")
-            .arg("-o")
+            .arg("--output")
             .arg("cli")
             // Turn off optimizations as work-around for debug info bug in EIR
             .arg("-O0");

--- a/lumen/tests/cli.rs
+++ b/lumen/tests/cli.rs
@@ -80,10 +80,7 @@ mod cli {
             .arg("-o")
             .arg("cli")
             // Turn off optimizations as work-around for debug info bug in EIR
-            .arg("-O0")
-            .arg("-lc");
-
-        add_link_args(&mut command);
+            .arg("-O0");
 
         let compile_output = command
             .arg("tests/cli/init.erl")
@@ -97,17 +94,5 @@ mod cli {
             String::from_utf8_lossy(&compile_output.stdout),
             String::from_utf8_lossy(&compile_output.stderr)
         );
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    fn add_link_args(_command: &mut Command) {}
-
-    #[cfg(target_os = "linux")]
-    fn add_link_args(command: &mut Command) {
-        command
-            .arg("-lunwind")
-            .arg("-lpthread")
-            .arg("-ldl")
-            .arg("-lm");
     }
 }

--- a/lumen/tests/hello_world.rs
+++ b/lumen/tests/hello_world.rs
@@ -9,7 +9,7 @@ mod hello_world {
             .arg("compile")
             .arg("--output-dir")
             .arg("_build")
-            .arg("-o")
+            .arg("--output")
             .arg("hello_world")
             // Turn off optimizations as work-around for debug info bug in EIR
             .arg("-O0");

--- a/lumen/tests/hello_world.rs
+++ b/lumen/tests/hello_world.rs
@@ -3,8 +3,6 @@ mod hello_world {
 
     #[test]
     fn prints_hello_world() {
-        std::fs::create_dir_all("_build").unwrap();
-
         let mut command = Command::new("../bin/lumen");
 
         command

--- a/lumen/tests/hello_world.rs
+++ b/lumen/tests/hello_world.rs
@@ -14,10 +14,7 @@ mod hello_world {
             .arg("-o")
             .arg("hello_world")
             // Turn off optimizations as work-around for debug info bug in EIR
-            .arg("-O0")
-            .arg("-lc");
-
-        add_link_args(&mut command);
+            .arg("-O0");
 
         let compile_output = command
             .arg("tests/hello_world/init.erl")
@@ -41,17 +38,5 @@ mod hello_world {
             "\nstdout = {}\nstderr = {}",
             hello_world_stdout, hello_world_stderr
         );
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    fn add_link_args(_command: &mut Command) {}
-
-    #[cfg(target_os = "linux")]
-    fn add_link_args(command: &mut Command) {
-        command
-            .arg("-lunwind")
-            .arg("-lpthread")
-            .arg("-ldl")
-            .arg("-lm");
     }
 }

--- a/native_implemented/otp/tests/lib/erlang/abs_1/with_number_returns_non_negative/src/test.erl
+++ b/native_implemented/otp/tests/lib/erlang/abs_1/with_number_returns_non_negative/src/test.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test.erl

--- a/native_implemented/otp/tests/lib/erlang/abs_1/with_number_returns_non_negative/src/test_big_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/abs_1/with_number_returns_non_negative/src/test_big_integer.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_big_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/abs_1/with_number_returns_non_negative/src/test_float.erl
+++ b/native_implemented/otp/tests/lib/erlang/abs_1/with_number_returns_non_negative/src/test_float.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_float.erl

--- a/native_implemented/otp/tests/lib/erlang/abs_1/with_number_returns_non_negative/src/test_small_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/abs_1/with_number_returns_non_negative/src/test_small_integer.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_small_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/abs_1/without_number_errors_badarg/src/test.erl
+++ b/native_implemented/otp/tests/lib/erlang/abs_1/without_number_errors_badarg/src/test.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test.erl

--- a/native_implemented/otp/tests/lib/erlang/abs_1/without_number_errors_badarg/src/test_big_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/abs_1/without_number_errors_badarg/src/test_big_integer.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_big_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/abs_1/without_number_errors_badarg/src/test_float.erl
+++ b/native_implemented/otp/tests/lib/erlang/abs_1/without_number_errors_badarg/src/test_float.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_float.erl

--- a/native_implemented/otp/tests/lib/erlang/abs_1/without_number_errors_badarg/src/test_small_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/abs_1/without_number_errors_badarg/src/test_small_integer.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_small_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_big_integer_augend/without_number_addend_errors_badarith/src/test.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_big_integer_augend/without_number_addend_errors_badarith/src/test.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_big_integer_augend/without_number_addend_errors_badarith/src/test_big_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_big_integer_augend/without_number_addend_errors_badarith/src/test_big_integer.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_big_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_big_integer_augend/without_number_addend_errors_badarith/src/test_float.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_big_integer_augend/without_number_addend_errors_badarith/src/test_float.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_float.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_big_integer_augend/without_number_addend_errors_badarith/src/test_small_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_big_integer_augend/without_number_addend_errors_badarith/src/test_small_integer.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_small_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_float_augend/without_number_addend_errors_badarith/src/test.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_float_augend/without_number_addend_errors_badarith/src/test.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_float_augend/without_number_addend_errors_badarith/src/test_big_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_float_augend/without_number_addend_errors_badarith/src/test_big_integer.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_big_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_float_augend/without_number_addend_errors_badarith/src/test_float.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_float_augend/without_number_addend_errors_badarith/src/test_float.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_float.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_float_augend/without_number_addend_errors_badarith/src/test_small_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_float_augend/without_number_addend_errors_badarith/src/test_small_integer.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_small_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_small_integer_augend/without_number_addend_errors_badarith/src/test.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_small_integer_augend/without_number_addend_errors_badarith/src/test.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_small_integer_augend/without_number_addend_errors_badarith/src/test_big_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_small_integer_augend/without_number_addend_errors_badarith/src/test_big_integer.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_big_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_small_integer_augend/without_number_addend_errors_badarith/src/test_float.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_small_integer_augend/without_number_addend_errors_badarith/src/test_float.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_float.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/with_small_integer_augend/without_number_addend_errors_badarith/src/test_small_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/with_small_integer_augend/without_number_addend_errors_badarith/src/test_small_integer.erl
@@ -1,1 +1,0 @@
-../../../../../../shared/src/test_small_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/without_number_augend_errors_badarith/src/test.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/without_number_augend_errors_badarith/src/test.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/without_number_augend_errors_badarith/src/test_big_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/without_number_augend_errors_badarith/src/test_big_integer.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_big_integer.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/without_number_augend_errors_badarith/src/test_float.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/without_number_augend_errors_badarith/src/test_float.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_float.erl

--- a/native_implemented/otp/tests/lib/erlang/add_2/without_number_augend_errors_badarith/src/test_small_integer.erl
+++ b/native_implemented/otp/tests/lib/erlang/add_2/without_number_augend_errors_badarith/src/test_small_integer.erl
@@ -1,1 +1,0 @@
-../../../../../shared/src/test_small_integer.erl

--- a/native_implemented/otp/tests/test.rs
+++ b/native_implemented/otp/tests/test.rs
@@ -144,15 +144,13 @@ fn compile(file: &str, name: &str) -> Result<PathBuf, (Command, Output)> {
     let mut command = Command::new("../../bin/lumen");
 
     let bin_path_buf = test_directory_path.join("bin");
-    std::fs::create_dir_all(&bin_path_buf).unwrap();
-
     let output_path_buf = bin_path_buf.join(name);
 
     command
         .arg("compile")
         .arg("--output-dir")
         .arg(build_path_buf)
-        .arg("-o")
+        .arg("--output")
         .arg(&output_path_buf)
         // Turn off optimizations as work-around for debug info bug in EIR
         .arg("-O0")

--- a/native_implemented/otp/tests/test.rs
+++ b/native_implemented/otp/tests/test.rs
@@ -140,7 +140,6 @@ fn compile(file: &str, name: &str) -> Result<PathBuf, (Command, Output)> {
     let test_directory_path = directory_path.join(file_stem).join(name);
 
     let build_path_buf = test_directory_path.join("_build");
-    std::fs::create_dir_all(&build_path_buf).unwrap();
 
     let mut command = Command::new("../../bin/lumen");
 

--- a/native_implemented/otp/tests/test.rs
+++ b/native_implemented/otp/tests/test.rs
@@ -157,8 +157,6 @@ fn compile(file: &str, name: &str) -> Result<PathBuf, (Command, Output)> {
         .arg(&output_path_buf)
         // Turn off optimizations as work-around for debug info bug in EIR
         .arg("-O0")
-        .arg("-lc")
-        .arg("-lm")
         .arg("--emit=all");
 
     let erlang_parent_path = directory_path.join(file_stem).join(name);

--- a/native_implemented/otp/tests/test.rs
+++ b/native_implemented/otp/tests/test.rs
@@ -1,3 +1,4 @@
+use std::env::current_dir;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Output, Stdio};
 
@@ -165,7 +166,10 @@ fn compile(file: &str, name: &str) -> Result<PathBuf, (Command, Output)> {
         erlang_parent_path.join("init.erl")
     };
 
+    let shared_path = current_dir().unwrap().join("tests/shared/src");
+
     let compile_output = command
+        .arg(shared_path)
         .arg(input_path)
         .stdin(Stdio::null())
         .output()


### PR DESCRIPTION
# Changelog
## Enhancements
* Remove `-l` flags no longer needed in integration tests.  The removed `-l` flags were added as defaults for the respective targets previously.
* Create all parent directories before emitting a file.  This ensures that the `--output-dir` exists before any file is written to it.
* Create all parent directories of `--output`
* Support multiple input paths to `lumen compile`.
  Makes it easier to test using the `native_implemented/otp/tests/shared/src` files.  No need to symlink into each test's src directory.