### PR TITLE
Migrate to environment files

### DIFF
--- a/.github/workflows/wasm32-unknown-unknown-macOS.yml
+++ b/.github/workflows/wasm32-unknown-unknown-macOS.yml
@@ -42,7 +42,7 @@ jobs:
           mv clang+llvm-12.0.0-x86_64-apple-darwin19.5.0 lumen
           popd
       - name: Set LLVM_PREFIX
-        run: echo "::set-env name=LLVM_PREFIX::$HOME/.local/share/llvm/lumen"
+        run: echo "LLVM_PREFIX=$HOME/.local/share/llvm/lumen" >> $GITHUB_ENV
       - name: Install Ninja
         run: brew install ninja
       - name: Cache Chrome Driver

--- a/.github/workflows/x86_64-apple-darwin-compiler.yml
+++ b/.github/workflows/x86_64-apple-darwin-compiler.yml
@@ -36,7 +36,7 @@ jobs:
           mv clang+llvm-12.0.0-x86_64-apple-darwin19.5.0 lumen
           popd
       - name: Set LLVM_PREFIX
-        run: echo "::set-env name=LLVM_PREFIX::$HOME/.local/share/llvm/lumen"
+        run: echo "LLVM_PREFIX=$HOME/.local/share/llvm/lumen" >> $GITHUB_ENV
       - name: Install Ninja
         run: brew install ninja
       - name: Make Build
@@ -44,7 +44,7 @@ jobs:
           RUST_BACKTRACE: full
         run: |
           make build-shared
-          echo "::add-path::$PWD/bin"
+          echo "$PWD/bin" >> $GITHUB_PATH
       - name: Lumen Test
         run: cargo test --package lumen --no-fail-fast
       - name: liblumen_otp Integration tests

--- a/.github/workflows/x86_64-apple-darwin-libraries.yml
+++ b/.github/workflows/x86_64-apple-darwin-libraries.yml
@@ -36,7 +36,7 @@ jobs:
           mv clang+llvm-12.0.0-x86_64-apple-darwin19.5.0 lumen
           popd
       - name: Set LLVM_PREFIX
-        run: echo "::set-env name=LLVM_PREFIX::$HOME/.local/share/llvm/lumen"
+        run: echo "LLVM_PREFIX=$HOME/.local/share/llvm/lumen" >> $GITHUB_ENV
       - name: Install Ninja
         run: brew install ninja
       - name: Test liblumen_arena

--- a/.github/workflows/x86_64-apple-darwin-lumen-otp.yml
+++ b/.github/workflows/x86_64-apple-darwin-lumen-otp.yml
@@ -36,7 +36,7 @@ jobs:
           mv clang+llvm-12.0.0-x86_64-apple-darwin19.5.0 lumen
           popd
       - name: Set LLVM_PREFIX
-        run: echo "::set-env name=LLVM_PREFIX::$HOME/.local/share/llvm/lumen"
+        run: echo "LLVM_PREFIX=$HOME/.local/share/llvm/lumen" >> $GITHUB_ENV
       - name: Install Ninja
         run: brew install ninja
       - name: Make Build
@@ -46,7 +46,7 @@ jobs:
           cd ..
           git init otp
           cd otp
-          echo "::set-env name=ERL_TOP::$PWD"
+          echo "ERL_TOP=$PWD" >> $GITHUB_ENV
           git remote add origin https://github.com/lumen/otp
           git fetch --no-tags --prune --progress --depth=1 origin +ca83f680aab717fe65634247d16f18a8cbfc6d8d:refs/remotes/origin/lumen
           git checkout --progress --force -B lumen refs/remotes/origin/lumen

--- a/.github/workflows/x86_64-apple-darwin-runtime_full.yml
+++ b/.github/workflows/x86_64-apple-darwin-runtime_full.yml
@@ -36,7 +36,7 @@ jobs:
           mv clang+llvm-12.0.0-x86_64-apple-darwin19.5.0 lumen
           popd
       - name: Set LLVM_PREFIX
-        run: echo "::set-env name=LLVM_PREFIX::$HOME/.local/share/llvm/lumen"
+        run: echo "LLVM_PREFIX=$HOME/.local/share/llvm/lumen" >> $GITHUB_ENV
       - name: Install Ninja
         run: brew install ninja
       - name: Make Build

--- a/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-compiler.yml
@@ -21,7 +21,7 @@ jobs:
           RUST_BACKTRACE: full
         run: |
           make build-shared
-          echo "::add-path::$PWD/bin"
+          echo "$PWD/bin" >> $GITHUB_PATH
       - name: Lumen Test
         run: cargo test --package lumen --no-fail-fast
       - name: liblumen_otp Integration Tests

--- a/.github/workflows/x86_64-unknown-linux-gnu-lumen-otp.yml
+++ b/.github/workflows/x86_64-unknown-linux-gnu-lumen-otp.yml
@@ -23,7 +23,7 @@ jobs:
           cd ..
           git init otp
           cd otp
-          echo "::set-env name=ERL_TOP::$PWD"
+          echo "ERL_TOP=$PWD" >> $GITHUB_ENV
           git remote add origin https://github.com/lumen/otp
           git fetch --no-tags --prune --progress --depth=1 origin +ca83f680aab717fe65634247d16f18a8cbfc6d8d:refs/remotes/origin/lumen
           git checkout --progress --force -B lumen refs/remotes/origin/lumen


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Migrate to environment files
  Followed [GitHub Changelog blog post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) to change deprecated `set-env` and `add-path` to appending to `$GITHUB_ENV` and `$GITHUB_PATH`, respectively as shown in [`environment files` docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).  Protects us from [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w).