### PR TITLE
NIF stubs

### DIFF
--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -115,6 +115,7 @@ pub mod list_to_integer_2;
 pub mod list_to_pid_1;
 mod list_to_string;
 pub mod list_to_tuple_1;
+pub mod load_nif_2;
 pub mod localtime_0;
 pub mod make_ref_0;
 pub mod make_tuple_2;

--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -128,6 +128,7 @@ pub mod monotonic_time_0;
 pub mod monotonic_time_1;
 pub mod multiply_2;
 pub mod negate_1;
+pub mod nif_error_1;
 pub mod node_0;
 pub mod not_1;
 pub mod now_0;

--- a/native_implemented/otp/src/erlang/load_nif_2.rs
+++ b/native_implemented/otp/src/erlang/load_nif_2.rs
@@ -1,0 +1,15 @@
+use liblumen_alloc::atom;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::prelude::Term;
+
+#[native_implemented::function(erlang:load_nif/2)]
+pub fn result(process: &Process, _path: Term, _load_info: Term) -> Term {
+    let reason = atom!("notsup");
+    // Similar to the text used for HiPE compiled modules
+    let text = process
+        .list_from_chars("Calling load_nif from Lumen compiled modules not supported".chars());
+    let tag = atom!("error");
+    let value = process.tuple_from_slice(&[reason, text]);
+
+    process.tuple_from_slice(&[tag, value])
+}

--- a/native_implemented/otp/src/erlang/nif_error_1.rs
+++ b/native_implemented/otp/src/erlang/nif_error_1.rs
@@ -1,0 +1,16 @@
+use anyhow::*;
+
+use liblumen_alloc::erts::exception::{self, error};
+use liblumen_alloc::erts::process::trace::Trace;
+use liblumen_alloc::erts::term::prelude::Term;
+
+#[native_implemented::function(erlang:nif_error/1)]
+pub fn result(reason: Term) -> exception::Result<Term> {
+    Err(error(
+        reason,
+        None,
+        Trace::capture(),
+        Some(anyhow!("explicit nif_error from Erlang").into()),
+    )
+    .into())
+}

--- a/native_implemented/otp/tests/internal/lib/erlang.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang.rs
@@ -132,6 +132,8 @@ pub mod is_pid_1;
 pub mod is_process_alive_1;
 #[path = "erlang/link_1.rs"]
 pub mod link_1;
+#[path = "erlang/load_nif_2.rs"]
+pub mod load_nif_2;
 #[path = "erlang/nif_error_1.rs"]
 pub mod nif_error_1;
 #[path = "erlang/or_2.rs"]

--- a/native_implemented/otp/tests/internal/lib/erlang.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang.rs
@@ -132,6 +132,8 @@ pub mod is_pid_1;
 pub mod is_process_alive_1;
 #[path = "erlang/link_1.rs"]
 pub mod link_1;
+#[path = "erlang/nif_error_1.rs"]
+pub mod nif_error_1;
 #[path = "erlang/or_2.rs"]
 pub mod or_2;
 #[path = "erlang/process_flag_2.rs"]

--- a/native_implemented/otp/tests/internal/lib/erlang/load_nif_2.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/load_nif_2.rs
@@ -1,0 +1,1 @@
+test_stdout!(returns_error_not_sup, "{returned, {error, {notsup, \"Calling load_nif from Lumen compiled modules not supported\"}}}\n");

--- a/native_implemented/otp/tests/internal/lib/erlang/load_nif_2/returns_error_not_sup/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/load_nif_2/returns_error_not_sup/init.erl
@@ -1,0 +1,10 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [load_nif/2]).
+
+start() ->
+  Path = "my_nif",
+  LoadInfo = 0,
+  test:caught(fun () ->
+    load_nif(Path, LoadInfo)
+  end).

--- a/native_implemented/otp/tests/internal/lib/erlang/nif_error_1.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/nif_error_1.rs
@@ -1,0 +1,1 @@
+test_stdout!(errors_with_reason, "{caught, error, reason}\n");

--- a/native_implemented/otp/tests/internal/lib/erlang/nif_error_1/errors_with_reason/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/nif_error_1/errors_with_reason/init.erl
@@ -1,0 +1,8 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [nif_error/1]).
+
+start() ->
+  test:caught(fun () ->
+    nif_error(reason)
+  end).


### PR DESCRIPTION
# Changelog
## Enhancements
* Minimal stubs for `nif_error/1` and `load_nif/2` to allow linking in `lumen/otp`.
  * NIFs cannot actually be loaded, but instead `erlang:load_nif/2` works similar to how it works with HiPE - it just returns `{error, {notsup, string()}}`.  This will allow for `lumen/otp` modules to be linked even if they would fail at runtime.