### PR TITLE
Support variadic logic and and or from EIR

### DIFF
--- a/compiler/codegen/src/builder/ffi.rs
+++ b/compiler/codegen/src/builder/ffi.rs
@@ -464,14 +464,14 @@ extern "C" {
     pub fn MLIRBuildLogicalAndOp(
         builder: ModuleBuilderRef,
         loc: LocationRef,
-        lhs: ValueRef,
-        rhs: ValueRef,
+        argv: *const ValueRef,
+        argc: libc::c_uint,
     ) -> ValueRef;
     pub fn MLIRBuildLogicalOrOp(
         builder: ModuleBuilderRef,
         loc: LocationRef,
-        lhs: ValueRef,
-        rhs: ValueRef,
+        argv: *const ValueRef,
+        argc: libc::c_uint,
     ) -> ValueRef;
 
     pub fn MLIRCons(

--- a/compiler/codegen/src/builder/function.rs
+++ b/compiler/codegen/src/builder/function.rs
@@ -1368,18 +1368,20 @@ impl<'f, 'o> ScopedFunctionBuilder<'f, 'o> {
             ir::PrimOpKind::LogicOp(kind) => {
                 debug_in!(self, "primop is logical operator");
                 debug_in!(self, "operator = {:?}", kind);
-                assert_eq!(
-                    num_reads, 2,
-                    "expected logical operation ({:?}) to have two operands",
+                assert!(
+                    num_reads >= 2,
+                    "expected logical operation ({:?}) to have at least two operands",
                     kind
                 );
-                let lhs = self.build_value(reads[0])?;
-                let rhs = self.build_value(reads[1])?;
+                let operands = reads
+                    .into_iter()
+                    .map(|read| self.build_value(read))
+                    .collect::<Result<Vec<Value>>>()?;
+
                 OpKind::LogicOp(LogicalOperator {
                     loc,
                     kind,
-                    lhs,
-                    rhs: Some(rhs),
+                    operands,
                 })
             }
             // (value)

--- a/compiler/codegen/src/builder/ops.rs
+++ b/compiler/codegen/src/builder/ops.rs
@@ -100,12 +100,11 @@ pub struct BinaryOperator {
     pub rhs: Value,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct LogicalOperator {
     pub loc: LocationRef,
     pub kind: ir::LogicOp,
-    pub lhs: Value,
-    pub rhs: Option<Value>,
+    pub operands: Vec<Value>,
 }
 
 #[derive(Debug, Clone)]

--- a/compiler/codegen/src/builder/ops/builders/logical_operators.rs
+++ b/compiler/codegen/src/builder/ops/builders/logical_operators.rs
@@ -11,12 +11,35 @@ impl LogicOpBuilder {
         op: LogicalOperator,
     ) -> Result<Option<Value>> {
         let builder_ref = builder.as_ref();
-        let lhs_ref = builder.value_ref(op.lhs);
-        let rhs_ref = op.rhs.map(|v| builder.value_ref(v)).unwrap_or_default();
+        let operand_refs = op
+            .operands
+            .iter()
+            .copied()
+            .map(|value| builder.value_ref(value))
+            .collect::<Vec<_>>();
+        builder.debug(&format!(
+            "logic operation ({:?}) operands: {:?}",
+            op.kind,
+            operand_refs.as_slice()
+        ));
 
         let result_ref = match op.kind {
-            LogicOp::And => unsafe { MLIRBuildLogicalAndOp(builder_ref, op.loc, lhs_ref, rhs_ref) },
-            LogicOp::Or => unsafe { MLIRBuildLogicalOrOp(builder_ref, op.loc, lhs_ref, rhs_ref) },
+            LogicOp::And => unsafe {
+                MLIRBuildLogicalAndOp(
+                    builder_ref,
+                    op.loc,
+                    operand_refs.as_ptr(),
+                    operand_refs.len() as libc::c_uint,
+                )
+            },
+            LogicOp::Or => unsafe {
+                MLIRBuildLogicalOrOp(
+                    builder_ref,
+                    op.loc,
+                    operand_refs.as_ptr(),
+                    operand_refs.len() as libc::c_uint,
+                )
+            },
             LogicOp::Eq => todo!("logical primop (eq)"),
         };
         assert!(!result_ref.is_null());

--- a/compiler/codegen_llvm/lib/lumen/EIR/Builder/ModuleBuilder.cpp
+++ b/compiler/codegen_llvm/lib/lumen/EIR/Builder/ModuleBuilder.cpp
@@ -874,32 +874,52 @@ Value ModuleBuilder::build_is_greater_than(Location loc, Value lhs, Value rhs) {
 
 extern "C" MLIRValueRef MLIRBuildLogicalAndOp(MLIRModuleBuilderRef b,
                                               MLIRLocationRef locref,
-                                              MLIRValueRef l, MLIRValueRef r) {
+                                              MLIRValueRef *argv, unsigned argc) {
   ModuleBuilder *builder = unwrap(b);
   Location loc = unwrap(locref);
-  Value lhs = unwrap(l);
-  Value rhs = unwrap(r);
-  return wrap(builder->build_logical_and(loc, lhs, rhs));
+
+  assert(argc >= 2 && "logical and operation does not have at least 2 operands");
+  SmallVector<Value, 2> args;
+  unwrapValues(argv, argc, args);
+
+  return wrap(builder->build_logical_and(loc, args));
 }
 
-Value ModuleBuilder::build_logical_and(Location loc, Value lhs, Value rhs) {
-  auto op = builder.create<LogicalAndOp>(loc, lhs, rhs);
-  return op.getResult();
+Value ModuleBuilder::build_logical_and(Location loc, ArrayRef<Value> args) {
+  auto begin = args.begin();
+  Value acc = *begin;
+
+  for (auto it = std::next(begin); it != args.end(); ++it) {
+    auto op = builder.create<LogicalAndOp>(loc, acc, *it);
+    acc = op.getResult();
+  }
+
+  return acc;
 }
 
 extern "C" MLIRValueRef MLIRBuildLogicalOrOp(MLIRModuleBuilderRef b,
                                              MLIRLocationRef locref,
-                                             MLIRValueRef l, MLIRValueRef r) {
+                                             MLIRValueRef *argv, unsigned argc) {
   ModuleBuilder *builder = unwrap(b);
   Location loc = unwrap(locref);
-  Value lhs = unwrap(l);
-  Value rhs = unwrap(r);
-  return wrap(builder->build_logical_or(loc, lhs, rhs));
+
+  assert(argc >= 2 && "logical or operation does not have at least 2 operands");
+  SmallVector<Value, 2> args;
+  unwrapValues(argv, argc, args);
+
+  return wrap(builder->build_logical_or(loc, args));
 }
 
-Value ModuleBuilder::build_logical_or(Location loc, Value lhs, Value rhs) {
-  auto op = builder.create<LogicalOrOp>(loc, lhs, rhs);
-  return op.getResult();
+Value ModuleBuilder::build_logical_or(Location loc, ArrayRef<Value> args) {
+  auto begin = args.begin();
+  Value acc = *begin;
+
+  for (auto it = std::next(begin); it != args.end(); ++it) {
+    auto op = builder.create<LogicalOrOp>(loc, acc, *it);
+    acc = op.getResult();
+  }
+
+  return acc;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/codegen_llvm/lib/lumen/EIR/Builder/ModuleBuilder.h
+++ b/compiler/codegen_llvm/lib/lumen/EIR/Builder/ModuleBuilder.h
@@ -100,8 +100,8 @@ class ModuleBuilder {
   Value build_is_less_than(Location loc, Value lhs, Value rhs);
   Value build_is_greater_than_or_equal(Location loc, Value lhs, Value rhs);
   Value build_is_greater_than(Location loc, Value lhs, Value rhs);
-  Value build_logical_and(Location loc, Value lhs, Value rhs);
-  Value build_logical_or(Location loc, Value lhs, Value rhs);
+  Value build_logical_and(Location loc, ArrayRef<Value> args);
+  Value build_logical_or(Location loc, ArrayRef<Value> args);
   Value build_cons(Location loc, Value head, Value tail);
   Value build_tuple(Location loc, ArrayRef<Value> elements);
   Value build_map(Location loc, ArrayRef<MapEntry> entries);


### PR DESCRIPTION
Fixes #603

# Changelog
## Bug Fixes
* Support variadic logic and and or from EIR
  * `LogicalOperator` has a `Vec` of `operands` now instead of just `rhs` and `lhs`.  The `operands` `Vec` is converted to a `Vec` of `ValueRef`s and passed to the `MLIRBuildLogic*Op` C functions as a `ptr` and `len` like the `argv` and `argc` of `*Call`.  When converting to MLIR `Operation`s though, the variadics are removed and instead a chain of `LogicalAndOp` or `LogicalOrOp` are constructed, so that the operation can continue to subclass `BinaryOperator`.