### PR TITLE
make inet_dns_record_adts.hrl for kernel

### DIFF
--- a/.github/workflows/x86_64-apple-darwin-lumen-otp.yml
+++ b/.github/workflows/x86_64-apple-darwin-lumen-otp.yml
@@ -50,5 +50,13 @@ jobs:
           git remote add origin https://github.com/lumen/otp
           git fetch --no-tags --prune --progress --depth=1 origin +ca83f680aab717fe65634247d16f18a8cbfc6d8d:refs/remotes/origin/lumen
           git checkout --progress --force -B lumen refs/remotes/origin/lumen
+      - name: lumen/otp autoconf
+        run: |
+          cd ../otp
+          ./otp_build autoconf
+      - name: lumen/otp configure
+        run: |
+          cd ../otp
+          ./configure
       - name: Test compiling lumen/otp against liblumen_otp
         run: "cargo test --package liblumen_otp --no-fail-fast lumen::otp::"

--- a/.github/workflows/x86_64-unknown-linux-gnu-lumen-otp.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-lumen-otp.yml
@@ -27,5 +27,13 @@ jobs:
           git remote add origin https://github.com/lumen/otp
           git fetch --no-tags --prune --progress --depth=1 origin +ca83f680aab717fe65634247d16f18a8cbfc6d8d:refs/remotes/origin/lumen
           git checkout --progress --force -B lumen refs/remotes/origin/lumen
+      - name: lumen/otp autoconf
+        run: |
+          cd ../otp
+          ./otp_build autoconf
+      - name: lumen/otp configure
+        run: |
+          cd ../otp
+          ./configure
       - name: Test compiling lumen/otp against liblumen_otp
         run: "cargo test --package liblumen_otp --no-fail-fast lumen::otp::"

--- a/native_implemented/otp/tests/external/lumen/otp/lib/kernel.rs
+++ b/native_implemented/otp/tests/external/lumen/otp/lib/kernel.rs
@@ -1,5 +1,8 @@
 //! https://github.com/lumen/otp/tree/lumen/lib/kernel/src
 
+use std::process::Command;
+use std::time::Duration;
+
 use super::*;
 
 test_compiles_lumen_otp!(application);
@@ -106,4 +109,27 @@ fn includes() -> Vec<&'static str> {
 
 fn relative_directory_path() -> PathBuf {
     super::relative_directory_path().join("kernel/src")
+}
+
+fn setup() {
+    let working_directory = lumen_otp_directory().join("lib/kernel/src");
+
+    let mut command = Command::new("make");
+    command
+        .current_dir(&working_directory)
+        .arg("inet_dns_record_adts.hrl");
+
+    if let Err((command, output)) = crate::test::timeout(
+        "make inet_dns_record_adts.hrl",
+        working_directory.clone(),
+        command,
+        Duration::from_secs(10),
+    ) {
+        crate::test::command_failed(
+            "make inet_dns_record_adts.hrl",
+            working_directory,
+            command,
+            output,
+        )
+    }
 }


### PR DESCRIPTION
# Changelog
## Bug Fixes
* `make inet_dns_record_adts.hrl` for OTP `lib/kernel` test builds so that `-include("inet_dns_record_adts.hrl")` works for `lib/kernel/src/inet_dns.erl`.  Fixes [https://github.com/lumen/lumen/runs/1161959214#step:11:7947].