### PR TITLE
Stub out seq_tracer.erl dependencies to fix linking

### DIFF
--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -124,6 +124,7 @@ pub mod map_get_2;
 pub mod map_size_1;
 pub mod max_2;
 pub mod min_2;
+pub mod module_loaded_1;
 pub mod monitor_2;
 pub mod monotonic_time_0;
 pub mod monotonic_time_1;

--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -172,6 +172,7 @@ mod string_to_float;
 mod string_to_integer;
 pub mod subtract_2;
 pub mod subtract_list_2;
+pub mod system_info_1;
 pub mod system_time_0;
 pub mod system_time_1;
 mod term_to_binary;

--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -153,6 +153,7 @@ pub mod send_2;
 pub mod send_3;
 pub mod send_after_3;
 pub mod send_after_4;
+pub mod seq_trace_info_1;
 pub mod seq_trace_print_1;
 pub mod setelement_3;
 pub mod size_1;

--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -153,6 +153,7 @@ pub mod send_2;
 pub mod send_3;
 pub mod send_after_3;
 pub mod send_after_4;
+pub mod seq_trace_print_1;
 pub mod setelement_3;
 pub mod size_1;
 pub mod spawn_1;

--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -174,6 +174,7 @@ mod string_to_float;
 mod string_to_integer;
 pub mod subtract_2;
 pub mod subtract_list_2;
+pub mod system_flag_2;
 pub mod system_info_1;
 pub mod system_time_0;
 pub mod system_time_1;

--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -153,6 +153,8 @@ pub mod send_2;
 pub mod send_3;
 pub mod send_after_3;
 pub mod send_after_4;
+pub mod seq_trace;
+pub mod seq_trace_2;
 pub mod seq_trace_info_1;
 pub mod seq_trace_print_1;
 pub mod seq_trace_print_2;

--- a/native_implemented/otp/src/erlang.rs
+++ b/native_implemented/otp/src/erlang.rs
@@ -155,6 +155,7 @@ pub mod send_after_3;
 pub mod send_after_4;
 pub mod seq_trace_info_1;
 pub mod seq_trace_print_1;
+pub mod seq_trace_print_2;
 pub mod setelement_3;
 pub mod size_1;
 pub mod spawn_1;

--- a/native_implemented/otp/src/erlang/function_exported_3.rs
+++ b/native_implemented/otp/src/erlang/function_exported_3.rs
@@ -9,11 +9,10 @@ use std::convert::TryInto;
 
 use anyhow::*;
 
+use liblumen_alloc::erts::apply::find_symbol;
 use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::term::prelude::{Atom, Term};
 use liblumen_alloc::{Arity, ModuleFunctionArity};
-
-use liblumen_alloc::erts::apply::find_symbol;
 
 #[native_implemented::function(erlang:function_exported/3)]
 pub fn result(module: Term, function: Term, arity: Term) -> exception::Result<Term> {

--- a/native_implemented/otp/src/erlang/module_loaded_1.rs
+++ b/native_implemented/otp/src/erlang/module_loaded_1.rs
@@ -1,0 +1,10 @@
+use liblumen_alloc::erts::apply::module_loaded;
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::term::prelude::*;
+
+#[native_implemented::function(erlang:module_loaded/1)]
+pub fn result(module: Term) -> exception::Result<Term> {
+    let module_atom = term_try_into_atom!(module)?;
+
+    Ok(module_loaded(module_atom).into())
+}

--- a/native_implemented/otp/src/erlang/seq_trace.rs
+++ b/native_implemented/otp/src/erlang/seq_trace.rs
@@ -1,0 +1,8 @@
+use anyhow::*;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::term::prelude::*;
+
+pub fn flag_is_not_a_supported_atom(flag: Term) -> exception::Result<Term> {
+    Err(anyhow!("flag ({}) is not a supported atom (label, monotonic_timestamp, print, receive, send, serial, spawn, strict_monotonic_timestamp, or timestamp)", flag).into())
+}

--- a/native_implemented/otp/src/erlang/seq_trace_2.rs
+++ b/native_implemented/otp/src/erlang/seq_trace_2.rs
@@ -1,0 +1,23 @@
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::term::prelude::*;
+
+use super::seq_trace::flag_is_not_a_supported_atom;
+
+// See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1705-L1828
+#[native_implemented::function(erlang:seq_trace/2)]
+pub fn result(flag: Term, _value: Term) -> exception::Result<Term> {
+    let flag_name = term_try_into_atom!(flag)?.name();
+
+    match flag_name {
+        "label" => unimplemented!(),
+        "monotonic_timestamp" => unimplemented!(),
+        "print" => unimplemented!(),
+        "receive" => unimplemented!(),
+        "send" => unimplemented!(),
+        "serial" => unimplemented!(),
+        "spawn" => unimplemented!(),
+        "strict_monotonic_timestamp" => unimplemented!(),
+        "timestamp" => unimplemented!(),
+        _ => flag_is_not_a_supported_atom(flag),
+    }
+}

--- a/native_implemented/otp/src/erlang/seq_trace_info_1.rs
+++ b/native_implemented/otp/src/erlang/seq_trace_info_1.rs
@@ -1,0 +1,36 @@
+use anyhow::*;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::process::Process;
+use liblumen_alloc::erts::term::prelude::*;
+
+// See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1855-L1917
+#[native_implemented::function(erlang:seq_trace_info/1)]
+pub fn result(process: &Process, item: Term) -> exception::Result<Term> {
+    let item_name = term_try_into_atom!(item)?.name();
+
+    // Stub as if seq tracing is ALWAYS NOT enabled
+    // See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1865-L1879
+    match item_name {
+        "label" => Ok(label(process, item)),
+        "monotonic_timestamp" | "print" | "receive" | "send" | "spawn" | "strict_monotonic_timestamp" | "timestamp" => Ok(boolean_item(process, item)),
+        "serial" => Ok(serial(process, item)),
+        _ => Err(anyhow!("item ({}) is not a supported atom (label, monotonic_timestamp, print, receive, send, serial, spawn, strict_monotonic_timestamp, or timestamp)").into())
+    }
+}
+
+fn boolean_item(process: &Process, item: Term) -> Term {
+    tagged(process, item, false.into())
+}
+
+fn label(process: &Process, item: Term) -> Term {
+    tagged(process, item, Term::NIL)
+}
+
+fn serial(process: &Process, item: Term) -> Term {
+    tagged(process, item, Term::NIL)
+}
+
+fn tagged(process: &Process, tag: Term, value: Term) -> Term {
+    process.tuple_from_slice(&[tag, value])
+}

--- a/native_implemented/otp/src/erlang/seq_trace_info_1.rs
+++ b/native_implemented/otp/src/erlang/seq_trace_info_1.rs
@@ -1,21 +1,27 @@
-use anyhow::*;
-
 use liblumen_alloc::erts::exception;
 use liblumen_alloc::erts::process::Process;
 use liblumen_alloc::erts::term::prelude::*;
 
+use super::seq_trace::flag_is_not_a_supported_atom;
+
 // See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1855-L1917
 #[native_implemented::function(erlang:seq_trace_info/1)]
-pub fn result(process: &Process, item: Term) -> exception::Result<Term> {
-    let item_name = term_try_into_atom!(item)?.name();
+pub fn result(process: &Process, flag: Term) -> exception::Result<Term> {
+    let flag_name = term_try_into_atom!(flag)?.name();
 
     // Stub as if seq tracing is ALWAYS NOT enabled
     // See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1865-L1879
-    match item_name {
-        "label" => Ok(label(process, item)),
-        "monotonic_timestamp" | "print" | "receive" | "send" | "spawn" | "strict_monotonic_timestamp" | "timestamp" => Ok(boolean_item(process, item)),
-        "serial" => Ok(serial(process, item)),
-        _ => Err(anyhow!("item ({}) is not a supported atom (label, monotonic_timestamp, print, receive, send, serial, spawn, strict_monotonic_timestamp, or timestamp)").into())
+    match flag_name {
+        "label" => Ok(label(process, flag)),
+        "monotonic_timestamp"
+        | "print"
+        | "receive"
+        | "send"
+        | "spawn"
+        | "strict_monotonic_timestamp"
+        | "timestamp" => Ok(boolean_item(process, flag)),
+        "serial" => Ok(serial(process, flag)),
+        _ => flag_is_not_a_supported_atom(flag),
     }
 }
 

--- a/native_implemented/otp/src/erlang/seq_trace_print_1.rs
+++ b/native_implemented/otp/src/erlang/seq_trace_print_1.rs
@@ -1,0 +1,9 @@
+use liblumen_alloc::erts::term::prelude::*;
+
+// See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1919-L1936
+#[native_implemented::function(erlang:seq_trace_print/1)]
+pub fn result(_message: Term) -> Term {
+    // Stub as if `tracing_token` is not set
+    // See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1930
+    false.into()
+}

--- a/native_implemented/otp/src/erlang/seq_trace_print_2.rs
+++ b/native_implemented/otp/src/erlang/seq_trace_print_2.rs
@@ -1,0 +1,9 @@
+use liblumen_alloc::erts::term::prelude::*;
+
+// See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1938-L1957
+#[native_implemented::function(erlang:seq_trace_print/2)]
+pub fn result(_label: Term, _message: Term) -> Term {
+    // Stub as if seq_trace token is always not set
+    // See https://github.com/lumen/otp/blob/30e2bfb9f1fd5c65bd7d9a4159f88cdcf72023fa/erts/emulator/beam/erl_bif_trace.c#L1948-L1950
+    false.into()
+}

--- a/native_implemented/otp/src/erlang/system_flag_2.rs
+++ b/native_implemented/otp/src/erlang/system_flag_2.rs
@@ -1,0 +1,35 @@
+use anyhow::*;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::term::prelude::*;
+
+#[native_implemented::function(erlang:system_flag/2)]
+pub fn result(flag: Term, _value: Term) -> exception::Result<Term> {
+    let flag_atom = term_try_into_atom!(flag)?;
+
+    match flag_atom.name() {
+        "backtrace_depth" => unimplemented!(),
+        "cpu_topology" => unimplemented!(),
+        "dirty_cpu_schedulers_online" => unimplemented!(),
+        "erts_alloc" => unimplemented!(),
+        "fullsweep_after" => unimplemented!(),
+        "microstate_accounting" => unimplemented!(),
+        "min_heap_size" => unimplemented!(),
+        "min_bin_vheap_size" => unimplemented!(),
+        "max_heap_size" => unimplemented!(),
+        "multi_scheduling" => unimplemented!(),
+        "scheduler_bind_type" => unimplemented!(),
+        "schedulers_online" => unimplemented!(),
+        "system_logger" => unimplemented!(),
+        "trace_control_word" => unimplemented!(),
+        "time_offset" => unimplemented!(),
+        _ => Err(anyhow!(
+            "flag ({}) is not supported (backtrace_depth, cpu_topology, \
+             dirty_cpu_schedulers_online, erts_alloc, fullsweep_after, microstate_accounting, \
+             min_heap_size, min_bin_vheap_size, max_heap_size, multi_scheduling, \
+             scheduler_bind_type, schedulers_online, system_logger, trace_control_word, \
+             time_offset)"
+        )
+        .into()),
+    }
+}

--- a/native_implemented/otp/src/erlang/system_info_1.rs
+++ b/native_implemented/otp/src/erlang/system_info_1.rs
@@ -1,0 +1,154 @@
+use anyhow::*;
+
+use liblumen_alloc::erts::exception;
+use liblumen_alloc::erts::term::prelude::*;
+
+#[native_implemented::function(erlang:system_info/1)]
+pub fn result(item: Term) -> exception::Result<Term> {
+    match item.decode().unwrap() {
+        TypedTerm::Atom(atom) => match atom.name() {
+            "alloc_util_allocators" => unimplemented!(),
+            "allocated_areas" => unimplemented!(),
+            "allocator" => unimplemented!(),
+            "atom_count" => unimplemented!(),
+            "atom_limit" => unimplemented!(),
+            "build_type" => unimplemented!(),
+            "c_compiler_used" => unimplemented!(),
+            "check_io" => unimplemented!(),
+            "compat_rel" => unimplemented!(),
+            "cpu_quota" => unimplemented!(),
+            "cpu_topology" => unimplemented!(),
+            "creation" => unimplemented!(),
+            "debug_compiled" => unimplemented!(),
+            "delayed_node_table_gc" => unimplemented!(),
+            "dirty_cpu_schedulers" => unimplemented!(),
+            "dirty_cpu_schedulers_online" => unimplemented!(),
+            "dirty_io_schedulers" => unimplemented!(),
+            "dist" => unimplemented!(),
+            "dist_buf_busy_limit" => unimplemented!(),
+            "dist_ctrl" => unimplemented!(),
+            "driver_version" => unimplemented!(),
+            "dynamic_trace" => unimplemented!(),
+            "dynamic_trace_probes" => unimplemented!(),
+            "elib_malloc" => unimplemented!(),
+            "end_time" => unimplemented!(),
+            "ets_count" => unimplemented!(),
+            "ets_limit" => unimplemented!(),
+            "fullsweep_after" => unimplemented!(),
+            "garbage_collection" => unimplemented!(),
+            "heap_sizes" => unimplemented!(),
+            "heap_type" => unimplemented!(),
+            "info" => unimplemented!(),
+            "kernel_poll" => unimplemented!(),
+            "loaded" => unimplemented!(),
+            "logic_processors" => unimplemented!(),
+            "logic_processors_available" => unimplemented!(),
+            "logical_processors_online" => unimplemented!(),
+            "machine" => unimplemented!(),
+            "max_heap_size" => unimplemented!(),
+            "message_queue_data" => unimplemented!(),
+            "min_bin_vheap_size" => unimplemented!(),
+            "min_heap_size" => unimplemented!(),
+            "modified_timing_level" => unimplemented!(),
+            "multi_scheduling" => unimplemented!(),
+            "multi_scheduling_blockers" => unimplemented!(),
+            "nif_version" => unimplemented!(),
+            "normal_multi_scheduling_blockers" => unimplemented!(),
+            "os_monotonic_time_source" => unimplemented!(),
+            "os_system_time_source" => unimplemented!(),
+            "otp_release" => unimplemented!(),
+            "port_count" => unimplemented!(),
+            "port_limit" => unimplemented!(),
+            "port_parallelism" => unimplemented!(),
+            "process_count" => unimplemented!(),
+            "process_limit" => unimplemented!(),
+            "procs" => unimplemented!(),
+            "scheduler_bind_type" => unimplemented!(),
+            "scheduler_bindings" => unimplemented!(),
+            "scheduler_id" => unimplemented!(),
+            "schedulers" => unimplemented!(),
+            "schedulers_online" => unimplemented!(),
+            "sequential_tracer" => unimplemented!(),
+            "smp_support" => unimplemented!(),
+            "start_time" => unimplemented!(),
+            "system_architecture" => unimplemented!(),
+            "system_logger" => unimplemented!(),
+            "system_version" => unimplemented!(),
+            "thread_pool_size" => unimplemented!(),
+            "threads" => unimplemented!(),
+            "time_correction" => unimplemented!(),
+            "time_offset" => unimplemented!(),
+            "time_warp_mode" => unimplemented!(),
+            "tolerant_timeofday" => unimplemented!(),
+            "trace_control_word" => unimplemented!(),
+            "update_cpu_info" => unimplemented!(),
+            "version" => unimplemented!(),
+            "wordsize" => unimplemented!(),
+            _ => Err(anyhow!(
+                "item ({}) is not a supported atom ({})",
+                item,
+                SUPPORTED_ATOMS
+            )
+            .into()),
+        },
+        TypedTerm::Tuple(boxed_tuple) => {
+            if boxed_tuple.len() == 2 {
+                let tag = boxed_tuple[0];
+
+                match tag.decode().unwrap() {
+                    TypedTerm::Atom(tag_atom) => match tag_atom.name() {
+                        "allocator" => unimplemented!(),
+                        "allocator_sizes" => unimplemented!(),
+                        "cpu_topology" => unimplemented!(),
+                        "wordsize" => unimplemented!(),
+                        _ => item_is_not_supported_tuple(item),
+                    },
+                    _ => item_is_not_supported_tuple(item),
+                }
+            } else {
+                item_is_not_supported_tuple(item)
+            }
+        }
+        _ => Err(anyhow!(
+            "item ({}) is not either an atom ({}) or tuple ({})",
+            item,
+            SUPPORTED_ATOMS,
+            SUPPORTED_TUPLES
+        )
+        .into()),
+    }
+}
+
+const SUPPORTED_ATOMS: &'static str = "`allocated_areas`, `allocator`, \
+                 `alloc_util_allocators`, `elib_malloc`, `cpu_topology`, `logic_processors`, \
+                 `logic_processors_available`, `logical_processors_online`, \
+                 `cpu_quota`, `update_cpu_info`, `fullsweep_after`, `garbage_collection`, \
+                 `heap_sizes`, `heap_type`, `max_heap_size`, `message_queue_data`, `min_heap_size` \
+                 `min_bin_vheap_size`, `procs`, `atom_count`, `atom_limit`, `ets_count`, \
+                 `ets_limit`, `port_count`, `port_limit`, `process_count`, `process_limit`, \
+                 `end_time`, `os_monotonic_time_source`, `os_system_time_source`, `start_time` \
+                 `time_correction`, `time_offset`, `time_warp_mode`, `tolerant_timeofday` \
+                 `dirty_cpu_schedulers`, `dirty_cpu_schedulers_online`, `dirty_io_schedulers`, \
+                 `multi_scheduling`, `multi_scheduling_blockers`, \
+                 `normal_multi_scheduling_blockers`, `scheduler_bind_type`, `scheduler_bindings`, \
+                 `scheduler_id`, `schedulers`, `schedulers_online`, `smp_support`, `threads`, \
+                 `thread_pool_size`, `creation`, `delayed_node_table_gc`, `dist`, \
+                 `dist_buf_busy_limit`, `dist_ctrl`, `build_type`, `c_compiler_used`, `check_io`, \
+                 `compat_rel`, `debug_compiled`, `driver_version`, `dynamic_trace`, \
+                 `dynamic_trace_probes`, `info`, `kernel_poll`, `loaded`, `machine`, \
+                 `modified_timing_level`, `nif_version`, `otp_release`, `port_parallelism`, \
+                 `sequential_tracer`, \
+                 `system_architecture`, `system_logger`, `system_version`, `trace_control_word`, \
+                 `version`, or `wordsize`";
+
+const SUPPORTED_TUPLES: &'static str = "`{allocator, Alloc}`, `{allocator_sizes, Alloc}`, \
+          `{cpu_topology, defined | detected | used}`, or `{wordsize, internal | external}`";
+
+fn item_is_not_supported_tuple(item: Term) -> exception::Result<Term> {
+    Err(anyhow!(
+        "item ({}) is not a supported tuple ({})",
+        item,
+        SUPPORTED_TUPLES
+    )
+    .into())
+}

--- a/native_implemented/otp/tests/internal/lib/erlang.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang.rs
@@ -142,6 +142,8 @@ pub mod nif_error_1;
 pub mod or_2;
 #[path = "erlang/process_flag_2.rs"]
 pub mod process_flag_2;
+#[path = "erlang/seq_trace_info_1.rs"]
+pub mod seq_trace_info_1;
 #[path = "erlang/spawn_1.rs"]
 pub mod spawn_1;
 #[path = "erlang/spawn_3.rs"]

--- a/native_implemented/otp/tests/internal/lib/erlang.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang.rs
@@ -144,6 +144,8 @@ pub mod or_2;
 pub mod process_flag_2;
 #[path = "erlang/seq_trace_info_1.rs"]
 pub mod seq_trace_info_1;
+#[path = "erlang/seq_trace_print_2.rs"]
+pub mod seq_trace_print_2;
 #[path = "erlang/spawn_1.rs"]
 pub mod spawn_1;
 #[path = "erlang/spawn_3.rs"]

--- a/native_implemented/otp/tests/internal/lib/erlang.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang.rs
@@ -142,6 +142,8 @@ pub mod nif_error_1;
 pub mod or_2;
 #[path = "erlang/process_flag_2.rs"]
 pub mod process_flag_2;
+#[path = "erlang/seq_trace_2.rs"]
+pub mod seq_trace_2;
 #[path = "erlang/seq_trace_info_1.rs"]
 pub mod seq_trace_info_1;
 #[path = "erlang/seq_trace_print_2.rs"]

--- a/native_implemented/otp/tests/internal/lib/erlang.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang.rs
@@ -134,6 +134,8 @@ pub mod is_process_alive_1;
 pub mod link_1;
 #[path = "erlang/load_nif_2.rs"]
 pub mod load_nif_2;
+#[path = "erlang/module_loaded_1.rs"]
+pub mod module_loaded_1;
 #[path = "erlang/nif_error_1.rs"]
 pub mod nif_error_1;
 #[path = "erlang/or_2.rs"]

--- a/native_implemented/otp/tests/internal/lib/erlang.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang.rs
@@ -160,5 +160,7 @@ pub mod spawn_monitor_3;
 pub mod spawn_opt_2;
 #[path = "erlang/spawn_opt_4.rs"]
 pub mod spawn_opt_4;
+#[path = "erlang/system_flag_2.rs"]
+pub mod system_flag_2;
 #[path = "erlang/tl_1.rs"]
 pub mod tl_1;

--- a/native_implemented/otp/tests/internal/lib/erlang/module_loaded_1.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/module_loaded_1.rs
@@ -1,0 +1,2 @@
+test_stdout!(without_loaded_module_returns_false, "false\n");
+test_stdout!(with_loaded_module_returns_true, "true\n");

--- a/native_implemented/otp/tests/internal/lib/erlang/module_loaded_1/with_loaded_module_returns_true/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/module_loaded_1/with_loaded_module_returns_true/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, module_loaded/1]).
+
+start() ->
+  display(module_loaded(init)).

--- a/native_implemented/otp/tests/internal/lib/erlang/module_loaded_1/without_loaded_module_returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/module_loaded_1/without_loaded_module_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, module_loaded/1]).
+
+start() ->
+  display(module_loaded(non_existing)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_2.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_2.rs
@@ -1,0 +1,4 @@
+// TODO test flags
+
+test_stdout!(without_atom_flag_errors_badarg, "{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n");
+test_stdout!(with_atom_flag_without_support_errors_badarg, "{caught, error, badarg}\n");

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_2/with_atom_flag_without_support_errors_badarg/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_2/with_atom_flag_without_support_errors_badarg/init.erl
@@ -1,0 +1,8 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [seq_trace/2]).
+
+start() ->
+  test:caught(fun () ->
+    seq_trace(unsupported_flag, false)
+  end).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_2/without_atom_flag_errors_badarg/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_2/without_atom_flag_errors_badarg/init.erl
@@ -1,0 +1,14 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [seq_trace/2]).
+
+start() ->
+  test:each(fun
+    (Atom) when is_atom(Atom) -> ignore;
+    (Term) -> test(Term)
+  end).
+
+test(Flag) ->
+  test:caught(fun () ->
+    seq_trace(Flag, false)
+  end).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1.rs
@@ -1,0 +1,3 @@
+#[path = "seq_trace_info_1/without_seq_trace_token.rs"]
+mod without_seq_trace_token;
+// TODO with_seq_trace_token

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token.rs
@@ -1,0 +1,20 @@
+test_stdout!(without_atom_errors_badarg, "{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n");
+test_stdout!(
+    without_supported_atom_errors_badarg,
+    "{caught, error, badarg}\n"
+);
+test_stdout!(with_label_returns_empty_list, "{label, []}\n");
+test_stdout!(
+    with_monotonic_timestamp_returns_false,
+    "{monotonic_timestamp, false}\n"
+);
+test_stdout!(with_print_returns_false, "{print, false}\n");
+test_stdout!(with_receive_returns_false, "{receive, false}\n");
+test_stdout!(with_send_returns_false, "{send, false}\n");
+test_stdout!(with_serial_returns_empty_list, "{serial, []}\n");
+test_stdout!(with_spawn_returns_false, "{spawn, false}\n");
+test_stdout!(
+    with_strict_monotonic_timestamp_returns_false,
+    "{strict_monotonic_timestamp, false}\n"
+);
+test_stdout!(with_timestamp_returns_false, "{timestamp, false}\n");

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_label_returns_empty_list/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_label_returns_empty_list/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info(label)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_monotonic_timestamp_returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_monotonic_timestamp_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info(monotonic_timestamp)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_print_returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_print_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info(print)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_receive_returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_receive_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info('receive')).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_send_returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_send_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info(send)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_serial_returns_empty_list/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_serial_returns_empty_list/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info(serial)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_spawn_returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_spawn_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info(spawn)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_strict_monotonic_timestamp_returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_strict_monotonic_timestamp_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info(strict_monotonic_timestamp)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_timestamp_returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/with_timestamp_returns_false/init.erl
@@ -1,0 +1,6 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_info/1]).
+
+start() ->
+  display(seq_trace_info(timestamp)).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/without_atom_errors_badarg/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/without_atom_errors_badarg/init.erl
@@ -1,0 +1,14 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [seq_trace_info/1]).
+
+start() ->
+  test:each(fun
+    (Atom) when is_atom(Atom) -> ignore;
+    (Term) -> test(Term)
+  end).
+
+test(Item) ->
+  test:caught(fun () ->
+    seq_trace_info(Item)
+  end).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/without_supported_atom_errors_badarg/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_info_1/without_seq_trace_token/without_supported_atom_errors_badarg/init.erl
@@ -1,0 +1,8 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [seq_trace_info/1]).
+
+start() ->
+  test:caught(fun () ->
+    seq_trace_info(invalid_atom)
+  end).

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_print_2.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_print_2.rs
@@ -1,0 +1,4 @@
+#[path = "seq_trace_print_2/without_seq_trace.rs"]
+mod without_seq_trace;
+// TODO
+// mod with_seq_trace;

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_print_2/without_seq_trace.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_print_2/without_seq_trace.rs
@@ -1,0 +1,1 @@
+test_stdout!(returns_false, "false\n");

--- a/native_implemented/otp/tests/internal/lib/erlang/seq_trace_print_2/without_seq_trace/returns_false/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/seq_trace_print_2/without_seq_trace/returns_false/init.erl
@@ -1,0 +1,8 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [display/1, seq_trace_print/2]).
+
+start() ->
+  Label = label,
+  Message = message,
+  display(seq_trace_print(Label, Message)).

--- a/native_implemented/otp/tests/internal/lib/erlang/system_flag_2.rs
+++ b/native_implemented/otp/tests/internal/lib/erlang/system_flag_2.rs
@@ -1,0 +1,9 @@
+// TODO with_*_flag
+// #[path = "system_flag_2/with_*_flag.rs"]
+// mod with_*_flag;
+
+test_stdout!(without_atom_flag_errors_badarg, "{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n{caught, error, badarg}\n");
+test_stdout!(
+    without_supported_atom_flag_errors_badarg,
+    "{caught, error, badarg}\n"
+);

--- a/native_implemented/otp/tests/internal/lib/erlang/system_flag_2/without_atom_flag_errors_badarg/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/system_flag_2/without_atom_flag_errors_badarg/init.erl
@@ -1,0 +1,14 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [system_flag/2]).
+
+start() ->
+  test:each(fun
+    (Atom) when is_atom(Atom) -> ignore;
+    (Term) -> test(Term)
+  end).
+
+test(Flag) ->
+  test:caught(fun () ->
+    system_flag(Flag, [])
+  end).

--- a/native_implemented/otp/tests/internal/lib/erlang/system_flag_2/without_supported_atom_flag_errors_badarg/init.erl
+++ b/native_implemented/otp/tests/internal/lib/erlang/system_flag_2/without_supported_atom_flag_errors_badarg/init.erl
@@ -1,0 +1,8 @@
+-module(init).
+-export([start/0]).
+-import(erlang, [system_flag/2]).
+
+start() ->
+  test:caught(fun () ->
+    system_flag(unsupported_flag, [])
+  end).


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Stub out `seq_trace.erl` dependencies, so that it can link to them to pass `cargo test --package liblumen_otp lumen::otp::lib::kernel::seq_trace`.
  * `module_loaded/1`
    Count module as loaded if they have an exported function.
  * `system_info/1`
    Stub out item parsing, but don't implement returning any data.
  * `seq_trace_print/1`
    Stub to always return `false` as turning on seq_trace isn't actually supported yet
  * `seq_trace_info/1`
   Support no-seq-trace-token mode only for now.
  * `system_flag/2`
    Stub out the flag validation, but leaf returning values unimplemented.
  * `seq_trace_print/2`
    Stub out to always return `false` as if seq_trace is never enabled.
  * `seq_trace/2`
    Stub out flag validation, but no actual flag setting.