### PR TITLE
Update paths in LLVM installation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ is recommended to export XDG variables in general, but if you have not, just
 replace the usages of `$XDG_DATA_HOME` below with `$HOME/.local/share`, which is
 the usual default for this XDG variable.
 
-    mkdir -p $XDG_DATA_HOME/llvm/
-    cd $XDG_DATA_HOME/llvm/
+    mkdir -p $XDG_DATA_HOME/llvm/lumen/
+    cd $XDG_DATA_HOME/llvm/lumen
     wget https://github.com/lumen/llvm-project/releases/download/lumen-12.0.0-dev_2020-10-22/clang+llvm-12.0.0-x86_64-linux-gnu.tar.gz
     tar -xz --strip-components 1 -f clang+llvm-12.0.0-x86_64-linux-gnu.tar.gz
     rm clang+llvm-12.0.0-x86_64-linux-gnu.tar.gz
@@ -84,8 +84,8 @@ the usual default for this XDG variable.
 
 ###### MacOS
 
-    mkdir -p $XDG_DATA_HOME/llvm/
-    cd $XDG_DATA_HOME/llvm/
+    mkdir -p $XDG_DATA_HOME/llvm/lumen/
+    cd $XDG_DATA_HOME/llvm/lumen
     wget https://github.com/lumen/llvm-project/releases/download/lumen-12.0.0-dev_2020-10-22/clang+llvm-12.0.0-x86_64-apple-darwin19.5.0.tar.gz
     tar -xzf clang+llvm-12.0.0-x86_64-apple-darwin19.5.0.tar.gz
     rm clang+llvm-12.0.0-x86_64-apple-darwin19.5.0.tar.gz


### PR DESCRIPTION
Change the example paths for prebuilt LLVM extraction to match what is mentioned further down in the README.