### PR TITLE
Global dynamic

### DIFF
--- a/compiler/codegen/src/builder/ffi.rs
+++ b/compiler/codegen/src/builder/ffi.rs
@@ -372,6 +372,22 @@ extern "C" {
         err_argc: libc::c_uint,
     );
 
+    pub fn MLIRBuildGlobalDynamicCall(
+        builder: ModuleBuilderRef,
+        loc: LocationRef,
+        module: ValueRef,
+        function: ValueRef,
+        argv: *const ValueRef,
+        argc: libc::c_uint,
+        is_tail: bool,
+        ok_block: BlockRef,
+        ok_argv: *const ValueRef,
+        ok_argc: libc::c_uint,
+        err_block: BlockRef,
+        err_argv: *const ValueRef,
+        err_argc: libc::c_uint,
+    );
+
     pub fn MLIRBuildClosureCall(
         builder: ModuleBuilderRef,
         loc: LocationRef,

--- a/compiler/codegen/src/builder/function.rs
+++ b/compiler/codegen/src/builder/function.rs
@@ -1370,7 +1370,8 @@ impl<'f, 'o> ScopedFunctionBuilder<'f, 'o> {
                 debug_in!(self, "operator = {:?}", kind);
                 assert_eq!(
                     num_reads, 2,
-                    "expected logical operations to have two operands"
+                    "expected logical operation ({:?}) to have two operands",
+                    kind
                 );
                 let lhs = self.build_value(reads[0])?;
                 let rhs = self.build_value(reads[1])?;

--- a/compiler/codegen/src/builder/ops/builders/call.rs
+++ b/compiler/codegen/src/builder/ops/builders/call.rs
@@ -67,6 +67,35 @@ impl CallBuilder {
 
                 Ok(None)
             }
+            Callee::GlobalDynamic {
+                module,
+                function,
+                arity,
+            } => {
+                builder.debug(&format!("globally dynamic target with arity {}", arity));
+
+                let module_ref = builder.value_ref(module);
+                let function_ref = builder.value_ref(function);
+                unsafe {
+                    MLIRBuildGlobalDynamicCall(
+                        builder.as_ref(),
+                        op.loc,
+                        module_ref,
+                        function_ref,
+                        args.as_ptr(),
+                        args.len() as libc::c_uint,
+                        op.is_tail,
+                        ok_block,
+                        ok_args.as_ptr(),
+                        ok_args.len() as libc::c_uint,
+                        err_block,
+                        err_args.as_ptr(),
+                        err_args.len() as libc::c_uint,
+                    );
+                }
+
+                Ok(None)
+            }
             Callee::Static(ref ident) => {
                 builder.debug(&format!("static call target is {}", ident));
 

--- a/compiler/codegen_llvm/lib/lumen/EIR/Builder/ModuleBuilder.h
+++ b/compiler/codegen_llvm/lib/lumen/EIR/Builder/ModuleBuilder.h
@@ -73,6 +73,12 @@ class ModuleBuilder {
   void build_static_call(Location loc, StringRef target, ArrayRef<Value> args,
                          bool isTail, Block *ok, ArrayRef<Value> okArgs);
 
+  void build_global_dynamic_call(Location loc,
+                                 Value module, Value function, ArrayRef<Value> args,
+                                 bool isTail,
+                                 Block *ok, ArrayRef<Value> okArgs,
+                                 Block *err, ArrayRef<Value> errArgs);
+
   void build_closure_call(Location loc, Value closure, ArrayRef<Value> args,
                           bool isTail, Block *ok, ArrayRef<Value> okArgs,
                           Block *err, ArrayRef<Value> errArgs);

--- a/compiler/codegen_llvm/lib/lumen/EIR/IR/EIROps.cpp
+++ b/compiler/codegen_llvm/lib/lumen/EIR/IR/EIROps.cpp
@@ -112,6 +112,55 @@ ArrayRef<Type> FuncOp::getCallableResults() {
 }
 
 //===----------------------------------------------------------------------===//
+// eir.call_global_dynamic
+//===----------------------------------------------------------------------===//
+namespace {
+struct CallGlobalDynamicOpToCallOpErlangApply3
+    : public OpRewritePattern<CallGlobalDynamicOp> {
+  using OpRewritePattern<CallGlobalDynamicOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(CallGlobalDynamicOp callGlobalDynamic,
+                                PatternRewriter &rewriter) const override {
+      auto calleeSymbol = rewriter.getSymbolRefAttr("erlang:apply/3");
+      auto termTy = rewriter.getType<TermType>();
+
+      SmallVector<Value, 3> args;
+      args.push_back(callGlobalDynamic.getTargetModule());
+      args.push_back(callGlobalDynamic.getTargetFunction());
+
+      // convert arg operands to a list
+
+      auto constantNilOp = rewriter.create<ConstantNilOp>(callGlobalDynamic.getLoc());
+      auto castOp = rewriter.create<CastOp>(callGlobalDynamic.getLoc(), constantNilOp, termTy);
+      auto tail = castOp.getResult();
+
+      if (callGlobalDynamic.getNumArgOperands() > 0) {
+          auto argOperands = callGlobalDynamic.getArgOperands();
+
+          for (auto i = argOperands.size(); i--;) {
+              auto consOp = rewriter.create<ConsOp>(callGlobalDynamic.getLoc(), argOperands[i], tail);
+              auto castOp = rewriter.create<CastOp>(callGlobalDynamic.getLoc(), consOp, termTy);
+              tail = castOp.getResult();
+          }
+      }
+
+      args.push_back(tail);
+
+      // Replace with a call of `erlang:apply/3`
+      SmallVector<Type, 1> resultTypes{termTy};
+      rewriter.replaceOpWithNewOp<CallOp>(callGlobalDynamic, calleeSymbol, resultTypes, args, callGlobalDynamic.getAttrs());
+
+      return success();
+  }
+};
+} // end anonymous namespace;
+
+void CallGlobalDynamicOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<CallGlobalDynamicOpToCallOpErlangApply3>(context);
+}
+
+//===----------------------------------------------------------------------===//
 // eir.call_indirect
 //===----------------------------------------------------------------------===//
 namespace {
@@ -1203,6 +1252,69 @@ Optional<MutableOperandRange> InvokeOp::getMutableSuccessorOperands(
     unsigned index) {
   assert(index < getNumSuccessors() && "invalid successor index");
   return index == okIndex ? llvm::None : Optional(errDestOperandsMutable());
+}
+
+//===----------------------------------------------------------------------===//
+// eir.invoke_global_dynamic
+//===----------------------------------------------------------------------===//
+namespace {
+struct InvokeGlobalDynamicOpToInvokeOpErlangApply3
+    : public OpRewritePattern<InvokeGlobalDynamicOp> {
+  using OpRewritePattern<InvokeGlobalDynamicOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(InvokeGlobalDynamicOp invokeGlobalDynamic,
+                                PatternRewriter &rewriter) const override {
+      auto calleeSymbol = rewriter.getSymbolRefAttr("erlang:apply/3");
+
+      SmallVector<Value, 3> args;
+      args.push_back(invokeGlobalDynamic.getTargetModule());
+      args.push_back(invokeGlobalDynamic.getTargetFunction());
+
+      auto termTy = rewriter.getType<TermType>();
+
+      // convert arg operands to a list
+
+      auto constantNilOp = rewriter.create<ConstantNilOp>(invokeGlobalDynamic.getLoc());
+      auto castOp = rewriter.create<CastOp>(invokeGlobalDynamic.getLoc(), constantNilOp, termTy);
+      auto tail = castOp.getResult();
+
+      if (invokeGlobalDynamic.getNumArgOperands() > 0) {
+          auto argOperands = invokeGlobalDynamic.getArgOperands();
+
+          for (auto i = argOperands.size(); i--;) {
+             auto consOp = rewriter.create<ConsOp>(invokeGlobalDynamic.getLoc(), argOperands[i], tail);
+             auto castOp = rewriter.create<CastOp>(invokeGlobalDynamic.getLoc(), consOp, termTy);
+             tail = castOp.getResult();
+          }
+      }
+
+      args.push_back(tail);
+
+      auto ok = invokeGlobalDynamic.okDest();
+      auto okArgs = invokeGlobalDynamic.okDestOperands();
+
+      auto err = invokeGlobalDynamic.errDest();
+      auto errArgs = invokeGlobalDynamic.errDestOperands();
+
+      // Replace with an invoke of `erlang:apply/3`
+      rewriter.replaceOpWithNewOp<InvokeOp>(invokeGlobalDynamic,
+                                            calleeSymbol, args,
+                                            ok, okArgs,
+                                            err, errArgs);
+      return success();
+  }
+};
+} // end anonymous namespace.
+
+void InvokeGlobalDynamicOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<InvokeGlobalDynamicOpToInvokeOpErlangApply3>(context);
+}
+
+Optional<MutableOperandRange> InvokeGlobalDynamicOp::getMutableSuccessorOperands(
+    unsigned index) {
+  assert(index < getNumSuccessors() && "invalid successor index");
+  return index == okIndex ? okDestOperandsMutable() : errDestOperandsMutable();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/codegen_llvm/lib/lumen/EIR/IR/EIROps.td
+++ b/compiler/codegen_llvm/lib/lumen/EIR/IR/EIROps.td
@@ -508,7 +508,7 @@ def eir_BranchOp : eir_Op<"br",
 }
 
 def eir_CondBranchOp : eir_Op<"cond_br",
-  [AttrSizedOperandSegments, 
+  [AttrSizedOperandSegments,
    DeclareOpInterfaceMethods<BranchOpInterface, ["getSuccessorForOperands"]>,
    NoSideEffect, Terminator]> {
   let summary = "conditional branch operation";
@@ -926,40 +926,44 @@ def eir_LandingPadOp : eir_Op<"landing_pad", []> {
   ];
 }
 
-def ApplyOp : eir_Op<"apply", []> {
-  let summary = "dynamic call operation";
+def CallGlobalDynamicOp : eir_Op<"call_global_dynamic", []> {
+  let summary = "call operation to for M:F(A...)";
   let description = [{
-    The "apply" operation represents an dynamic call to an MFA.
+      Calls a dynamic functon in a dynamic module with a fixed number of arguments.
 
-    The first two operands are the module, and function; the arity
-    is inferred by the number of arguments passed.
+      The first two operands are the module, and function; the arity
+      is inferred by the number of arguments passed.
 
-      %0 = eir.constant.atom { value = "erlang" }
-      %1 = eir.constant.atom { value = "+" }
-      %4 = eir.apply [%0, %1](%2, %3) : (f32, f32) -> f32
+        %0 = eir.constant.atom { value = "erlang" }
+        %1 = eir.constant.atom { value = "+" }
+        %4 = eir.call_global_dynamic [%0, %1](%2, %3) : (f32, f32) -> f32
   }];
 
-  let arguments = (ins eir_AnyType:$module, eir_AnyType:$fun, Variadic<eir_AnyType>:$operands);
+  let arguments = (ins eir_AnyType:$module, eir_AnyType:$function, Variadic<eir_AnyType>:$operands);
   let results = (outs eir_AnyType:$result);
 
   let skipDefaultBuilders = 1;
   let builders = [OpBuilder<
-    "OpBuilder &builder, OperationState &result, Value module, Value fun,"
+    "OpBuilder &builder, OperationState &result, Value module, Value function,"
     "ValueRange operands = {}", [{
       result.operands.push_back(module);
-      result.operands.push_back(fun);
+      result.operands.push_back(function);
       result.addOperands(operands);
       result.addTypes(builder.getType<TermType>());
   }]>];
 
+  let hasCanonicalizer = 1;
+
   let extraClassDeclaration = [{
     Value getTargetModule() { return getOperand(0); }
-    Value getTargetFun() { return getOperand(1); }
+    Value getTargetFunction() { return getOperand(1); }
 
     /// Get the argument operands to the called function.
     operand_range getArgOperands() {
       return {arg_operand_begin(), arg_operand_end()};
     }
+
+    unsigned getNumArgOperands() { return getArgOperands().size(); }
 
     operand_iterator arg_operand_begin() { return operand_begin() + 2; }
     operand_iterator arg_operand_end() { return operand_end(); }
@@ -967,7 +971,60 @@ def ApplyOp : eir_Op<"apply", []> {
 
   let verifier = ?;
 
-  let assemblyFormat = "`[` $module `:` type($module) `,` $fun `:` type($fun) `]` `(` $operands `)` attr-dict `:` functional-type($operands, $result)";
+  let assemblyFormat = "`[` $module `:` type($module) `,` $function `:` type($function) `]` `(` $operands `)` attr-dict `:` functional-type($operands, $result)";
+}
+
+def eir_InvokeGlobalDynamicOp : eir_InvokeBaseOp<"invoke_global_dynamic", []> {
+  let summary = "call operation for M:F(A...) that may raise exceptions";
+  let description = [{
+    Calls a dynamic function in a dynamic module with a fixed number of arguments, uses the provided ok/err blocks
+    to handle the flow of control upon return of the callee, based on whether
+    an exception was raised or not.
+  }];
+
+  let arguments = (ins
+    eir_AnyType:$module,
+    eir_AnyType:$function,
+    Variadic<eir_AnyType>:$operands,
+    Variadic<AnyType>:$okDestOperands,
+    Variadic<AnyType>:$errDestOperands
+  );
+  let results = (outs eir_AnyType:$result);
+
+  let assemblyFormat = [{
+    `[` $module `:` type($module) `,` $function `:` type($function) `]` (`(` $operands^ `:` type($operands) `)`)? `to`
+      $okDest (`(` $okDestOperands^ `:` type($okDestOperands) `)`)? `unwind`
+      $errDest (`(` $errDestOperands^ `:` type($errDestOperands) `)`)?
+      attr-dict `:` type(results)
+  }];
+
+  let builders = [
+    OpBuilder<[{
+      OpBuilder &builder, OperationState &result,
+      Value module, Value function, ValueRange operands,
+      Block *okDest, ValueRange okDestOperands,
+      Block *errDest, ValueRange errDestOperands
+    }], [{
+      Type resultType = builder.getType<TermType>();
+      build(builder, result,
+            resultType, module, function, operands,
+            okDestOperands, errDestOperands,
+            okDest, errDest);
+    }]>,
+  ];
+
+  let hasCanonicalizer = 1;
+  let verifier = ?;
+
+  let extraExtraClassDeclaration = [{
+    Value getTargetModule() { return module(); }
+    Value getTargetFunction() { return function(); }
+
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() { return operands(); }
+
+    unsigned getNumArgOperands() { return getArgOperands().size(); }
+  }];
 }
 
 def CallClosureOp : eir_Op<"call_closure", []> {

--- a/lumen/tests/global_dynamic.rs
+++ b/lumen/tests/global_dynamic.rs
@@ -1,0 +1,57 @@
+use std::process::{Command, Stdio};
+use std::sync::Once;
+
+#[test]
+fn without_arguments_calls_global_dynamic_functions() {
+    ensure_compiled();
+
+    let cli_output = Command::new("./global_dynamic")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&cli_output.stdout);
+    let stderr = String::from_utf8_lossy(&cli_output.stderr);
+
+    assert_eq!(
+        String::from_utf8_lossy(&cli_output.stdout),
+        "{alice, says, hello, to, bob}\n{eve, overhears}\n",
+        "\nstdout = {}\nstderr = {}",
+        stdout,
+        stderr
+    );
+}
+
+static COMPILED: Once = Once::new();
+
+fn ensure_compiled() {
+    COMPILED.call_once(|| {
+        compile();
+    })
+}
+
+fn compile() {
+    let mut command = Command::new("../bin/lumen");
+
+    command
+        .arg("compile")
+        .arg("--output-dir")
+        .arg("_build")
+        .arg("--output")
+        .arg("global_dynamic")
+        // Turn off optimizations as work-around for debug info bug in EIR
+        .arg("-O0");
+
+    let compile_output = command
+        .arg("tests/global_dynamic/init.erl")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    assert!(
+        compile_output.status.success(),
+        "stdout = {}\nstderr = {}",
+        String::from_utf8_lossy(&compile_output.stdout),
+        String::from_utf8_lossy(&compile_output.stderr)
+    );
+}

--- a/lumen/tests/global_dynamic/init.erl
+++ b/lumen/tests/global_dynamic/init.erl
@@ -1,0 +1,19 @@
+-module(init).
+-export([hello/2, listen/1, start/0]).
+-import(erlang, [display/1, print/1]).
+
+start() ->
+  global_dynamic(init, hello, [alice, bob]),
+  global_dynamic(init, listen, [eve]).
+
+
+global_dynamic(M, F, [A]) ->
+  M:F(A);
+global_dynamic(M, F, [A, B]) ->
+  M:F(A, B).
+
+hello(Speaker, Listener) ->
+  display({Speaker, says, hello, to, Listener}).
+
+listen(Listener) ->
+  display({Listener, overhears}).


### PR DESCRIPTION
Fixes #599 

# Changelog
## Enhancements
* Include logical operation `kind` when `num_reads` assertion fails.
* Test for `GlobalDynamic` in the `lumen` crate.

## Bug Fixes
* Implement Callee::GlobalDynamic
  Lower as new InvokeApplyOp when invoke is needed or CallApplyOp when invoke is not needed.  Convert both of those to either invoke or call or `erlang:apply/3`.
