### PR TITLE
Install Erlang on CI

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -88,3 +88,8 @@ RUN curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz
+
+RUN wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb \
+  && dpkg -i erlang-solutions_2.0_all.deb \
+  && apt-get update \
+  && apt-get install -y esl-erlang

--- a/.github/workflows/wasm32-unknown-unknown-linux.yml
+++ b/.github/workflows/wasm32-unknown-unknown-linux.yml
@@ -6,7 +6,7 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     container:
-      image: kronicdeth/lumen-development@sha256:c784a8eeb79fa5244bd15d408e469dc37b9e538b44f9b40fa4a20fd6c72c5f47
+      image: kronicdeth/lumen-development@sha256:bb25b47f31e25caf1ff66ed9e7b920a9986fa643873deb9d72f727bca6812987
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-apple-darwin-lumen-otp.yml
+++ b/.github/workflows/x86_64-apple-darwin-lumen-otp.yml
@@ -58,5 +58,7 @@ jobs:
         run: |
           cd ../otp
           ./configure
+      - name: Install Erlang
+        run: brew install erlang
       - name: Test compiling lumen/otp against liblumen_otp
         run: "cargo test --package liblumen_otp --no-fail-fast lumen::otp::"

--- a/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   compiler:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:c784a8eeb79fa5244bd15d408e469dc37b9e538b44f9b40fa4a20fd6c72c5f47
+    container: kronicdeth/lumen-development@sha256:bb25b47f31e25caf1ff66ed9e7b920a9986fa643873deb9d72f727bca6812987
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-libraries.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-libraries.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   formatted:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:c784a8eeb79fa5244bd15d408e469dc37b9e538b44f9b40fa4a20fd6c72c5f47
+    container: kronicdeth/lumen-development@sha256:bb25b47f31e25caf1ff66ed9e7b920a9986fa643873deb9d72f727bca6812987
 
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
 
   libraries:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:c784a8eeb79fa5244bd15d408e469dc37b9e538b44f9b40fa4a20fd6c72c5f47
+    container: kronicdeth/lumen-development@sha256:bb25b47f31e25caf1ff66ed9e7b920a9986fa643873deb9d72f727bca6812987
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-lumen-otp.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-lumen-otp.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   lumen-otp:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:c784a8eeb79fa5244bd15d408e469dc37b9e538b44f9b40fa4a20fd6c72c5f47
+    container: kronicdeth/lumen-development@sha256:bb25b47f31e25caf1ff66ed9e7b920a9986fa643873deb9d72f727bca6812987
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-runtime_full.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   runtime:
     runs-on: ubuntu-latest
-    container: kronicdeth/lumen-development@sha256:c784a8eeb79fa5244bd15d408e469dc37b9e538b44f9b40fa4a20fd6c72c5f47
+    container: kronicdeth/lumen-development@sha256:bb25b47f31e25caf1ff66ed9e7b920a9986fa643873deb9d72f727bca6812987
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #663

# Changelog
## Bug Fixes
* Install Erlang on CI, so that `erlc` is available for building derived files when testing compiling `lumen/otp`.